### PR TITLE
Refactor DNS provider transport/signing abstractions and migrate Aliyun/NameSilo

### DIFF
--- a/server/src/lib/dns/providers/_template.ts
+++ b/server/src/lib/dns/providers/_template.ts
@@ -1,0 +1,64 @@
+import { DnsRecord, DomainInfo, PageResult } from '../DnsInterface';
+import { BaseAdapter, Dict, normalizeRrName, safeString } from './common';
+
+/**
+ * Provider scaffold:
+ * 1) 必须实现 mapRecord：将第三方记录映射为 DnsRecord。
+ * 2) 必须实现 normalizeLine：统一线路参数。
+ * 3) 必须实现 mapProviderError：将第三方错误映射为可读错误文本。
+ */
+export abstract class ProviderTemplateAdapter extends BaseAdapter {
+  protected abstract mapRecord(source: Dict): DnsRecord;
+  protected abstract normalizeLine(line?: string): string;
+  protected abstract mapProviderError(errorPayload: unknown): string;
+
+  protected normalizeName(name: string): string {
+    return normalizeRrName(name);
+  }
+
+  protected toError(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    const mapped = this.mapProviderError(error);
+    return mapped || safeString(error);
+  }
+
+  async check(): Promise<boolean> { throw new Error('Implement check()'); }
+  async getDomainList(_keyword?: string, _page?: number, _pageSize?: number): Promise<PageResult<DomainInfo>> { throw new Error('Implement getDomainList()'); }
+  async getDomainRecords(
+    _page?: number,
+    _pageSize?: number,
+    _keyword?: string,
+    _subdomain?: string,
+    _value?: string,
+    _type?: string,
+    _line?: string,
+    _status?: number
+  ): Promise<PageResult<DnsRecord>> { throw new Error('Implement getDomainRecords()'); }
+  async getDomainRecordInfo(_recordId: string): Promise<DnsRecord | null> { throw new Error('Implement getDomainRecordInfo()'); }
+  async addDomainRecord(
+    _name: string,
+    _type: string,
+    _value: string,
+    _line?: string,
+    _ttl?: number,
+    _mx?: number,
+    _weight?: number,
+    _remark?: string
+  ): Promise<string | null> { throw new Error('Implement addDomainRecord()'); }
+  async updateDomainRecord(
+    _recordId: string,
+    _name: string,
+    _type: string,
+    _value: string,
+    _line?: string,
+    _ttl?: number,
+    _mx?: number,
+    _weight?: number,
+    _remark?: string
+  ): Promise<boolean> { throw new Error('Implement updateDomainRecord()'); }
+  async deleteDomainRecord(_recordId: string): Promise<boolean> { throw new Error('Implement deleteDomainRecord()'); }
+  async setDomainRecordStatus(_recordId: string, _status: number): Promise<boolean> { throw new Error('Implement setDomainRecordStatus()'); }
+  async getRecordLines(): Promise<Array<{ id: string; name: string }>> { return [{ id: 'default', name: '默认' }]; }
+  async getMinTTL(): Promise<number> { return 600; }
+  async addDomain(_domain: string): Promise<boolean> { throw new Error('Implement addDomain()'); }
+}

--- a/server/src/lib/dns/providers/aliyun.ts
+++ b/server/src/lib/dns/providers/aliyun.ts
@@ -1,73 +1,16 @@
-import crypto from 'node:crypto';
 import { DnsRecord, DomainInfo, PageResult } from '../DnsInterface';
-import { asArray, BaseAdapter, Dict, normalizeRrName, safeString, toNumber, toRecordStatus, uuid } from './common';
+import { AliyunRpcAdapter, asArray, Dict, normalizeRrName, safeString, toNumber, toRecordStatus } from './common';
 
-class AliyunRpcClient {
-  constructor(private readonly endpoint: string, private readonly accessKeyId: string, private readonly accessKeySecret: string) {}
-
-  private percentEncode(value: string): string {
-    return encodeURIComponent(value)
-      .replace(/\+/g, '%20')
-      .replace(/\*/g, '%2A')
-      .replace(/%7E/g, '~');
-  }
-
-  private buildSignedQuery(action: string, params: Record<string, unknown>): URLSearchParams {
-    const publicParams: Record<string, string> = {
-      Action: action,
-      Format: 'JSON',
-      Version: '2015-01-09',
-      AccessKeyId: this.accessKeyId,
-      SignatureMethod: 'HMAC-SHA1',
-      Timestamp: new Date().toISOString(),
-      SignatureVersion: '1.0',
-      SignatureNonce: uuid(),
-    };
-
-    for (const [key, value] of Object.entries(params)) {
-      if (value === undefined || value === null || value === '') continue;
-      publicParams[key] = String(value);
-    }
-
-    const sortedKeys = Object.keys(publicParams).sort();
-    const canonicalized = sortedKeys
-      .map((key) => `${this.percentEncode(key)}=${this.percentEncode(publicParams[key])}`)
-      .join('&');
-
-    const stringToSign = `GET&%2F&${this.percentEncode(canonicalized)}`;
-    const signature = crypto
-      .createHmac('sha1', `${this.accessKeySecret}&`)
-      .update(stringToSign)
-      .digest('base64');
-
-    const search = new URLSearchParams(publicParams);
-    search.set('Signature', signature);
-    return search;
-  }
-
-  async call<T = Dict>(action: string, params: Record<string, unknown> = {}): Promise<T> {
-    const query = this.buildSignedQuery(action, params);
-    const url = `${this.endpoint}?${query.toString()}`;
-    const res = await fetch(url, { method: 'GET' });
-    const data = (await res.json()) as Dict;
-    if (!res.ok || data.Code) {
-      const err = safeString(data.Message) || safeString(data.Code) || `Aliyun action ${action} failed`;
-      throw new Error(err);
-    }
-    return data as T;
-  }
-}
-
-export class AliyunAdapter extends BaseAdapter {
+export class AliyunAdapter extends AliyunRpcAdapter {
   private readonly domain: string;
-  private readonly client: AliyunRpcClient;
 
   constructor(config: Record<string, string>) {
-    super();
+    super(config);
     this.domain = safeString(config.domain);
-    const id = safeString(config.AccessKeyId);
-    const secret = safeString(config.AccessKeySecret);
-    this.client = new AliyunRpcClient('https://alidns.aliyuncs.com/', id, secret);
+  }
+
+  protected endpoint(): string {
+    return 'https://alidns.aliyuncs.com/';
   }
 
   private mapRecord(item: Dict): DnsRecord {
@@ -87,7 +30,7 @@ export class AliyunAdapter extends BaseAdapter {
     };
   }
 
-  private convertLineCode(line?: string): string | undefined {
+  private normalizeLine(line?: string): string | undefined {
     const convertDict: Record<string, string> = {
       '0': 'default',
       '10=1': 'unicom',
@@ -105,7 +48,7 @@ export class AliyunAdapter extends BaseAdapter {
 
   async check(): Promise<boolean> {
     try {
-      await this.client.call('DescribeDomains', { PageSize: 1, PageNumber: 1 });
+      await this.rpcCall('DescribeDomains', { PageSize: 1, PageNumber: 1 });
       return true;
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
@@ -115,7 +58,7 @@ export class AliyunAdapter extends BaseAdapter {
 
   async getDomainList(keyword?: string, page = 1, pageSize = 50): Promise<PageResult<DomainInfo>> {
     try {
-      const data = await this.client.call<Dict>('DescribeDomains', {
+      const data = await this.rpcCall<Dict>('DescribeDomains', {
         PageNumber: page,
         PageSize: pageSize,
         KeyWord: keyword,
@@ -144,7 +87,6 @@ export class AliyunAdapter extends BaseAdapter {
   ): Promise<PageResult<DnsRecord>> {
     try {
       const params: Record<string, unknown> = {
-        Action: 'DescribeDomainRecords',
         DomainName: this.domain,
         PageNumber: page,
         PageSize: pageSize,
@@ -154,14 +96,14 @@ export class AliyunAdapter extends BaseAdapter {
         params.RRKeyWord = subdomain;
         params.ValueKeyWord = value;
         params.Type = type;
-        params.Line = this.convertLineCode(line);
+        params.Line = this.normalizeLine(line);
       } else if (keyword) {
         params.KeyWord = keyword;
       }
       if (status !== undefined) {
         params.Status = status === 1 ? 'Enable' : 'Disable';
       }
-      const data = await this.client.call<Dict>('DescribeDomainRecords', params);
+      const data = await this.rpcCall<Dict>('DescribeDomainRecords', params);
       const list = asArray<Dict>((data.DomainRecords as Dict | undefined)?.Record).map((item) => this.mapRecord(item));
       return { total: toNumber(data.TotalCount, list.length), list };
     } catch (e) {
@@ -172,7 +114,7 @@ export class AliyunAdapter extends BaseAdapter {
 
   async getDomainRecordInfo(recordId: string): Promise<DnsRecord | null> {
     try {
-      const data = await this.client.call<Dict>('DescribeDomainRecordInfo', { RecordId: recordId });
+      const data = await this.rpcCall<Dict>('DescribeDomainRecordInfo', { RecordId: recordId });
       return this.mapRecord(data);
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
@@ -182,18 +124,18 @@ export class AliyunAdapter extends BaseAdapter {
 
   async addDomainRecord(name: string, type: string, value: string, line?: string, ttl = 600, mx = 0, weight?: number, remark?: string): Promise<string | null> {
     try {
-      const data = await this.client.call<Dict>('AddDomainRecord', {
+      const data = await this.rpcCall<Dict>('AddDomainRecord', {
         DomainName: this.domain,
         RR: normalizeRrName(name),
         Type: type,
         Value: value,
-        Line: this.convertLineCode(line) ?? 'default',
+        Line: this.normalizeLine(line) ?? 'default',
         TTL: ttl,
         Priority: type === 'MX' ? mx : undefined,
         Weight: weight,
       });
       if (remark) {
-        await this.client.call('UpdateDomainRecordRemark', { RecordId: safeString(data.RecordId), Remark: remark });
+        await this.rpcCall('UpdateDomainRecordRemark', { RecordId: safeString(data.RecordId), Remark: remark });
       }
       return safeString(data.RecordId) || null;
     } catch (e) {
@@ -214,18 +156,18 @@ export class AliyunAdapter extends BaseAdapter {
     remark?: string
   ): Promise<boolean> {
     try {
-      await this.client.call('UpdateDomainRecord', {
+      await this.rpcCall('UpdateDomainRecord', {
         RecordId: recordId,
         RR: normalizeRrName(name),
         Type: type,
         Value: value,
-        Line: this.convertLineCode(line) ?? 'default',
+        Line: this.normalizeLine(line) ?? 'default',
         TTL: ttl,
         Priority: type === 'MX' ? mx : undefined,
         Weight: weight,
       });
       if (remark !== undefined) {
-        await this.client.call('UpdateDomainRecordRemark', { RecordId: recordId, Remark: remark });
+        await this.rpcCall('UpdateDomainRecordRemark', { RecordId: recordId, Remark: remark });
       }
       return true;
     } catch (e) {
@@ -236,7 +178,7 @@ export class AliyunAdapter extends BaseAdapter {
 
   async deleteDomainRecord(recordId: string): Promise<boolean> {
     try {
-      await this.client.call('DeleteDomainRecord', { RecordId: recordId });
+      await this.rpcCall('DeleteDomainRecord', { RecordId: recordId });
       return true;
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
@@ -246,7 +188,7 @@ export class AliyunAdapter extends BaseAdapter {
 
   async setDomainRecordStatus(recordId: string, status: number): Promise<boolean> {
     try {
-      await this.client.call('SetDomainRecordStatus', {
+      await this.rpcCall('SetDomainRecordStatus', {
         RecordId: recordId,
         Status: status === 1 ? 'Enable' : 'Disable',
       });
@@ -259,7 +201,7 @@ export class AliyunAdapter extends BaseAdapter {
 
   async getRecordLines(): Promise<Array<{ id: string; name: string }>> {
     try {
-      const data = await this.client.call<Dict>('DescribeDomainInfo', {
+      const data = await this.rpcCall<Dict>('DescribeDomainInfo', {
         DomainName: this.domain,
         NeedDetailAttributes: true,
       });
@@ -275,7 +217,7 @@ export class AliyunAdapter extends BaseAdapter {
 
   async getMinTTL(): Promise<number> {
     try {
-      const data = await this.client.call<Dict>('DescribeDomainInfo', {
+      const data = await this.rpcCall<Dict>('DescribeDomainInfo', {
         DomainName: this.domain,
         NeedDetailAttributes: true,
       });
@@ -287,7 +229,7 @@ export class AliyunAdapter extends BaseAdapter {
 
   async addDomain(domain: string): Promise<boolean> {
     try {
-      await this.client.call('AddDomain', { DomainName: domain });
+      await this.rpcCall('AddDomain', { DomainName: domain });
       return true;
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);

--- a/server/src/lib/dns/providers/common.ts
+++ b/server/src/lib/dns/providers/common.ts
@@ -1,7 +1,13 @@
 import crypto from 'node:crypto';
 import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../DnsInterface';
+import {
+  Dict,
+  buildCanonicalQuery,
+  hmacSignSha1,
+  requestJson,
+} from './http';
 
-export type Dict = Record<string, unknown>;
+export type { Dict };
 
 export function safeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
@@ -109,6 +115,74 @@ export abstract class BaseAdapter implements DnsAdapter {
   abstract addDomain(domain: string): Promise<boolean>;
 }
 
+export abstract class TokenAuthAdapter extends BaseAdapter {
+  protected readonly token: string;
+
+  constructor(config: Record<string, string>, tokenField = 'token') {
+    super();
+    this.token = safeString(config[tokenField]);
+  }
+
+  protected bearerAuth(headers: Record<string, string> = {}): Record<string, string> {
+    return {
+      ...headers,
+      Authorization: `Bearer ${this.token}`,
+    };
+  }
+}
+
+export abstract class AliyunRpcAdapter extends BaseAdapter {
+  protected readonly accessKeyId: string;
+  protected readonly accessKeySecret: string;
+
+  constructor(config: Record<string, string>) {
+    super();
+    this.accessKeyId = safeString(config.AccessKeyId);
+    this.accessKeySecret = safeString(config.AccessKeySecret);
+  }
+
+  protected abstract endpoint(): string;
+  protected version(): string {
+    return '2015-01-09';
+  }
+
+  protected async rpcCall<T = Dict>(action: string, params: Record<string, unknown> = {}): Promise<T> {
+    const publicParams: Record<string, unknown> = {
+      Action: action,
+      Format: 'JSON',
+      Version: this.version(),
+      AccessKeyId: this.accessKeyId,
+      SignatureMethod: 'HMAC-SHA1',
+      Timestamp: new Date().toISOString(),
+      SignatureVersion: '1.0',
+      SignatureNonce: uuid(),
+      ...params,
+    };
+
+    const canonicalized = buildCanonicalQuery(publicParams);
+    const stringToSign = `GET&%2F&${encodeURIComponent(canonicalized)}`;
+    const signature = hmacSignSha1(`${this.accessKeySecret}&`, stringToSign, 'base64');
+
+    const query = new URLSearchParams();
+    for (const [k, v] of Object.entries(publicParams)) {
+      if (v === undefined || v === null || v === '') continue;
+      query.set(k, String(v));
+    }
+    query.set('Signature', signature);
+
+    return requestJson<T>(`${this.endpoint()}?${query.toString()}`, {
+      method: 'GET',
+      parseError: (payload) => {
+        const data = (payload ?? {}) as Dict;
+        if (data.Code || data.Message) {
+          return safeString(data.Message) || safeString(data.Code) || `Aliyun action ${action} failed`;
+        }
+        return undefined;
+      },
+    });
+  }
+}
+
 export abstract class TencentCloudAdapter extends BaseAdapter {
   protected readonly secretId: string;
   protected readonly secretKey: string;
@@ -163,7 +237,7 @@ export abstract class TencentCloudAdapter extends BaseAdapter {
       `TC3-HMAC-SHA256 Credential=${this.secretId}/${credentialScope}, ` +
       `SignedHeaders=${signedHeaders}, Signature=${signature}`;
 
-    const res = await fetch(`https://${host}`, {
+    const data = await requestJson<Dict>(`https://${host}`, {
       method: 'POST',
       headers: {
         Authorization: authorization,
@@ -176,10 +250,9 @@ export abstract class TencentCloudAdapter extends BaseAdapter {
       body,
     });
 
-    const data = (await res.json()) as Dict;
     const response = (data.Response ?? data) as Dict;
     const error = response.Error as Dict | undefined;
-    if (!res.ok || error) {
+    if (error) {
       const code = safeString(error?.Code);
       const msg = safeString(error?.Message) || `TencentCloud action ${action} failed`;
       throw new Error(code ? `${code}: ${msg}` : msg);

--- a/server/src/lib/dns/providers/http.ts
+++ b/server/src/lib/dns/providers/http.ts
@@ -1,0 +1,185 @@
+import crypto from 'node:crypto';
+
+export type Dict = Record<string, unknown>;
+
+export interface RequestOptions {
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  headers?: Record<string, string>;
+  query?: Record<string, unknown>;
+  body?: string;
+  timeoutMs?: number;
+  parseError?: (payload: unknown) => string | undefined;
+}
+
+function withQuery(url: string, query?: Record<string, unknown>): string {
+  if (!query) return url;
+  const u = new URL(url);
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null || value === '') continue;
+    u.searchParams.set(key, String(value));
+  }
+  return u.toString();
+}
+
+function toErrorMessage(status: number, statusText: string, message?: string): string {
+  if (message) return message;
+  return `HTTP ${status}${statusText ? ` ${statusText}` : ''}`.trim();
+}
+
+async function performRequest(url: string, options: RequestOptions): Promise<{ res: Response; text: string }> {
+  const timeoutMs = options.timeoutMs ?? 10000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(withQuery(url, options.query), {
+      method: options.method ?? 'GET',
+      headers: options.headers,
+      body: options.body,
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    return { res, text };
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Request timeout after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function requestJson<T = unknown>(url: string, options: RequestOptions = {}): Promise<T> {
+  const { res, text } = await performRequest(url, options);
+  let payload: unknown = undefined;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      throw new Error(`Invalid JSON response: ${text.slice(0, 200)}`);
+    }
+  }
+
+  const businessError = options.parseError?.(payload);
+  if (!res.ok || businessError) {
+    throw new Error(toErrorMessage(res.status, res.statusText, businessError));
+  }
+  return payload as T;
+}
+
+type XmlNode = string | Dict | XmlNode[];
+
+function assignNode(target: Dict, key: string, value: XmlNode): void {
+  const current = target[key];
+  if (current === undefined) {
+    target[key] = value;
+    return;
+  }
+  if (Array.isArray(current)) {
+    current.push(value);
+    target[key] = current;
+    return;
+  }
+  target[key] = [current as XmlNode, value];
+}
+
+function parseXml(xml: string): Dict {
+  const cleaned = xml
+    .replace(/<\?xml[\s\S]*?\?>/g, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .trim();
+
+  const root: Dict = {};
+  const stack: Array<{ key: string; node: Dict }> = [{ key: '__root__', node: root }];
+  const tokenRegex = /<[^>]+>|[^<]+/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = tokenRegex.exec(cleaned))) {
+    const token = match[0];
+    if (!token) continue;
+
+    if (token.startsWith('</')) {
+      stack.pop();
+      continue;
+    }
+
+    if (token.startsWith('<')) {
+      if (token.startsWith('<!') || token.startsWith('<?')) continue;
+      const selfClosing = token.endsWith('/>');
+      const rawName = token.replace(/^</, '').replace(/\/?>(\s*)$/, '').trim();
+      const key = rawName.split(/\s+/)[0];
+      if (!key) continue;
+      const node: Dict = {};
+      assignNode(stack[stack.length - 1].node, key, node);
+      if (!selfClosing) {
+        stack.push({ key, node });
+      }
+      continue;
+    }
+
+    const value = token.trim();
+    if (!value) continue;
+    const current = stack[stack.length - 1];
+    assignNode(current.node, '#text', value);
+  }
+
+  return root;
+}
+
+function unwrapTextNode(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => unwrapTextNode(item));
+  if (!value || typeof value !== 'object') return value;
+  const node = value as Dict;
+  const keys = Object.keys(node);
+  if (keys.length === 1 && keys[0] === '#text') return node['#text'];
+  const out: Dict = {};
+  for (const [k, v] of Object.entries(node)) {
+    out[k] = unwrapTextNode(v);
+  }
+  return out;
+}
+
+export async function requestXml<T = unknown>(url: string, options: RequestOptions = {}): Promise<T> {
+  const { res, text } = await performRequest(url, options);
+  if (!text) {
+    throw new Error(toErrorMessage(res.status, res.statusText, 'Empty XML response'));
+  }
+
+  const parsed = unwrapTextNode(parseXml(text));
+  const businessError = options.parseError?.(parsed);
+  if (!res.ok || businessError) {
+    throw new Error(toErrorMessage(res.status, res.statusText, businessError));
+  }
+  return parsed as T;
+}
+
+export function percentEncodeRfc3986(value: string): string {
+  return encodeURIComponent(value)
+    .replace(/\+/g, '%20')
+    .replace(/\*/g, '%2A')
+    .replace(/%7E/g, '~');
+}
+
+export function buildCanonicalQuery(params: Record<string, unknown>): string {
+  return Object.keys(params)
+    .filter((key) => params[key] !== undefined && params[key] !== null && params[key] !== '')
+    .sort()
+    .map((key) => `${percentEncodeRfc3986(key)}=${percentEncodeRfc3986(String(params[key]))}`)
+    .join('&');
+}
+
+export function buildCanonicalBody(params: Record<string, unknown>): string {
+  return Object.keys(params)
+    .filter((key) => params[key] !== undefined && params[key] !== null)
+    .sort()
+    .map((key) => `${key}=${String(params[key])}`)
+    .join('&');
+}
+
+export function hmacSignSha1(key: Buffer | string, content: string, encoding: crypto.BinaryToTextEncoding = 'hex'): string {
+  return crypto.createHmac('sha1', key).update(content).digest(encoding);
+}
+
+export function hmacSignSha256(key: Buffer | string, content: string, encoding: crypto.BinaryToTextEncoding = 'hex'): string {
+  return crypto.createHmac('sha256', key).update(content).digest(encoding);
+}

--- a/server/src/lib/dns/providers/namesilo.ts
+++ b/server/src/lib/dns/providers/namesilo.ts
@@ -1,10 +1,13 @@
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../DnsInterface';
-import { BaseAdapter, Dict, safeString, toNumber } from './common';
+import { DnsRecord, DomainInfo, PageResult } from '../DnsInterface';
+import { asArray, BaseAdapter, normalizeRrName, safeString, toNumber } from './common';
+import { requestXml } from './http';
 
 interface NamesiloConfig {
   apikey: string;
   domain?: string;
 }
+
+type XmlDict = Record<string, unknown>;
 
 export class NamesiloAdapter extends BaseAdapter {
   private config: NamesiloConfig;
@@ -18,15 +21,36 @@ export class NamesiloAdapter extends BaseAdapter {
     };
   }
 
-  private async request<T>(operation: string, params: Record<string, string> = {}): Promise<T> {
-    const query = new URLSearchParams({ version: '1', type: 'json', key: this.config.apikey, ...params });
-    const url = `${this.baseUrl}/${operation}?${query.toString()}`;
-    const res = await fetch(url);
-    const data = (await res.json()) as Dict;
-    if (!res.ok || (data.reply as Dict)?.code !== '300') {
-      throw new Error(safeString((data.reply as Dict)?.detail) || `Namesilo request failed: ${res.status}`);
-    }
-    return data as T;
+  private normalizeLine(line?: string): string {
+    return safeString(line) || 'default';
+  }
+
+  private toList<T>(value: unknown): T[] {
+    return Array.isArray(value) ? (value as T[]) : value ? [value as T] : [];
+  }
+
+  private resolveReply(payload: XmlDict): XmlDict {
+    const root = (payload.namesilo as XmlDict | undefined) ?? payload;
+    return (root.reply as XmlDict | undefined) ?? {};
+  }
+
+  private mapError(reply: XmlDict, operation: string): string | undefined {
+    const code = safeString(reply.code);
+    if (code === '300') return undefined;
+    return safeString(reply.detail) || `Namesilo ${operation} failed`;
+  }
+
+  private async request(operation: string, params: Record<string, string> = {}): Promise<XmlDict> {
+    const query = { version: '1', type: 'xml', key: this.config.apikey, ...params };
+    const url = `${this.baseUrl}/${operation}`;
+    const data = await requestXml<XmlDict>(url, {
+      query,
+      parseError: (payload) => {
+        const reply = this.resolveReply((payload ?? {}) as XmlDict);
+        return this.mapError(reply, operation);
+      },
+    });
+    return this.resolveReply(data);
   }
 
   async check(): Promise<boolean> {
@@ -39,12 +63,13 @@ export class NamesiloAdapter extends BaseAdapter {
     }
   }
 
-  async getDomainList(keyword?: string, page = 1, pageSize = 50): Promise<PageResult<DomainInfo>> {
+  async getDomainList(keyword?: string, _page = 1, _pageSize = 50): Promise<PageResult<DomainInfo>> {
     try {
-      const data = await this.request<{ reply: { domains: { domain: Array<{ domain: string }> } } }>('listDomains');
-      let list = (data.reply?.domains?.domain || []).map((item) => ({
-        Domain: item.domain,
-        ThirdId: item.domain,
+      const reply = await this.request('listDomains');
+      const domainsNode = (reply.domains as XmlDict | undefined)?.domain;
+      let list = this.toList<string>(domainsNode).map((domain) => ({
+        Domain: safeString(domain),
+        ThirdId: safeString(domain),
         RecordCount: undefined as number | undefined,
       }));
       if (keyword) {
@@ -64,13 +89,14 @@ export class NamesiloAdapter extends BaseAdapter {
     subdomain?: string,
     value?: string,
     type?: string,
-    _line?: string,
+    line?: string,
     _status?: number
   ): Promise<PageResult<DnsRecord>> {
     try {
       if (!this.config.domain) return { total: 0, list: [] };
-      const data = await this.request<{ reply: { resource_record: Array<{ record_id: string; host: string; type: string; value: string; ttl: number }> } }>('dnsListRecords', { domain: this.config.domain });
-      let list = (data.reply?.resource_record || []).map((r) => this.mapRecord(r));
+      const reply = await this.request('dnsListRecords', { domain: this.config.domain });
+      const listNode = reply.resource_record;
+      let list = this.toList<XmlDict>(listNode).map((r) => this.mapRecord(r, this.normalizeLine(line)));
       if (subdomain) list = list.filter((r) => r.Name.toLowerCase() === subdomain.toLowerCase());
       else if (keyword) {
         const lower = keyword.toLowerCase();
@@ -78,7 +104,10 @@ export class NamesiloAdapter extends BaseAdapter {
       }
       if (value) list = list.filter((r) => r.Value === value);
       if (type) list = list.filter((r) => r.Type === type);
-      return { total: list.length, list };
+
+      const start = Math.max(0, (page - 1) * pageSize);
+      const end = start + pageSize;
+      return { total: list.length, list: list.slice(start, end) };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
       return { total: 0, list: [] };
@@ -87,7 +116,7 @@ export class NamesiloAdapter extends BaseAdapter {
 
   async getDomainRecordInfo(recordId: string): Promise<DnsRecord | null> {
     try {
-      const records = await this.getDomainRecords(1, 100);
+      const records = await this.getDomainRecords(1, 500);
       return records.list.find((r) => r.RecordId === recordId) || null;
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
@@ -98,8 +127,14 @@ export class NamesiloAdapter extends BaseAdapter {
   async addDomainRecord(name: string, type: string, value: string, _line?: string, ttl = 7207, _mx?: number, _weight?: number, _remark?: string): Promise<string | null> {
     try {
       if (!this.config.domain) return null;
-      await this.request('dnsAddRecord', { domain: this.config.domain, rrtype: type, rrhost: name, rrvalue: value, rrttl: String(ttl) });
-      return 'success';
+      const reply = await this.request('dnsAddRecord', {
+        domain: this.config.domain,
+        rrtype: type,
+        rrhost: normalizeRrName(name),
+        rrvalue: value,
+        rrttl: String(ttl),
+      });
+      return safeString(reply.record_id) || 'success';
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
       return null;
@@ -109,7 +144,14 @@ export class NamesiloAdapter extends BaseAdapter {
   async updateDomainRecord(recordId: string, name: string, type: string, value: string, _line?: string, ttl = 7207, _mx?: number, _weight?: number, _remark?: string): Promise<boolean> {
     try {
       if (!this.config.domain) return false;
-      await this.request('dnsUpdateRecord', { domain: this.config.domain, rrid: recordId, rrhost: name, rrvalue: value, rrttl: String(ttl) });
+      await this.request('dnsUpdateRecord', {
+        domain: this.config.domain,
+        rrid: recordId,
+        rrtype: type,
+        rrhost: normalizeRrName(name),
+        rrvalue: value,
+        rrttl: String(ttl),
+      });
       return true;
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
@@ -146,16 +188,17 @@ export class NamesiloAdapter extends BaseAdapter {
     return false;
   }
 
-  private mapRecord(r: { record_id: string; host: string; type: string; value: string; ttl: number }): DnsRecord {
+  private mapRecord(r: XmlDict, line = 'default'): DnsRecord {
     const domain = this.config.domain || '';
+    const host = safeString(r.host);
     return {
-      RecordId: r.record_id,
+      RecordId: safeString(r.record_id),
       Domain: domain,
-      Name: r.host === '' ? '@' : r.host,
-      Type: r.type,
-      Value: r.value,
-      Line: 'default',
-      TTL: r.ttl || 7207,
+      Name: host === '' ? '@' : host,
+      Type: safeString(r.type),
+      Value: safeString(r.value),
+      Line: line,
+      TTL: toNumber(r.ttl, 7207),
       MX: 0,
       Status: 1,
     };


### PR DESCRIPTION
### Motivation
- Introduce shared HTTP and signing primitives to centralize timeout/error handling and canonical signing for multiple DNS providers. 
- Provide reusable provider base classes so provider implementations can focus on mapping and business logic. 
- Validate the new abstractions by migrating two existing providers (`aliyun` and `namesilo`) first. 

### Description
- Added a shared HTTP helper `server/src/lib/dns/providers/http.ts` exposing `requestJson`, `requestXml`, RFC3986 percent-encoding, canonical query/body builders, and HMAC helpers to unify request/response handling and signing. 
- Extended `server/src/lib/dns/providers/common.ts` with `AliyunRpcAdapter` (RPC signing wrapper) and `TokenAuthAdapter` and refactored `TencentCloudAdapter` to use the shared request helper. 
- Migrated `AliyunAdapter` to inherit from `AliyunRpcAdapter` and removed the previous inline RPC client, keeping `mapRecord` and line normalization logic in `server/src/lib/dns/providers/aliyun.ts`. 
- Migrated `NamesiloAdapter` to use the new `requestXml` flow with centralized reply parsing and error mapping in `server/src/lib/dns/providers/namesilo.ts`. 
- Added a provider scaffold `server/src/lib/dns/providers/_template.ts` that enforces implementation of `mapRecord`, `normalizeLine`, and provider error mapping. 

### Testing
- Ran a TypeScript build for the server with `cd server && pnpm -s build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1410242808324931a3cfa3e22777b)