### PR TITLE
Centralize DNS provider registration with registry and startup validation

### DIFF
--- a/server/src/lib/dns/DnsHelper.ts
+++ b/server/src/lib/dns/DnsHelper.ts
@@ -1,221 +1,19 @@
 import { DnsAdapter } from './DnsInterface';
 import {
-  CloudflareAdapter,
-  AliyunAdapter,
-  DnspodAdapter,
-  HuaweiAdapter,
-  BaiduAdapter,
-  HuoshanAdapter,
-  JdcloudAdapter,
-  DnslaAdapter,
-  WestAdapter,
-  QingcloudAdapter,
-  NamesiloAdapter,
-  BtAdapter,
-  SpaceshipAdapter,
-  PowerdnsAdapter,
-  AliyunesaAdapter,
-  TencenteoAdapter,
-  DnsheAdapter,
-  RainyunAdapter,
-} from './providers';
+  ProviderCapabilities,
+  ProviderConfigField,
+  ProviderInfo,
+  getProviderDefinitions,
+  getProviderInfoList,
+  providerDefinitionMap,
+} from './providers/registry';
 
-export interface ProviderCapabilities {
-  remark: boolean;
-  status: boolean;
-  redirect: boolean;
-  log: boolean;
-  weight: boolean;
-}
-
-export interface ProviderConfigField {
-  key: string;
-  label: string;
-  type: 'text' | 'password';
-  required: boolean;
-  group?: string; // for grouped/conditional fields
-}
-
-export interface ProviderInfo {
-  type: string;
-  name: string;
-  capabilities: ProviderCapabilities;
-  configFields: ProviderConfigField[];
-  isStub?: boolean;
-}
+export type { ProviderCapabilities, ProviderConfigField, ProviderInfo };
 
 // All providers now have implementations
 const STUB_TYPES = new Set<string>([]);
 
-const providers: ProviderInfo[] = [
-  {
-    type: 'aliyun',
-    name: '阿里云',
-    capabilities: { remark: false, status: true, redirect: false, log: true, weight: false },
-    configFields: [
-      { key: 'AccessKeyId', label: 'AccessKeyId', type: 'text', required: true },
-      { key: 'AccessKeySecret', label: 'AccessKeySecret', type: 'password', required: true },
-      { key: 'region', label: 'Region', type: 'text', required: false },
-    ],
-  },
-  {
-    type: 'dnspod',
-    name: '腾讯云-DNSPod',
-    capabilities: { remark: false, status: true, redirect: false, log: true, weight: false },
-    configFields: [
-      { key: 'SecretId', label: 'SecretId', type: 'text', required: true },
-      { key: 'SecretKey', label: 'SecretKey', type: 'password', required: true },
-      { key: 'site_type', label: 'Site Type (intl)', type: 'text', required: false },
-    ],
-  },
-  {
-    type: 'huawei',
-    name: '华为云',
-    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'AccessKeyId', label: 'AccessKeyId', type: 'text', required: true },
-      { key: 'SecretAccessKey', label: 'SecretAccessKey', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'baidu',
-    name: '百度云',
-    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'AccessKeyId', label: 'AccessKeyId', type: 'text', required: true },
-      { key: 'SecretAccessKey', label: 'SecretAccessKey', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'huoshan',
-    name: '火山引擎',
-    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'AccessKeyId', label: 'AccessKeyId', type: 'text', required: true },
-      { key: 'SecretAccessKey', label: 'SecretAccessKey', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'jdcloud',
-    name: '京东云',
-    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'AccessKeyId', label: 'AccessKeyId', type: 'text', required: true },
-      { key: 'AccessKeySecret', label: 'AccessKeySecret', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'cloudflare',
-    name: 'Cloudflare',
-    capabilities: { remark: true, status: false, redirect: true, log: false, weight: true },
-    configFields: [
-      { key: 'apiToken', label: 'API Token', type: 'password', required: false, group: 'token' },
-      { key: 'email', label: 'Email', type: 'text', required: false, group: 'key' },
-      { key: 'apiKey', label: 'Global API Key', type: 'password', required: false, group: 'key' },
-    ],
-  },
-  {
-    type: 'dnsla',
-    name: 'DNS.LA',
-    capabilities: { remark: false, status: true, redirect: false, log: false, weight: true },
-    configFields: [
-      { key: 'apiid', label: 'API ID', type: 'text', required: true },
-      { key: 'apisecret', label: 'API Secret', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'west',
-    name: '西部数码',
-    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'username', label: 'Username', type: 'text', required: true },
-      { key: 'api_password', label: 'API Password', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'qingcloud',
-    name: '青云',
-    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'access_key_id', label: 'Access Key ID', type: 'text', required: true },
-      { key: 'secret_access_key', label: 'Secret Access Key', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'namesilo',
-    name: 'NameSilo',
-    capabilities: { remark: false, status: false, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'apikey', label: 'API Key', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'bt',
-    name: '宝塔',
-    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'AccountID', label: 'Account ID', type: 'text', required: true },
-      { key: 'AccessKey', label: 'Access Key', type: 'password', required: true },
-      { key: 'SecretKey', label: 'Secret Key', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'spaceship',
-    name: 'Spaceship',
-    capabilities: { remark: false, status: false, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'apiKey', label: 'API Key', type: 'text', required: true },
-      { key: 'apiSecret', label: 'API Secret', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'powerdns',
-    name: 'PowerDNS',
-    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'serverUrl', label: 'Server URL', type: 'text', required: true },
-      { key: 'apiKey', label: 'API Key', type: 'password', required: true },
-      { key: 'serverId', label: 'Server ID', type: 'text', required: false },
-    ],
-  },
-  {
-    type: 'aliyunesa',
-    name: '阿里云ESA',
-    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'AccessKeyId', label: 'AccessKeyId', type: 'text', required: true },
-      { key: 'AccessKeySecret', label: 'AccessKeySecret', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'tencenteo',
-    name: '腾讯EdgeOne',
-    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'SecretId', label: 'SecretId', type: 'text', required: true },
-      { key: 'SecretKey', label: 'SecretKey', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'dnshe',
-    name: 'DNSHE',
-    capabilities: { remark: false, status: false, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'apiKey', label: 'API Key', type: 'text', required: true },
-      { key: 'apiSecret', label: 'API Secret', type: 'password', required: true },
-    ],
-  },
-  {
-    type: 'rainyun',
-    name: '雨云',
-    capabilities: { remark: false, status: false, redirect: false, log: false, weight: false },
-    configFields: [
-      { key: 'apiKey', label: 'API Key', type: 'password', required: true },
-    ],
-  },
-];
-
-const providerMap = new Map(providers.map((p) => [p.type, p]));
+const providers = getProviderInfoList();
 
 export function getProviders(includeStub = false): ProviderInfo[] {
   const enriched = providers.map((p) => ({ ...p, isStub: STUB_TYPES.has(p.type) }));
@@ -224,7 +22,7 @@ export function getProviders(includeStub = false): ProviderInfo[] {
 }
 
 export function getProvider(type: string): ProviderInfo | undefined {
-  return providerMap.get(type);
+  return getProviderDefinitions().find((provider) => provider.type === type);
 }
 
 export function isStubProvider(type: string): boolean {
@@ -232,26 +30,11 @@ export function isStubProvider(type: string): boolean {
 }
 
 export function createAdapter(type: string, config: Record<string, string>, domain?: string, zoneId?: string): DnsAdapter {
-  const cfg = { ...config, domain: domain ?? '', zoneId: zoneId ?? '' };
-  switch (type) {
-    case 'cloudflare': return new CloudflareAdapter(cfg);
-    case 'aliyun': return new AliyunAdapter(cfg);
-    case 'aliyunesa': return new AliyunesaAdapter(cfg);
-    case 'dnspod': return new DnspodAdapter(cfg);
-    case 'tencenteo': return new TencenteoAdapter(cfg);
-    case 'huawei': return new HuaweiAdapter(cfg);
-    case 'baidu': return new BaiduAdapter(cfg);
-    case 'huoshan': return new HuoshanAdapter(cfg);
-    case 'jdcloud': return new JdcloudAdapter(cfg);
-    case 'dnsla': return new DnslaAdapter(cfg);
-    case 'west': return new WestAdapter(cfg);
-    case 'qingcloud': return new QingcloudAdapter(cfg);
-    case 'namesilo': return new NamesiloAdapter(cfg);
-    case 'bt': return new BtAdapter(cfg);
-    case 'spaceship': return new SpaceshipAdapter(cfg);
-    case 'powerdns': return new PowerdnsAdapter(cfg);
-    case 'dnshe': return new DnsheAdapter(cfg);
-    case 'rainyun': return new RainyunAdapter(cfg);
-    default: throw new Error(`Unknown provider type: ${type}`);
+  const definition = providerDefinitionMap.get(type);
+  if (!definition) {
+    throw new Error(`Unknown provider type: ${type}`);
   }
+
+  const cfg = { ...config, domain: domain ?? '', zoneId: zoneId ?? '' };
+  return definition.adapterFactory(cfg);
 }

--- a/server/src/lib/dns/providers/registry.ts
+++ b/server/src/lib/dns/providers/registry.ts
@@ -1,0 +1,262 @@
+import { DnsAdapter } from '../DnsInterface';
+import {
+  CloudflareAdapter,
+  AliyunAdapter,
+  DnspodAdapter,
+  HuaweiAdapter,
+  BaiduAdapter,
+  HuoshanAdapter,
+  JdcloudAdapter,
+  DnslaAdapter,
+  WestAdapter,
+  QingcloudAdapter,
+  NamesiloAdapter,
+  BtAdapter,
+  SpaceshipAdapter,
+  PowerdnsAdapter,
+  AliyunesaAdapter,
+  TencenteoAdapter,
+  DnsheAdapter,
+  RainyunAdapter,
+} from './index';
+
+export interface ProviderCapabilities {
+  remark: boolean;
+  status: boolean;
+  redirect: boolean;
+  log: boolean;
+  weight: boolean;
+}
+
+export interface ProviderConfigField {
+  key: string;
+  label: string;
+  type: 'text' | 'password';
+  required: boolean;
+  group?: string;
+}
+
+export interface ProviderDefinition {
+  type: string;
+  name: string;
+  capabilities: ProviderCapabilities;
+  configFields: ProviderConfigField[];
+  adapterFactory: (config: Record<string, string>) => DnsAdapter;
+}
+
+export type ProviderInfo = Omit<ProviderDefinition, 'adapterFactory'>;
+
+const providerDefinitions: ProviderDefinition[] = [
+  {
+    type: 'aliyun',
+    name: '阿里云',
+    capabilities: { remark: false, status: true, redirect: false, log: true, weight: false },
+    configFields: [
+      { key: 'AccessKeyId', label: 'AccessKeyId', type: 'text', required: true },
+      { key: 'AccessKeySecret', label: 'AccessKeySecret', type: 'password', required: true },
+      { key: 'region', label: 'Region', type: 'text', required: false },
+    ],
+    adapterFactory: (config) => new AliyunAdapter(config),
+  },
+  {
+    type: 'dnspod',
+    name: '腾讯云-DNSPod',
+    capabilities: { remark: false, status: true, redirect: false, log: true, weight: false },
+    configFields: [
+      { key: 'SecretId', label: 'SecretId', type: 'text', required: true },
+      { key: 'SecretKey', label: 'SecretKey', type: 'password', required: true },
+      { key: 'site_type', label: 'Site Type (intl)', type: 'text', required: false },
+    ],
+    adapterFactory: (config) => new DnspodAdapter(config),
+  },
+  {
+    type: 'huawei',
+    name: '华为云',
+    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'AccessKeyId', label: 'AccessKeyId', type: 'text', required: true },
+      { key: 'SecretAccessKey', label: 'SecretAccessKey', type: 'password', required: true },
+    ],
+    adapterFactory: (config) => new HuaweiAdapter(config),
+  },
+  {
+    type: 'baidu',
+    name: '百度云',
+    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'AccessKeyId', label: 'AccessKeyId', type: 'text', required: true },
+      { key: 'SecretAccessKey', label: 'SecretAccessKey', type: 'password', required: true },
+    ],
+    adapterFactory: (config) => new BaiduAdapter(config),
+  },
+  {
+    type: 'huoshan',
+    name: '火山引擎',
+    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'AccessKeyId', label: 'AccessKeyId', type: 'text', required: true },
+      { key: 'SecretAccessKey', label: 'SecretAccessKey', type: 'password', required: true },
+    ],
+    adapterFactory: (config) => new HuoshanAdapter(config),
+  },
+  {
+    type: 'jdcloud',
+    name: '京东云',
+    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'AccessKeyId', label: 'AccessKeyId', type: 'text', required: true },
+      { key: 'AccessKeySecret', label: 'AccessKeySecret', type: 'password', required: true },
+    ],
+    adapterFactory: (config) => new JdcloudAdapter(config),
+  },
+  {
+    type: 'cloudflare',
+    name: 'Cloudflare',
+    capabilities: { remark: true, status: false, redirect: true, log: false, weight: true },
+    configFields: [
+      { key: 'apiToken', label: 'API Token', type: 'password', required: false, group: 'token' },
+      { key: 'email', label: 'Email', type: 'text', required: false, group: 'key' },
+      { key: 'apiKey', label: 'Global API Key', type: 'password', required: false, group: 'key' },
+    ],
+    adapterFactory: (config) => new CloudflareAdapter(config),
+  },
+  {
+    type: 'dnsla',
+    name: 'DNS.LA',
+    capabilities: { remark: false, status: true, redirect: false, log: false, weight: true },
+    configFields: [
+      { key: 'apiid', label: 'API ID', type: 'text', required: true },
+      { key: 'apisecret', label: 'API Secret', type: 'password', required: true },
+    ],
+    adapterFactory: (config) => new DnslaAdapter(config),
+  },
+  {
+    type: 'west',
+    name: '西部数码',
+    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'username', label: 'Username', type: 'text', required: true },
+      { key: 'api_password', label: 'API Password', type: 'password', required: true },
+    ],
+    adapterFactory: (config) => new WestAdapter(config),
+  },
+  {
+    type: 'qingcloud',
+    name: '青云',
+    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'access_key_id', label: 'Access Key ID', type: 'text', required: true },
+      { key: 'secret_access_key', label: 'Secret Access Key', type: 'password', required: true },
+    ],
+    adapterFactory: (config) => new QingcloudAdapter(config),
+  },
+  {
+    type: 'namesilo',
+    name: 'NameSilo',
+    capabilities: { remark: false, status: false, redirect: false, log: false, weight: false },
+    configFields: [{ key: 'apikey', label: 'API Key', type: 'password', required: true }],
+    adapterFactory: (config) => new NamesiloAdapter(config),
+  },
+  {
+    type: 'bt',
+    name: '宝塔',
+    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'AccountID', label: 'Account ID', type: 'text', required: true },
+      { key: 'AccessKey', label: 'Access Key', type: 'password', required: true },
+      { key: 'SecretKey', label: 'Secret Key', type: 'password', required: true },
+    ],
+    adapterFactory: (config) => new BtAdapter(config),
+  },
+  {
+    type: 'spaceship',
+    name: 'Spaceship',
+    capabilities: { remark: false, status: false, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'apiKey', label: 'API Key', type: 'text', required: true },
+      { key: 'apiSecret', label: 'API Secret', type: 'password', required: true },
+    ],
+    adapterFactory: (config) => new SpaceshipAdapter(config),
+  },
+  {
+    type: 'powerdns',
+    name: 'PowerDNS',
+    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'serverUrl', label: 'Server URL', type: 'text', required: true },
+      { key: 'apiKey', label: 'API Key', type: 'password', required: true },
+      { key: 'serverId', label: 'Server ID', type: 'text', required: false },
+    ],
+    adapterFactory: (config) => new PowerdnsAdapter(config),
+  },
+  {
+    type: 'aliyunesa',
+    name: '阿里云ESA',
+    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'AccessKeyId', label: 'AccessKeyId', type: 'text', required: true },
+      { key: 'AccessKeySecret', label: 'AccessKeySecret', type: 'password', required: true },
+    ],
+    adapterFactory: (config) => new AliyunesaAdapter(config),
+  },
+  {
+    type: 'tencenteo',
+    name: '腾讯EdgeOne',
+    capabilities: { remark: false, status: true, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'SecretId', label: 'SecretId', type: 'text', required: true },
+      { key: 'SecretKey', label: 'SecretKey', type: 'password', required: true },
+    ],
+    adapterFactory: (config) => new TencenteoAdapter(config),
+  },
+  {
+    type: 'dnshe',
+    name: 'DNSHE',
+    capabilities: { remark: false, status: false, redirect: false, log: false, weight: false },
+    configFields: [
+      { key: 'apiKey', label: 'API Key', type: 'text', required: true },
+      { key: 'apiSecret', label: 'API Secret', type: 'password', required: true },
+    ],
+    adapterFactory: (config) => new DnsheAdapter(config),
+  },
+  {
+    type: 'rainyun',
+    name: '雨云',
+    capabilities: { remark: false, status: false, redirect: false, log: false, weight: false },
+    configFields: [{ key: 'apiKey', label: 'API Key', type: 'password', required: true }],
+    adapterFactory: (config) => new RainyunAdapter(config),
+  },
+];
+
+function validateDefinitions(definitions: ProviderDefinition[]): void {
+  const seenTypes = new Set<string>();
+
+  for (const definition of definitions) {
+    if (seenTypes.has(definition.type)) {
+      throw new Error(`Duplicate provider type detected in registry: "${definition.type}"`);
+    }
+    seenTypes.add(definition.type);
+
+    const seenConfigKeys = new Set<string>();
+    for (const field of definition.configFields) {
+      if (seenConfigKeys.has(field.key)) {
+        throw new Error(
+          `Duplicate config key detected in provider "${definition.type}": "${field.key}"`,
+        );
+      }
+      seenConfigKeys.add(field.key);
+    }
+  }
+}
+
+validateDefinitions(providerDefinitions);
+
+export const providerDefinitionMap = new Map(providerDefinitions.map((definition) => [definition.type, definition]));
+
+export function getProviderDefinitions(): ProviderDefinition[] {
+  return providerDefinitions;
+}
+
+export function getProviderInfoList(): ProviderInfo[] {
+  return providerDefinitions.map(({ adapterFactory, ...providerInfo }) => providerInfo);
+}


### PR DESCRIPTION
### Motivation
- 将 provider 的元数据与适配器构造集中到单一入口以便统一管理与扩展。 
- 消除 `DnsHelper` 中的硬编码 `providers` 常量与 `createAdapter` 的 `switch` 分支以减少重复并简化新增 provider 的流程。 
- 在启动阶段尽早检测 `type` 与 `configFields.key` 的命名冲突以便在批量接入时快速定位问题。 

### Description
- 新增 `server/src/lib/dns/providers/registry.ts`，定义了 `ProviderDefinition`（含 `type`、`name`、`capabilities`、`configFields`、`adapterFactory`）以及导出 `getProviderDefinitions`/`getProviderInfoList`/`providerDefinitionMap`。 
- 将现有 provider 的元数据与 `adapterFactory`（包含 `cloudflare`、`aliyun`、`dnspod` 等）迁移到 registry，并保留 `server/src/lib/dns/providers/index.ts` 仅做 Adapter 导出。 
- 更新 `server/src/lib/dns/DnsHelper.ts`：`getProviders()` 改为从 registry 返回元数据，`createAdapter()` 通过 `providerDefinitionMap` 查找对应的 `adapterFactory` 来实例化适配器，移除了原有的 `switch` 实现。 
- 在 registry 中新增启动期校验逻辑以抛出明确错误，分别校验 provider `type` 的全局唯一性与每个 provider 中 `configFields.key` 的唯一性。 

### Testing
- 在 `server/` 目录运行了 `npm run build`（即 `tsc`），TypeScript 编译通过并且无编译错误。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d13faa0abc83248b9cd6240062899e)