### PR TITLE
feat: add DNSHE provider support

### DIFF
--- a/server/src/lib/dns/DnsHelper.ts
+++ b/server/src/lib/dns/DnsHelper.ts
@@ -16,6 +16,7 @@ import {
   PowerdnsAdapter,
   AliyunesaAdapter,
   TencenteoAdapter,
+  DnsheAdapter,
 } from './providers';
 
 export interface ProviderCapabilities {
@@ -186,6 +187,15 @@ const providers: ProviderInfo[] = [
       { key: 'SecretKey', label: 'SecretKey', type: 'password', required: true },
     ],
   },
+  {
+    type: 'dnshe',
+    name: 'DNSHE',
+    capabilities: { remark: false, status: false, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'apiKey', label: 'API Key', type: 'text', required: true },
+      { key: 'apiSecret', label: 'API Secret', type: 'password', required: true },
+    ],
+  },
 ];
 
 const providerMap = new Map(providers.map((p) => [p.type, p]));
@@ -217,6 +227,7 @@ export function createAdapter(type: string, config: Record<string, string>, doma
     case 'bt': return new BtAdapter(cfg);
     case 'spaceship': return new SpaceshipAdapter(cfg);
     case 'powerdns': return new PowerdnsAdapter(cfg);
+    case 'dnshe': return new DnsheAdapter(cfg);
     default: throw new Error(`Unknown provider type: ${type}`);
   }
 }

--- a/server/src/lib/dns/providers/dnshe.ts
+++ b/server/src/lib/dns/providers/dnshe.ts
@@ -1,0 +1,360 @@
+import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../DnsInterface';
+import { asArray, Dict, normalizeRrName, safeString, BaseAdapter, toNumber, toRecordStatus } from './common';
+
+interface DnsheConfig {
+  apiKey: string;
+  apiSecret: string;
+  domain?: string;
+  subdomainId?: string;
+}
+
+interface DnsheSubdomain {
+  id: number;
+  subdomain: string;
+  rootdomain: string;
+  full_domain: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface DnsheRecord {
+  id: number;
+  name: string;
+  type: string;
+  content: string;
+  ttl: number;
+  priority: number | null;
+  proxied: boolean;
+  status: string;
+  created_at: string;
+}
+
+interface DnsheApiResponse<T> {
+  success: boolean;
+  message?: string;
+  error?: string;
+  count?: number;
+  subdomains?: DnsheSubdomain[];
+  subdomain?: DnsheSubdomain;
+  dns_records?: DnsheRecord[];
+  records?: DnsheRecord[];
+  record_id?: number;
+}
+
+export class DnsheAdapter extends BaseAdapter {
+  private config: DnsheConfig;
+  private baseUrl = 'https://api005.dnshe.com/index.php?m=domain_hub';
+
+  constructor(config: Record<string, string>) {
+    super();
+    this.config = {
+      apiKey: safeString(config.apiKey),
+      apiSecret: safeString(config.apiSecret),
+      domain: safeString(config.domain),
+      subdomainId: safeString(config.zoneId),
+    };
+  }
+
+  private getHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      'X-API-Key': this.config.apiKey,
+      'X-API-Secret': this.config.apiSecret,
+    };
+  }
+
+  private async request<T>(
+    endpoint: string,
+    action: string,
+    method: 'GET' | 'POST' = 'GET',
+    body?: Dict
+  ): Promise<DnsheApiResponse<T>> {
+    const url = `${this.baseUrl}&endpoint=${endpoint}&action=${action}`;
+    
+    const options: RequestInit = {
+      method,
+      headers: this.getHeaders(),
+    };
+
+    if (method === 'POST' && body) {
+      options.body = JSON.stringify(body);
+    }
+
+    const res = await fetch(url, options);
+    const data = (await res.json()) as DnsheApiResponse<T>;
+    
+    if (!data.success && data.error) {
+      this.error = data.error;
+    }
+    
+    return data;
+  }
+
+  async check(): Promise<boolean> {
+    try {
+      const res = await this.request<DnsheSubdomain[]>('subdomains', 'list', 'GET');
+      return res.success;
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return false;
+    }
+  }
+
+  async getDomainList(keyword?: string, page = 1, pageSize = 50): Promise<PageResult<DomainInfo>> {
+    try {
+      const res = await this.request<DnsheSubdomain[]>('subdomains', 'list', 'GET');
+      if (!res.success || !res.subdomains) {
+        return { total: 0, list: [] };
+      }
+
+      let list = res.subdomains.map((item) => ({
+        Domain: item.full_domain,
+        ThirdId: String(item.id),
+        RecordCount: undefined as number | undefined,
+      }));
+
+      if (keyword) {
+        const lowerKeyword = keyword.toLowerCase();
+        list = list.filter((d) => d.Domain.toLowerCase().includes(lowerKeyword));
+      }
+
+      const total = list.length;
+      const offset = (page - 1) * pageSize;
+      list = list.slice(offset, offset + pageSize);
+
+      return { total, list };
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return { total: 0, list: [] };
+    }
+  }
+
+  async getDomainRecords(
+    page = 1,
+    pageSize = 100,
+    keyword?: string,
+    subdomain?: string,
+    value?: string,
+    type?: string,
+    _line?: string,
+    status?: number
+  ): Promise<PageResult<DnsRecord>> {
+    try {
+      if (!this.config.subdomainId) {
+        return { total: 0, list: [] };
+      }
+
+      const res = await this.request<DnsheRecord[]>('dns_records', 'list', 'GET');
+      if (!res.success || !res.records) {
+        return { total: 0, list: [] };
+      }
+
+      let list = res.records.map((r) => this.mapRecord(r));
+
+      if (keyword) {
+        const lowerKeyword = keyword.toLowerCase();
+        list = list.filter((r) => 
+          r.Name.toLowerCase().includes(lowerKeyword) ||
+          r.Value.toLowerCase().includes(lowerKeyword)
+        );
+      }
+
+      if (subdomain) {
+        list = list.filter((r) => r.Name.toLowerCase() === subdomain.toLowerCase());
+      }
+
+      if (value) {
+        list = list.filter((r) => r.Value.toLowerCase().includes(value.toLowerCase()));
+      }
+
+      if (type) {
+        list = list.filter((r) => r.Type.toUpperCase() === type.toUpperCase());
+      }
+
+      if (status !== undefined) {
+        list = list.filter((r) => r.Status === status);
+      }
+
+      const total = list.length;
+      const offset = (page - 1) * pageSize;
+      list = list.slice(offset, offset + pageSize);
+
+      return { total, list };
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return { total: 0, list: [] };
+    }
+  }
+
+  async getDomainRecordInfo(recordId: string): Promise<DnsRecord | null> {
+    try {
+      if (!this.config.subdomainId) {
+        return null;
+      }
+
+      const res = await this.request<DnsheRecord[]>('dns_records', 'list', 'GET');
+      if (!res.success || !res.records) {
+        return null;
+      }
+
+      const record = res.records.find((r) => String(r.id) === recordId);
+      if (!record) {
+        return null;
+      }
+
+      return this.mapRecord(record);
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return null;
+    }
+  }
+
+  async addDomainRecord(
+    name: string,
+    type: string,
+    value: string,
+    _line?: string,
+    ttl = 120,
+    mx = 0,
+    _weight?: number,
+    _remark?: string
+  ): Promise<string | null> {
+    try {
+      if (!this.config.subdomainId) {
+        return null;
+      }
+
+      const body: Dict = {
+        subdomain_id: toNumber(this.config.subdomainId, 0),
+        type: type.toUpperCase(),
+        content: value,
+        ttl,
+      };
+
+      if (name && name !== '@') {
+        body.name = name;
+      }
+
+      if (type.toUpperCase() === 'MX' && mx > 0) {
+        body.priority = mx;
+      }
+
+      const res = await this.request<{ record_id: number }>('dns_records', 'create', 'POST', body);
+      if (!res.success) {
+        return null;
+      }
+
+      return String(res.record_id ?? '');
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return null;
+    }
+  }
+
+  async updateDomainRecord(
+    recordId: string,
+    name: string,
+    type: string,
+    value: string,
+    _line?: string,
+    ttl = 120,
+    mx = 0,
+    _weight?: number,
+    _remark?: string
+  ): Promise<boolean> {
+    try {
+      const body: Dict = {
+        record_id: toNumber(recordId, 0),
+        content: value,
+        ttl,
+      };
+
+      if (name && name !== '@') {
+        body.name = name;
+      }
+
+      if (type.toUpperCase() === 'MX' && mx > 0) {
+        body.priority = mx;
+      }
+
+      const res = await this.request<Dict>('dns_records', 'update', 'POST', body);
+      return res.success;
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return false;
+    }
+  }
+
+  async deleteDomainRecord(recordId: string): Promise<boolean> {
+    try {
+      const res = await this.request<Dict>('dns_records', 'delete', 'POST', {
+        record_id: toNumber(recordId, 0),
+      });
+      return res.success;
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return false;
+    }
+  }
+
+  async setDomainRecordStatus(recordId: string, status: number): Promise<boolean> {
+    // DNSHE API 没有直接的启用/禁用记录功能
+    // 通过更新记录状态来模拟（如果 API 支持）
+    // 这里返回 true 表示操作成功，但实际上 DNSHE 可能不支持此功能
+    this.error = 'DNSHE does not support record status toggle';
+    return false;
+  }
+
+  async getRecordLines(): Promise<Array<{ id: string; name: string }>> {
+    // DNSHE 不支持线路选择，返回默认线路
+    return [{ id: 'default', name: '默认' }];
+  }
+
+  async getMinTTL(): Promise<number> {
+    // DNSHE 默认最小 TTL 为 120
+    return 120;
+  }
+
+  async addDomain(domain: string): Promise<boolean> {
+    try {
+      // 解析域名获取 subdomain 和 rootdomain
+      const parts = domain.split('.');
+      if (parts.length < 2) {
+        this.error = 'Invalid domain format';
+        return false;
+      }
+
+      const subdomain = parts[0];
+      const rootdomain = parts.slice(1).join('.');
+
+      const res = await this.request<DnsheSubdomain>('subdomains', 'register', 'POST', {
+        subdomain,
+        rootdomain,
+      });
+
+      return res.success;
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return false;
+    }
+  }
+
+  private mapRecord(r: DnsheRecord): DnsRecord {
+    const domain = this.config.domain || '';
+    const name = r.name === domain ? '@' : r.name.replace(`.${domain}`, '');
+
+    return {
+      RecordId: String(r.id),
+      Domain: domain,
+      Name: name || '@',
+      Type: safeString(r.type).toUpperCase(),
+      Value: safeString(r.content),
+      Line: 'default',
+      TTL: r.ttl ?? 120,
+      MX: r.priority ?? 0,
+      Status: r.status === 'active' ? 1 : 0,
+      UpdateTime: r.created_at,
+    };
+  }
+}

--- a/server/src/lib/dns/providers/index.ts
+++ b/server/src/lib/dns/providers/index.ts
@@ -2,6 +2,7 @@ export { CloudflareAdapter } from './cloudflare';
 export { AliyunAdapter } from './aliyun';
 export { DnspodAdapter } from './dnspod';
 export { TencenteoAdapter } from './tencenteo';
+export { DnsheAdapter } from './dnshe';
 export {
   HuaweiAdapter,
   BaiduAdapter,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
- Add DNSHE adapter with full API implementation
- Support subdomain management and DNS record operations
- Register DNSHE in DnsHelper with API Key + API Secret auth
- Update tsconfig.json to include DOM lib for fetch types