### PR TITLE
feat: expand lego provider alias mapping compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ When creating/updating DNS accounts, the API normalizes lego-style provider name
 | Internal Type | Supported Aliases |
 |---|---|
 | `aliyun` | `aliyun`, `alidns` |
+| `aliyunesa` | `aliesa` |
+| `baidu` | `baiducloud` |
+| `huawei` | `huaweicloud` |
+| `huoshan` | `huoshan`, `volcengine` |
+| `west` | `westcn` |
+| `cloudflare` | `cloudflare` |
+| `jdcloud` | `jdcloud` |
+| `namesilo` | `namesilo` |
+| `rainyun` | `rainyun` |
 | `powerdns` | `powerdns`, `pdns` |
 | `dnspod` | `dnspod`, `tencentcloud` |
 | `tencenteo` | `tencenteo`, `edgeone` |

--- a/README_zh.md
+++ b/README_zh.md
@@ -146,6 +146,15 @@ interface DnsAdapter {
 | ڲ | ֱ֧ |
 |---|---|
 | `aliyun` | `aliyun`, `alidns` |
+| `aliyunesa` | `aliesa` |
+| `baidu` | `baiducloud` |
+| `huawei` | `huaweicloud` |
+| `huoshan` | `huoshan`, `volcengine` |
+| `west` | `westcn` |
+| `cloudflare` | `cloudflare` |
+| `jdcloud` | `jdcloud` |
+| `namesilo` | `namesilo` |
+| `rainyun` | `rainyun` |
 | `powerdns` | `powerdns`, `pdns` |
 | `dnspod` | `dnspod`, `tencentcloud` |
 | `tencenteo` | `tencenteo`, `edgeone` |

--- a/server/src/lib/dns/providerAlias.test.ts
+++ b/server/src/lib/dns/providerAlias.test.ts
@@ -4,6 +4,11 @@ import { getProviderAliases, normalizeProviderType, providerAliasMap } from './p
 
 test('normalizes common lego aliases to internal provider types', () => {
   assert.equal(normalizeProviderType('alidns'), 'aliyun');
+  assert.equal(normalizeProviderType('aliesa'), 'aliyunesa');
+  assert.equal(normalizeProviderType('baiducloud'), 'baidu');
+  assert.equal(normalizeProviderType('huaweicloud'), 'huawei');
+  assert.equal(normalizeProviderType('volcengine'), 'huoshan');
+  assert.equal(normalizeProviderType('westcn'), 'west');
   assert.equal(normalizeProviderType('pdns'), 'powerdns');
   assert.equal(normalizeProviderType('edgeone'), 'tencenteo');
   assert.equal(normalizeProviderType('tencentcloud'), 'dnspod');
@@ -11,7 +16,9 @@ test('normalizes common lego aliases to internal provider types', () => {
 
 test('normalization is case-insensitive and trims spaces', () => {
   assert.equal(normalizeProviderType('  ALIDNS  '), 'aliyun');
+  assert.equal(normalizeProviderType('  ALIESA  '), 'aliyunesa');
   assert.equal(normalizeProviderType('  TeNcEnTcLoUd  '), 'dnspod');
+  assert.equal(normalizeProviderType('  VOLCENGINE  '), 'huoshan');
 });
 
 test('returns normalized original type when alias is unknown', () => {
@@ -21,6 +28,11 @@ test('returns normalized original type when alias is unknown', () => {
 
 test('exposes reverse aliases for import compatibility', () => {
   assert.deepEqual(getProviderAliases('aliyun').sort(), ['alidns', 'aliyun']);
+  assert.deepEqual(getProviderAliases('aliyunesa').sort(), ['aliesa']);
+  assert.deepEqual(getProviderAliases('baidu').sort(), ['baiducloud']);
+  assert.deepEqual(getProviderAliases('huawei').sort(), ['huaweicloud']);
+  assert.deepEqual(getProviderAliases('huoshan').sort(), ['huoshan', 'volcengine']);
+  assert.deepEqual(getProviderAliases('west').sort(), ['westcn']);
   assert.deepEqual(getProviderAliases('powerdns').sort(), ['pdns', 'powerdns']);
   assert.deepEqual(getProviderAliases('tencenteo').sort(), ['edgeone', 'tencenteo']);
   assert.deepEqual(getProviderAliases('dnspod').sort(), ['dnspod', 'tencentcloud']);

--- a/server/src/lib/dns/providerAlias.ts
+++ b/server/src/lib/dns/providerAlias.ts
@@ -1,12 +1,22 @@
 const LEGO_TO_INTERNAL = {
   alidns: 'aliyun',
+  aliesa: 'aliyunesa',
   aliyun: 'aliyun',
+  baiducloud: 'baidu',
+  cloudflare: 'cloudflare',
+  dnspod: 'dnspod',
+  edgeone: 'tencenteo',
+  huaweicloud: 'huawei',
+  huoshan: 'huoshan',
+  jdcloud: 'jdcloud',
+  namesilo: 'namesilo',
   pdns: 'powerdns',
   powerdns: 'powerdns',
-  edgeone: 'tencenteo',
+  rainyun: 'rainyun',
   tencenteo: 'tencenteo',
   tencentcloud: 'dnspod',
-  dnspod: 'dnspod',
+  volcengine: 'huoshan',
+  westcn: 'west',
 } as const;
 
 type LegoName = keyof typeof LEGO_TO_INTERNAL;


### PR DESCRIPTION
### Motivation
- Improve compatibility with lego-style provider names so accounts created using lego provider identifiers map to DNSMgr internal provider types automatically.

### Description
- Extended `LEGO_TO_INTERNAL` mappings in `server/src/lib/dns/providerAlias.ts` to include `aliesa -> aliyunesa`, `baiducloud -> baidu`, `huaweicloud -> huawei`, `volcengine -> huoshan`, `westcn -> west`, and other same-name entries (`cloudflare`, `jdcloud`, `namesilo`, `rainyun`).
- Adjusted reverse alias resolution so `getProviderAliases` exposes the new aliases and added unit tests in `server/src/lib/dns/providerAlias.test.ts` covering normalization, case/space trimming, and reverse alias lists.
- Synchronized documentation by updating `README.md` and `README_zh.md` provider alias tables to reflect the new mappings.
- Changed files: `server/src/lib/dns/providerAlias.ts`, `server/src/lib/dns/providerAlias.test.ts`, `README.md`, and `README_zh.md`.

### Testing
- Ran unit tests with `cd server && pnpm test` and all tests passed (`5/5` tests OK).
- Built the server with `cd server && pnpm build` and TypeScript compilation succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d145f64aa8832498a20a3af4f6cfc2)