### PR TITLE
feat: add 雨云(Rainyun) provider support

### DIFF
--- a/server/src/lib/dns/DnsHelper.ts
+++ b/server/src/lib/dns/DnsHelper.ts
@@ -17,6 +17,7 @@ import {
   AliyunesaAdapter,
   TencenteoAdapter,
   DnsheAdapter,
+  RainyunAdapter,
 } from './providers';
 
 export interface ProviderCapabilities {
@@ -196,6 +197,14 @@ const providers: ProviderInfo[] = [
       { key: 'apiSecret', label: 'API Secret', type: 'password', required: true },
     ],
   },
+  {
+    type: 'rainyun',
+    name: '雨云',
+    capabilities: { remark: false, status: false, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'apiKey', label: 'API Key', type: 'password', required: true },
+    ],
+  },
 ];
 
 const providerMap = new Map(providers.map((p) => [p.type, p]));
@@ -228,6 +237,7 @@ export function createAdapter(type: string, config: Record<string, string>, doma
     case 'spaceship': return new SpaceshipAdapter(cfg);
     case 'powerdns': return new PowerdnsAdapter(cfg);
     case 'dnshe': return new DnsheAdapter(cfg);
+    case 'rainyun': return new RainyunAdapter(cfg);
     default: throw new Error(`Unknown provider type: ${type}`);
   }
 }

--- a/server/src/lib/dns/providers/index.ts
+++ b/server/src/lib/dns/providers/index.ts
@@ -3,6 +3,7 @@ export { AliyunAdapter } from './aliyun';
 export { DnspodAdapter } from './dnspod';
 export { TencenteoAdapter } from './tencenteo';
 export { DnsheAdapter } from './dnshe';
+export { RainyunAdapter } from './rainyun';
 export {
   HuaweiAdapter,
   BaiduAdapter,

--- a/server/src/lib/dns/providers/rainyun.ts
+++ b/server/src/lib/dns/providers/rainyun.ts
@@ -1,0 +1,370 @@
+import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../DnsInterface';
+import { Dict, normalizeRrName, safeString, BaseAdapter, toNumber } from './common';
+
+interface RainyunConfig {
+  apiKey: string;
+  domain?: string;
+  domainId?: string;
+}
+
+interface RainyunDomain {
+  id: number;
+  domain: string;
+  status: string;
+  created_at: string;
+  expired_at: string;
+}
+
+interface RainyunRecord {
+  record_id: number;
+  host: string;
+  type: string;
+  value: string;
+  ttl: number;
+  line: string;
+  level: number;
+  rain_product_id?: number;
+  rain_product_type?: string;
+}
+
+interface RainyunApiResponse<T> {
+  code?: number;
+  message?: string;
+  data?: T;
+}
+
+export class RainyunAdapter extends BaseAdapter {
+  private config: RainyunConfig;
+  private baseUrl = 'https://api.v2.rainyun.com';
+
+  constructor(config: Record<string, string>) {
+    super();
+    this.config = {
+      apiKey: safeString(config.apiKey),
+      domain: safeString(config.domain),
+      domainId: safeString(config.zoneId),
+    };
+  }
+
+  private getHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      'X-Api-Key': this.config.apiKey,
+    };
+  }
+
+  private async request<T>(
+    path: string,
+    method: 'GET' | 'POST' | 'PATCH' | 'DELETE' = 'GET',
+    body?: Dict
+  ): Promise<RainyunApiResponse<T>> {
+    const url = `${this.baseUrl}${path}`;
+
+    const options: RequestInit = {
+      method,
+      headers: this.getHeaders(),
+    };
+
+    if (body && (method === 'POST' || method === 'PATCH' || method === 'DELETE')) {
+      options.body = JSON.stringify(body);
+    }
+
+    const res = await fetch(url, options);
+    const data = (await res.json()) as RainyunApiResponse<T>;
+
+    if (!res.ok || data.code !== 200) {
+      this.error = data.message || `Request failed: ${res.status}`;
+    }
+
+    return data;
+  }
+
+  async check(): Promise<boolean> {
+    try {
+      const res = await this.request<RainyunDomain[]>('/product/domain/', 'GET');
+      return res.code === 200;
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return false;
+    }
+  }
+
+  async getDomainList(keyword?: string, page = 1, pageSize = 50): Promise<PageResult<DomainInfo>> {
+    try {
+      const res = await this.request<{
+        data: RainyunDomain[];
+        total: number;
+      }>(`/product/domain/?options=${encodeURIComponent(JSON.stringify({
+        page: page,
+        per_page: pageSize,
+      }))}`, 'GET');
+
+      if (res.code !== 200 || !res.data) {
+        return { total: 0, list: [] };
+      }
+
+      let list = res.data.data || [];
+
+      if (keyword) {
+        const lowerKeyword = keyword.toLowerCase();
+        list = list.filter((d) => d.domain.toLowerCase().includes(lowerKeyword));
+      }
+
+      return {
+        total: res.data.total || list.length,
+        list: list.map((item) => ({
+          Domain: item.domain,
+          ThirdId: String(item.id),
+          RecordCount: undefined as number | undefined,
+        })),
+      };
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return { total: 0, list: [] };
+    }
+  }
+
+  async getDomainRecords(
+    page = 1,
+    pageSize = 100,
+    keyword?: string,
+    subdomain?: string,
+    value?: string,
+    type?: string,
+    line?: string,
+    status?: number
+  ): Promise<PageResult<DnsRecord>> {
+    try {
+      if (!this.config.domainId) {
+        return { total: 0, list: [] };
+      }
+
+      const res = await this.request<{
+        data: RainyunRecord[];
+        total: number;
+      }>(`/product/domain/${this.config.domainId}/dns/?limit=${pageSize}&page_no=${page}`, 'GET');
+
+      if (res.code !== 200 || !res.data) {
+        return { total: 0, list: [] };
+      }
+
+      let list = res.data.data.map((r) => this.mapRecord(r));
+
+      if (keyword) {
+        const lowerKeyword = keyword.toLowerCase();
+        list = list.filter((r) =>
+          r.Name.toLowerCase().includes(lowerKeyword) ||
+          r.Value.toLowerCase().includes(lowerKeyword)
+        );
+      }
+
+      if (subdomain) {
+        list = list.filter((r) => r.Name.toLowerCase() === subdomain.toLowerCase());
+      }
+
+      if (value) {
+        list = list.filter((r) => r.Value.toLowerCase().includes(value.toLowerCase()));
+      }
+
+      if (type) {
+        list = list.filter((r) => r.Type.toUpperCase() === type.toUpperCase());
+      }
+
+      if (line) {
+        list = list.filter((r) => r.Line === line);
+      }
+
+      if (status !== undefined) {
+        list = list.filter((r) => r.Status === status);
+      }
+
+      return {
+        total: res.data.total || list.length,
+        list,
+      };
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return { total: 0, list: [] };
+    }
+  }
+
+  async getDomainRecordInfo(recordId: string): Promise<DnsRecord | null> {
+    try {
+      if (!this.config.domainId) {
+        return null;
+      }
+
+      const res = await this.request<{
+        data: RainyunRecord[];
+      }>(`/product/domain/${this.config.domainId}/dns/`, 'GET');
+
+      if (res.code !== 200 || !res.data) {
+        return null;
+      }
+
+      const record = res.data.data.find((r) => String(r.record_id) === recordId);
+      if (!record) {
+        return null;
+      }
+
+      return this.mapRecord(record);
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return null;
+    }
+  }
+
+  async addDomainRecord(
+    name: string,
+    type: string,
+    value: string,
+    line?: string,
+    ttl = 600,
+    mx = 0,
+    _weight?: number,
+    _remark?: string
+  ): Promise<string | null> {
+    try {
+      if (!this.config.domainId) {
+        return null;
+      }
+
+      const body: Dict = {
+        host: name === '@' ? '' : name,
+        type: type.toUpperCase(),
+        value: value,
+        ttl: ttl,
+        line: line || 'DEFAULT',
+      };
+
+      if (type.toUpperCase() === 'MX' && mx > 0) {
+        body.level = mx;
+      }
+
+      const res = await this.request<{ record_id: number }>(
+        `/product/domain/${this.config.domainId}/dns`,
+        'POST',
+        body
+      );
+
+      if (res.code !== 200) {
+        return null;
+      }
+
+      return String(res.data?.record_id ?? '');
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return null;
+    }
+  }
+
+  async updateDomainRecord(
+    recordId: string,
+    name: string,
+    type: string,
+    value: string,
+    line?: string,
+    ttl = 600,
+    mx = 0,
+    _weight?: number,
+    _remark?: string
+  ): Promise<boolean> {
+    try {
+      if (!this.config.domainId) {
+        return false;
+      }
+
+      const body: Dict = {
+        record_id: toNumber(recordId, 0),
+        host: name === '@' ? '' : name,
+        type: type.toUpperCase(),
+        value: value,
+        ttl: ttl,
+        line: line || 'DEFAULT',
+      };
+
+      if (type.toUpperCase() === 'MX' && mx > 0) {
+        body.level = mx;
+      }
+
+      const res = await this.request<Dict>(
+        `/product/domain/${this.config.domainId}/dns`,
+        'PATCH',
+        body
+      );
+
+      return res.code === 200;
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return false;
+    }
+  }
+
+  async deleteDomainRecord(recordId: string): Promise<boolean> {
+    try {
+      if (!this.config.domainId) {
+        return false;
+      }
+
+      const res = await this.request<Dict>(
+        `/product/domain/${this.config.domainId}/dns/`,
+        'DELETE',
+        {
+          record_id: toNumber(recordId, 0),
+        }
+      );
+
+      return res.code === 200;
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+      return false;
+    }
+  }
+
+  async setDomainRecordStatus(recordId: string, status: number): Promise<boolean> {
+    // 雨云 API 没有直接的启用/禁用记录功能
+    this.error = 'Rainyun does not support record status toggle';
+    return false;
+  }
+
+  async getRecordLines(): Promise<Array<{ id: string; name: string }>> {
+    // 雨云支持的线路
+    return [
+      { id: 'DEFAULT', name: '默认' },
+      { id: 'LTEL', name: '电信' },
+      { id: 'LCNC', name: '联通' },
+      { id: 'LMOB', name: '移动' },
+      { id: 'LEDU', name: '教育网' },
+      { id: 'LSEO', name: '搜索引擎' },
+      { id: 'LFOR', name: '国外' },
+    ];
+  }
+
+  async getMinTTL(): Promise<number> {
+    // 雨云默认最小 TTL 为 600
+    return 600;
+  }
+
+  async addDomain(domain: string): Promise<boolean> {
+    // 雨云 API 不支持通过 API 注册域名
+    this.error = 'Rainyun does not support domain registration via API';
+    return false;
+  }
+
+  private mapRecord(r: RainyunRecord): DnsRecord {
+    const domain = this.config.domain || '';
+    const name = r.host || '@';
+
+    return {
+      RecordId: String(r.record_id),
+      Domain: domain,
+      Name: name,
+      Type: safeString(r.type).toUpperCase(),
+      Value: safeString(r.value),
+      Line: r.line || 'DEFAULT',
+      TTL: r.ttl ?? 600,
+      MX: r.level ?? 0,
+      Status: 1, // 雨云没有记录状态字段，默认启用
+    };
+  }
+}


### PR DESCRIPTION
- Add Rainyun adapter with full API implementation
- Support domain list and DNS record operations
- Support multiple record lines (DEFAULT, LTEL, LCNC, LMOB, LEDU, LSEO, LFOR)
- Register Rainyun in DnsHelper with API Key auth
- Export RainyunAdapter in providers/index.ts