### PR TITLE
Refactor logging: unified createLogger/SubLogger API, provider logging factories, and widespread logger updates

### DIFF
--- a/root.ai.md
+++ b/root.ai.md
@@ -108,54 +108,55 @@
 
 ### 日志相关
 1. 日志架构
-    - 日志系统实现为单例模式（`server/src/lib/logger.ts`），使用 `createLogger('ModuleName')` 创建绑定模块名的日志器。
-    - 所有模块必须使用 `createLogger` 导入时绑定模块名，**禁止**使用旧的 `log.info(module, msg)` 模式。
+    - 日志系统实现为单例模式（`server/src/lib/logger.ts`），使用 `createLogger('ModuleName')` 创建绑定主模块名的日志器。
+    - 所有模块必须在文件顶部创建本地日志映射：`const log = createLogger('MODULE')`；禁止使用 `const dsmLog = createLogger('DSM')`、`const balLog = ...` 等带模块前缀的变量名。
+    - 所有模块必须使用绑定日志器调用：`log.info(msg, data?)`，**禁止**使用旧的 `log.info(module, msg)` 模式。
+    - DNS Provider 必须使用 `server/src/lib/dns/providers/internal.ts` 二次定义的日志工厂，不允许具体 DNS 提供商文件再次定义 `createLogger('DNS')` 主模块。
     - 支持的日志级别（按严重程度升序）：`trace` < `debug` < `info` < `warn` < `error`。
     - 日志级别通过环境变量 `HIDNS_LOG_LEVEL` 配置，默认为 `info`。
 2. 日志格式规范
-    - 格式：`日期 级别 [主模块名] [子模块] [函数名] [L行号] ["自定义标签"] 内容`
+    - 格式：`日期 级别 [主模块名] [子模块.三级模块.四级模块] [函数名] [L行号] ["自定义标签"] 内容`
+    - 主模块名使用独立方括号输出；多级子模块使用点号拼接后输出到第二个方括号中。
     - 函数名和行号由日志系统自动从调用栈捕获，开发者无需手动传入。
     - 示例：
       ```
-      2026-06-07T12:00:00.000Z  INFO [BAL] [execQuery] [L42] Executing query ...
-      2026-06-07T12:00:00.000Z  INFO [DSM] [DRY RUN] [reconcile] [L88] Would create table: xxx
-      2026-06-07T12:00:00.000Z DEBUG [DL] [MySQL] [query] [L55] Creating connection pool ...
-      2026-06-07T12:00:00.000Z  INFO [WhoisService] [queryApex] [L125] ["SUCCESS"] Query succeeded
-      2026-06-07T12:00:00.000Z  INFO [MCP OAuth] [Cleanup] [L67] ["count:5"] Cleaned up 5 temporary clients
+      2026-06-07T12:00:00.000Z  INFO [BAL] [BusinessAdapter] [execQuery] [L42] Executing query ...
+      2026-06-07T12:00:00.000Z  INFO [DSM] [Reconciler.Table] [reconcile] [L88] ["DRY_RUN"] Would create table: xxx
+      2026-06-07T12:00:00.000Z DEBUG [DL] [MySQL.Pool] [query] [L55] Creating connection pool ...
+      2026-06-07T12:00:00.000Z  INFO [DNS] [Provider.Aliyun.Adapter] [getDomainList] [L125] ["SUCCESS"] Query succeeded
+      2026-06-07T12:00:00.000Z  INFO [MCP] [OAuth.Cleanup] [cleanup] [L67] ["count:5"] Cleaned up 5 temporary clients
       ```
-    - 主模块名使用大写缩写（如：BAL、DSM、DL、MCP、DNS、HTTP、Server 等）。
-    - 子模块使用 `.sub('SubModule')` 创建，输出为 `[主模块] [子模块]`。
+    - 主模块名使用大写缩写或固定名称（如：BAL、DAL、DSM、DL、MCP、DNS、HTTP、Server 等）。
+    - 子模块使用 `.sub('SubModule')` 创建；多次 `.sub()` 调用输出为 `[SubModule.NextLevel]`。
     - 调用位置`[函数名] [L行号]` 自动捕获，无需手动传入。
     - 自定义标签使用 `.tag('label1', 'label2')` 创建，输出为 `["label1"] ["label2"]`。
 3. 日志器创建方式
     - 标准方式（推荐）：
       ```typescript
       import { createLogger } from '../../lib/logger';
-      const myLog = createLogger('MODULE');
-      myLog.info('message');
+      const log = createLogger('MODULE');
+      log.info('message');
       // 输出: 2026-06-07T12:00:00.000Z  INFO [MODULE] [myFunction] [L10] message
       
-      myLog.sub('Sub').info('message');
+      log.sub('Sub').info('message');
       // 输出: 2026-06-07T12:00:00.000Z  INFO [MODULE] [Sub] [myFunction] [L12] message
       
-      myLog.tag('SUCCESS').info('message');
-      // 输出: 2026-06-07T12:00:00.000Z  INFO [MODULE] [myFunction] [L14] ["SUCCESS"] message
-      
-      myLog.sub('Sub').tag('k:v').info('msg');
-      // 输出: 2026-06-07T12:00:00.000Z  INFO [MODULE] [Sub] [myFunction] [L16] ["k:v"] msg
+      log.sub('Sub').sub('Third').tag('SUCCESS').info('message');
+      // 输出: 2026-06-07T12:00:00.000Z  INFO [MODULE] [Sub.Third] [myFunction] [L14] ["SUCCESS"] message
       ```
-    - 子日志器嵌套和标签链式调用：
+    - DNS Provider 间接方式（强制）：
       ```typescript
-      const dnsLog = createLogger('DNS');
-      dnsLog.sub('Cloudflare').debug('Resolving zone...');
-      // 输出: 2026-06-07T12:00:00.000Z DEBUG [DNS] [Cloudflare] [resolveZone] [L30] Resolving zone...
+      import { createProviderAdapterLogger } from '../internal';
+      const log = createProviderAdapterLogger('Aliyun');
+      log.tag('SUCCESS').info('Domain list fetched');
+      // 输出: 2026-06-07T12:00:00.000Z  INFO [DNS] [Provider.Aliyun.Adapter] [getDomainList] [L30] ["SUCCESS"] Domain list fetched
       ```
 4. 日志分类
     - 通用日志：`.trace(msg, data?)`、`.debug(msg, data?)`、`.info(msg, data?)`、`.warn(msg, data?)`、`.error(msg, data?)`
-    - DNS Provider 日志：使用 `createLogger('DNS').sub('ProviderName')` 记录
-    - 适配器方法调用日志：由 `DnsHelper.ts` 中的 `createLoggingAdapter` Proxy 自动拦截所有 `DnsAdapter` 方法调用并记录，无需各适配器手动添加
-    - 数据库日志：BAL 层使用 `createLogger('BAL')`，DL 层使用 `createLogger('DL').sub('DriverType')`
-    - HTTP 请求日志：使用 `logger.logHttpRequest/Response` 方法（保留旧 API 供中间件使用）
+    - DNS Provider 日志：由 `internal.ts` 中的 `createProviderAdapterLogger/createProviderAuthLogger/...` 创建，不在 provider 文件直接创建 DNS 主模块。
+    - 适配器方法调用日志：由 `DnsHelper.ts` 中的 `createLoggingAdapter` Proxy 自动拦截所有 `DnsAdapter` 方法调用并记录，无需各适配器手动添加。
+    - 数据库日志：BAL 层使用 `createLogger('BAL')`，DAL 层使用 `createLogger('DAL')`，DL 层使用 `createLogger('DL').sub('DriverType')`，DSM 层使用 `createLogger('DSM')`。
+    - HTTP 请求日志：使用 `createLogger('HTTP').sub(...)`。
 5. 错误日志规范
     - 日志必须包含上下文信息（模块名、子模块名、自定义标签）。
     - 错误日志必须包含详细错误信息（错误类型、错误消息、错误栈等），通过第二个参数 `data` 传入。
@@ -164,17 +165,18 @@
     - `DnsHelper.ts` 中的 `createLoggingAdapter` 使用 JavaScript Proxy 在 `createAdapter` 出口处统一包裹，自动拦截所有 `DnsAdapter` 接口方法的调用并记录日志。
     - 日志内容：方法调用（参数）→ 成功/失败（耗时）。
     - 适配器日志层与 Provider 内部日志独立并存：适配器层记录方法级摘要，Provider 内部日志记录具体 API 请求细节。
-    - 新增 DNS 提供商后，无需手动添加日志代码即可自动获得方法调用日志。
+    - 新增 DNS 提供商后，无需手动添加适配器方法调用日志代码即可自动获得方法调用日志。
 7. 模块名规范
     - 各层模块名固定：
       - `BAL` - 业务适配器层（`server/src/db/bal/`）
+      - `DAL` - 数据访问/连接抽象层（`server/src/db/dal/`）
       - `DSM` - 声明式模式管理层（`server/src/db/dsm/`）
       - `DL` - 数据库驱动层（`server/src/db/dl/`），子模块为具体驱动（MySQL/SQLite/PostgreSQL）
       - `MCP` - MCP 协议相关
-      - `DNS` - DNS 提供商适配器，子模块为提供商名称（Cloudflare/Aliyun 等）
-      - `HTTP` - HTTP 请求/响应日志
+      - `DNS` - DNS 提供商适配器、DNS Helper、DNS Resolver；Provider 文件通过 `internal.ts` 间接创建
+      - `HTTP` - HTTP 请求/响应、路由、中间件日志
       - `Server` - 服务器启动/关闭/生命周期
-    - 其他模块可根据用途自行命名，保持简短、清晰、大写。
+    - 其他模块可根据用途自行命名，保持简短、清晰。
 8. Whois 模块日志定义
     - 主模块名：`WhoisService`
     - 子模块（`.sub()`）：表示查询层级

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -81,7 +81,7 @@ function printBanner(port: number): void {
   const GRAY = '\x1b[90m';
   const RESET = '\x1b[0m';
   const BOLD = '\x1b[1m';
-  
+
   const banner = `
 ${CYAN}╔═══════════════════════════════════════════════════════════╗${RESET}
 ${CYAN}║${RESET}                                                       ${CYAN}║${RESET}
@@ -98,7 +98,8 @@ ${CYAN}╚═══════════════════════�
 import { initRenewalSchedulers } from './service/renewalInit';
 import { wsService } from './service/websocket';
 import { initWhoisSchedulers } from './service/whois';
-import { log } from './lib/logger';
+import { createLogger } from './lib/logger';
+const log = createLogger('Server').sub('App');
 import { OAuthOperations, McpOperations } from './db/bal/business-adapter';
 
 const app = express();
@@ -159,7 +160,7 @@ const corsOptions = {
     if (!origin) {
       return callback(null, true);
     }
-    
+
     // If CORS_ORIGIN is set, only allow those origins
     if (process.env.CORS_ORIGIN) {
       const allowedOrigins = process.env.CORS_ORIGIN.split(',').map(o => o.trim());
@@ -168,7 +169,7 @@ const corsOptions = {
       }
       return callback(new Error('Not allowed by CORS'));
     }
-    
+
     // Default: allow all origins (development mode)
     // This makes it work out of the box without configuration
     return callback(null, true);
@@ -199,14 +200,14 @@ const swaggerOptions: swaggerJsdoc.Options = {
 This API supports two authentication methods:
 
 ### 1. JWT Token (User Login)
-After logging in via \`/api/auth/login\`, you will receive a JWT token. 
+After logging in via \`/api/auth/login\`, you will receive a JWT token.
 Include it in the Authorization header:
 \`\`\`
 Authorization: Bearer <jwt_token>
 \`\`\`
 
 ### 2. API Token (Programmatic Access)
-API tokens can be created from the web UI (Settings > API Tokens) and are 
+API tokens can be created from the web UI (Settings > API Tokens) and are
 suitable for automated scripts and CI/CD pipelines.
 
 Include the API token in the Authorization header:
@@ -214,7 +215,7 @@ Include the API token in the Authorization header:
 Authorization: Bearer <api_token>
 \`\`\`
 
-API tokens have the same permissions as the user who created them and can be 
+API tokens have the same permissions as the user who created them and can be
 restricted to specific domains and time ranges.
 
 ### Token Permissions
@@ -434,26 +435,26 @@ async function gracefulShutdown(
 ): Promise<void> {
   if (initCheckInterval) clearInterval(initCheckInterval);
   if (oauthStateCleanupInterval) clearInterval(oauthStateCleanupInterval);
-  
-  log.info('Server', `${signal} received, starting graceful shutdown...`);
-  
+
+  log.info(`${signal} received, starting graceful shutdown...`);
+
   // Shutdown WebSocket service
   wsService.shutdown();
-  
+
   try {
     await disconnect();
-    log.info('Server', 'Database disconnected gracefully');
+    log.info('Database disconnected gracefully');
   } catch (err) {
-    log.error('Server', 'Error during database disconnect', { error: err });
+    log.error('Error during database disconnect', { error: err });
   }
-  
+
   if (server) {
     server.close(() => {
-      log.info('Server', 'Server closed');
+      log.info('Server closed');
       process.exit(0);
     });
   } else {
-    log.info('Server', 'No server instance to close');
+    log.info('No server instance to close');
     process.exit(0);
   }
 }
@@ -472,19 +473,19 @@ async function initializeApp() {
     isInitialized = await checkInitialization();
 
     if (isInitialized) {
-      log.info('Server', 'System initialized. Running in normal mode.');
-      
+      log.info('System initialized. Running in normal mode.');
+
       // 重启时清理所有未分配用户的临时 OAuth 客户端
       McpOperations.cleanupUnassignedOAuthClients().then((count: number) => {
-        if (count > 0) log.info('MCP OAuth', `Cleaned up ${count} unassigned temporary clients on startup`);
+        if (count > 0) log.info(`Cleaned up ${count} unassigned temporary clients on startup`);
       }).catch((err: unknown) => {
-        log.error('MCP OAuth', 'Failed to cleanup unassigned clients on startup', { error: err });
+        log.error('Failed to cleanup unassigned clients on startup', { error: err });
       });
 
       // 初始化续期和 WHOIS 调度器
       initRenewalSchedulers();
       initWhoisSchedulers();
-      
+
       startFailoverJob();
       startWhoisJob();
       startNsMonitorJob();
@@ -492,24 +493,24 @@ async function initializeApp() {
       startRecordCountCacheRefresh(30); // Refresh every 30 minutes
       startDomainSyncJob(0.5); // Sync every 30 minutes
     } else {
-      log.info('Server', 'System not initialized. Running in initialization mode.');
-      log.info('Server', 'Please access the setup wizard to configure the system.');
+      log.info('System not initialized. Running in initialization mode.');
+      log.info('Please access the setup wizard to configure the system.');
     }
 
     // Start server with WebSocket support
     server = http.createServer(app);
-    
+
     // Initialize WebSocket service
     wsService.initialize(server);
-    
+
     // 打印启动横幅
     printBanner(PORT);
-    
+
     server.listen(PORT, () => {
-      log.info('Server', `HiDNS running on http://localhost:${PORT}`);
-      log.info('Server', `API Docs: http://localhost:${PORT}/api/docs`);
+      log.info(`HiDNS running on http://localhost:${PORT}`);
+      log.info(`API Docs: http://localhost:${PORT}/api/docs`);
       if (!isInitialized) {
-        log.info('Server', `Setup Wizard: http://localhost:${PORT}/setup`);
+        log.info(`Setup Wizard: http://localhost:${PORT}/setup`);
       }
     });
 
@@ -519,8 +520,8 @@ async function initializeApp() {
         if (!isInitialized && newState) {
           // System just got initialized
           isInitialized = true;
-          log.info('Server', 'System initialized detected. Normal routes are now enabled.');
-          log.info('Server', 'You may need to refresh the page.');
+          log.info('System initialized detected. Normal routes are now enabled.');
+          log.info('You may need to refresh the page.');
           startFailoverJob();
           startWhoisJob();
           startNsMonitorJob();
@@ -535,10 +536,10 @@ async function initializeApp() {
       try {
         const deletedCount = await OAuthOperations.cleanupExpiredStates();
         if (deletedCount > 0) {
-          log.debug('OAuth', `Cleaned up ${deletedCount} expired states`);
+          log.debug(`Cleaned up ${deletedCount} expired states`);
         }
       } catch (err) {
-        log.error('OAuth', 'Failed to cleanup expired states', { error: err });
+        log.error('Failed to cleanup expired states', { error: err });
       }
     }, 10 * 60 * 1000);
 
@@ -550,21 +551,21 @@ async function initializeApp() {
     process.on('SIGINT', () => gracefulShutdown('SIGINT', initCheckInterval, oauthStateCleanupInterval));
 
   } catch (error) {
-    log.info('Server', 'Database not configured. Running in initialization mode.');
-    log.info('Server', 'Please access the setup wizard to configure the system.');
+    log.info('Database not configured. Running in initialization mode.');
+    log.info('Please access the setup wizard to configure the system.');
 
     server = http.createServer(app);
-    
+
     // Initialize WebSocket service
     wsService.initialize(server);
-    
+
     // 打印启动横幅
     printBanner(PORT);
-    
+
     server.listen(PORT, () => {
-      log.info('Server', `HiDNS running on http://localhost:${PORT}`);
-      log.info('Server', `API Docs: http://localhost:${PORT}/api/docs`);
-      log.info('Server', `Setup Wizard: http://localhost:${PORT}/setup`);
+      log.info(`HiDNS running on http://localhost:${PORT}`);
+      log.info(`API Docs: http://localhost:${PORT}/api/docs`);
+      log.info(`Setup Wizard: http://localhost:${PORT}/setup`);
     });
 
     // Re-check initialization status periodically
@@ -584,13 +585,13 @@ async function initializeApp() {
           startDomainRenewalJob();
           startRecordCountCacheRefresh(30); // Refresh every 30 minutes
           startDomainSyncJob(0.5); // Sync every 30 minutes
-          log.info('Server', 'System initialized detected. Normal routes are now enabled.');
-          log.info('Server', 'You may need to refresh the page.');
+          log.info('System initialized detected. Normal routes are now enabled.');
+          log.info('You may need to refresh the page.');
         }
       } catch (err) {
         retryCount++;
         if (retryCount >= MAX_RETRIES) {
-          log.error('Server', `Failed to initialize after ${MAX_RETRIES} attempts. Stopping retry.`);
+          log.error(`Failed to initialize after ${MAX_RETRIES} attempts. Stopping retry.`);
           clearInterval(initCheckInterval);
         }
         // Still not initialized

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -6,7 +6,6 @@
 
 import { connect, disconnect, getConnection } from './db/dal/connection';
 import { UserOperations, TOTPOperations } from './db/bal/business-adapter';
-import { log } from './lib/logger';
 import fs from 'fs';
 import path from 'path';
 

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -1,8 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 import dotenv from 'dotenv';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('Config').sub('Env');
 // Get the current working directory (where the server is running)
 function getCwd(): string {
   return process.cwd();
@@ -25,32 +26,32 @@ export function loadEnv(): void {
   const dataEnvPath = path.join(dataDir, '.env');
   const rootEnvPath = path.join(cwd, '.env');
 
-  log.info('Env', 'Current working directory', { cwd });
-  log.info('Env', 'Looking for data/.env', { path: dataEnvPath });
-  log.info('Env', 'Looking for root .env', { path: rootEnvPath });
+  log.info('Current working directory', { cwd });
+  log.info('Looking for data/.env', { path: dataEnvPath });
+  log.info('Looking for root .env', { path: rootEnvPath });
 
   // Load root .env first (lowest priority)
   if (fs.existsSync(rootEnvPath)) {
-    log.info('Env', 'Loading root .env');
+    log.info('Loading root .env');
     dotenv.config({ path: rootEnvPath });
   } else {
-    log.info('Env', 'Root .env not found');
+    log.info('Root .env not found');
   }
 
   // Load data/.env second (highest priority, overrides root .env)
   if (fs.existsSync(dataEnvPath)) {
-    log.info('Env', 'Loading data/.env');
+    log.info('Loading data/.env');
     const result = dotenv.config({ path: dataEnvPath, override: true });
     if (result.error) {
-      log.error('Env', 'Error loading data/.env', { error: result.error });
+      log.error('Error loading data/.env', { error: result.error });
     } else {
-      log.info('Env', 'data/.env loaded successfully');
+      log.info('data/.env loaded successfully');
     }
   } else {
-    log.info('Env', 'data/.env not found');
+    log.info('data/.env not found');
   }
 
-  log.info('Env', 'DB_TYPE after loading', { dbType: process.env.DB_TYPE || 'not set' });
+  log.info('DB_TYPE after loading', { dbType: process.env.DB_TYPE || 'not set' });
 }
 
 // Save configuration to ./data/.env (current working directory)
@@ -58,18 +59,18 @@ export function saveEnvConfig(config: Record<string, string>): void {
   const cwd = getCwd();
   const dataDir = path.join(cwd, 'data');
   const envPath = path.join(dataDir, '.env');
-  
+
   // Ensure data directory exists
   if (!fs.existsSync(dataDir)) {
     fs.mkdirSync(dataDir, { recursive: true });
   }
-  
+
   // Read existing content if file exists
   let existingContent = '';
   if (fs.existsSync(envPath)) {
     existingContent = fs.readFileSync(envPath, 'utf-8');
   }
-  
+
   // Parse existing config
   const existingConfig: Record<string, string> = {};
   existingContent.split('\n').forEach(line => {
@@ -78,20 +79,20 @@ export function saveEnvConfig(config: Record<string, string>): void {
       existingConfig[match[1].trim()] = match[2].trim();
     }
   });
-  
+
   // Merge with new config
   const mergedConfig = { ...existingConfig, ...config };
-  
+
   // Write back
   const content = Object.entries(mergedConfig)
     .map(([key, value]) => `${key}=${value}`)
     .join('\n');
-  
+
   fs.writeFileSync(envPath, content);
-  
+
   // Reload environment variables
   dotenv.config({ path: envPath, override: true });
-  
+
   // Also directly update process.env to ensure the changes take effect immediately
   Object.entries(config).forEach(([key, value]) => {
     process.env[key] = value;
@@ -126,7 +127,7 @@ export function validateEnv(): void {
 
   // 如果有错误，抛出异常
   if (errors.length > 0) {
-    log.error('Env', 'Environment Validation Failed', { errors });
+    log.error('Environment Validation Failed', { errors });
     throw new Error(`Environment validation failed: ${errors.join(', ')}`);
   }
 }
@@ -138,13 +139,13 @@ export function getDbConfig(): {
   mysql: { host: string; port: number; database: string; user: string; password: string; ssl: boolean };
   postgresql: { host: string; port: number; database: string; user: string; password: string; ssl: boolean };
 } {
-  log.info('Env', 'getDbConfig() called', { dbType: process.env.DB_TYPE || 'not set' });
+  log.info('getDbConfig() called', { dbType: process.env.DB_TYPE || 'not set' });
 
   // 在获取配置前验证环境变量
   validateEnv();
 
   const dbType = (process.env.DB_TYPE as 'sqlite' | 'mysql' | 'postgresql') || 'sqlite';
-  log.info('Env', 'Using database type', { dbType });
+  log.info('Using database type', { dbType });
 
   return {
     type: dbType,

--- a/server/src/db/bal/business-adapter.ts
+++ b/server/src/db/bal/business-adapter.ts
@@ -1,9 +1,9 @@
 /**
  * 数据库业务适配器层 (Database Business Adapter Layer)
- * 
+ *
  * 架构层级：
  * 路由 → 业务适配器（本文件）→ 数据库抽象层 → 数据库驱动层 → 数据库
- * 
+ *
  * 设计原则：
  * 1. 函数式API - 路由层通过简单函数调用使用数据库
  * 2. 单一职责 - 每个函数只处理一个业务操作
@@ -16,15 +16,15 @@ import crypto from 'crypto';
 import type { SQLCompiler } from '../dal/query/compiler';
 import { getDefaultCompiler } from '../dal/query/compiler';
 import { transaction, getConnection } from '../dal/connection';
-import { log, createLogger } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 import { DomainQueryBuilder, RenewableDomainQueryBuilder, AccountQueryBuilder, TeamQueryBuilder } from './query-builders';
 
-const balLog = createLogger('BAL');
+const log = createLogger('BAL').sub('BusinessAdapter');
 
 // 本地 db 对象，避免循环依赖
 const db = {
   get type() { return process.env.DB_TYPE || 'sqlite'; },
-  get isConnected() { 
+  get isConnected() {
     try {
       const conn = getConnection();
       return !!conn;
@@ -89,10 +89,10 @@ function buildUpsertSql(
   updateColumns: string[]
 ): { sql: string; params: unknown[] } {
   const dbType = getDbType();
-  
-  // 添加 updated_at 
+
+  // 添加 updated_at
   const allColumns = [...columns, 'updated_at'];
-  
+
   if (dbType === 'mysql') {
     // MySQL: INSERT ... ON DUPLICATE KEY UPDATE
     // updated_at 不在 INSERT 的列中，只在 UPDATE 部分使用 NOW()
@@ -102,7 +102,7 @@ function buildUpsertSql(
       const escaped = col === 'key' || col === 'value' ? `\`${col}\`` : col;
       return `${escaped} = VALUES(${escaped})`;
     }).join(', ');
-    
+
     const sql = `INSERT INTO ${table} (${insertColumns}) VALUES (${placeholders}) ON DUPLICATE KEY UPDATE ${updates}, updated_at = NOW()`;
     return { sql, params: values };
   } else if (dbType === 'postgresql') {
@@ -113,7 +113,7 @@ function buildUpsertSql(
     const updates = updateColumns.map(col => {
       return `${col} = EXCLUDED.${col}`;
     }).join(', ');
-    
+
     const sql = `INSERT INTO ${table} (${insertColumns}) VALUES (${placeholders}) ON CONFLICT(${conflictKey}) DO UPDATE SET ${updates}, updated_at = NOW()`;
     return { sql, params: values };
   } else {
@@ -124,7 +124,7 @@ function buildUpsertSql(
     const updates = updateColumns.map(col => {
       return `${col} = excluded.${col}`;
     }).join(', ');
-    
+
     const sql = `INSERT INTO ${table} (${insertColumns}) VALUES (${placeholders}) ON CONFLICT(${conflictKey}) DO UPDATE SET ${updates}, updated_at = CURRENT_TIMESTAMP`;
     return { sql, params: values };
   }
@@ -137,11 +137,11 @@ function buildUpsertSql(
 /** 创建操作日志上下*/
 function createOperationLogger(context: OperationContext) {
   return {
-    start: () => balLog.debug( `Starting ${context.operation}`, { table: context.table, userId: context.userId }),
-    success: (duration: number, meta?: Record<string, unknown>) => 
-      balLog.debug( `${context.operation} completed`, { ...meta, duration: `${duration}ms`, table: context.table }),
-    error: (error: unknown, duration: number) => 
-      balLog.error( `${context.operation} failed`, { error, duration: `${duration}ms`, table: context.table }),
+    start: () => log.debug( `Starting ${context.operation}`, { table: context.table, userId: context.userId }),
+    success: (duration: number, meta?: Record<string, unknown>) =>
+      log.debug( `${context.operation} completed`, { ...meta, duration: `${duration}ms`, table: context.table }),
+    error: (error: unknown, duration: number) =>
+      log.error( `${context.operation} failed`, { error, duration: `${duration}ms`, table: context.table }),
   };
 }
 
@@ -180,29 +180,29 @@ function processSql(sql: string, dbType: string): string {
         const upperSql = sql.toUpperCase();
         const beforeContext = sql.substring(Math.max(0, offset - 20), offset).toUpperCase();
         const afterContext = sql.substring(offset + match.length, Math.min(sql.length, offset + match.length + 20)).toUpperCase();
-        
+
         // 跳过 ON DUPLICATE KEY UPDATE 中的 KEY
         if (beforeContext.includes('ON DUPLICATE') && keyword.toLowerCase() === 'key') {
           return match;
         }
-        
+
         // 跳过 ORDER BY / GROUP BY 中的 BY
         if (beforeContext.includes('ORDER') || beforeContext.includes('GROUP')) {
           return match;
         }
-        
+
         // 跳过 FOREIGN KEY / PRIMARY KEY 中的 KEY
         if (beforeContext.includes('FOREIGN') || beforeContext.includes('PRIMARY')) {
           return match;
         }
-        
+
         return `\`${keyword}\``;
       });
     });
   }
 
   if (sql !== originalSql) {
-    balLog.debug( 'SQL processed', { original: originalSql, processed: sql });
+    log.debug( 'SQL processed', { original: originalSql, processed: sql });
   }
 
   return sql;
@@ -212,14 +212,14 @@ function processSql(sql: string, dbType: string): string {
 async function queryInternal<T = QueryResult>(sql: string, params?: unknown[], context?: OperationContext): Promise<T[]> {
   const startTime = Date.now();
   const processedSql = processSql(sql, db.type);
-  
-  balLog.debug( 'Executing query', { sql: processedSql, params, operation: context?.operation });
-  
+
+  log.debug( 'Executing query', { sql: processedSql, params, operation: context?.operation });
+
   try {
     const results = await db.query<T>(processedSql, params);
     const duration = Date.now() - startTime;
-    balLog.debug( `Query executed`, { 
-      sql: processedSql.substring(0, 100), 
+    log.debug( `Query executed`, {
+      sql: processedSql.substring(0, 100),
       rowCount: results.length,
       duration: `${duration}ms`,
       operation: context?.operation
@@ -227,9 +227,9 @@ async function queryInternal<T = QueryResult>(sql: string, params?: unknown[], c
     return results;
   } catch (error) {
     const duration = Date.now() - startTime;
-    balLog.error( 'Query failed', { 
-      sql: processedSql, 
-      params, 
+    log.error( 'Query failed', {
+      sql: processedSql,
+      params,
       error,
       duration: `${duration}ms`,
       operation: context?.operation
@@ -242,14 +242,14 @@ async function queryInternal<T = QueryResult>(sql: string, params?: unknown[], c
 async function getInternal<T = QueryResult>(sql: string, params?: unknown[], context?: OperationContext): Promise<T | undefined> {
   const startTime = Date.now();
   const processedSql = processSql(sql, db.type);
-  
-  balLog.debug( 'Executing get', { sql: processedSql, params, operation: context?.operation });
-  
+
+  log.debug( 'Executing get', { sql: processedSql, params, operation: context?.operation });
+
   try {
     const result = await db.get<T>(processedSql, params);
     const duration = Date.now() - startTime;
-    balLog.debug( `Get executed`, { 
-      sql: processedSql.substring(0, 100), 
+    log.debug( `Get executed`, {
+      sql: processedSql.substring(0, 100),
       found: result !== undefined,
       duration: `${duration}ms`,
       operation: context?.operation
@@ -257,9 +257,9 @@ async function getInternal<T = QueryResult>(sql: string, params?: unknown[], con
     return result;
   } catch (error) {
     const duration = Date.now() - startTime;
-    balLog.error( 'Get failed', { 
-      sql: processedSql, 
-      params, 
+    log.error( 'Get failed', {
+      sql: processedSql,
+      params,
       error,
       duration: `${duration}ms`,
       operation: context?.operation
@@ -272,21 +272,21 @@ async function getInternal<T = QueryResult>(sql: string, params?: unknown[], con
 async function executeInternal(sql: string, params?: unknown[], context?: OperationContext): Promise<void> {
   const startTime = Date.now();
   const processedSql = processSql(sql, db.type);
-  
-  balLog.debug( 'Executing command', { sql: processedSql, params, operation: context?.operation });
-  
+
+  log.debug( 'Executing command', { sql: processedSql, params, operation: context?.operation });
+
   try {
     await db.execute(processedSql, params);
     const duration = Date.now() - startTime;
-    balLog.debug( `Command executed`, { 
+    log.debug( `Command executed`, {
       operation: context?.operation,
       duration: `${duration}ms`
     });
   } catch (error) {
     const duration = Date.now() - startTime;
-    balLog.error( 'Command failed', { 
-      sql: processedSql, 
-      params, 
+    log.error( 'Command failed', {
+      sql: processedSql,
+      params,
       error,
       duration: `${duration}ms`,
       operation: context?.operation
@@ -299,13 +299,13 @@ async function executeInternal(sql: string, params?: unknown[], context?: Operat
 async function insertInternal(sql: string, params?: unknown[], context?: OperationContext): Promise<number> {
   const startTime = Date.now();
   const processedSql = processSql(sql, db.type);
-  
-  balLog.debug( 'Executing insert', { sql: processedSql, params, operation: context?.operation });
-  
+
+  log.debug( 'Executing insert', { sql: processedSql, params, operation: context?.operation });
+
   try {
     const id = await db.insert(processedSql, params);
     const duration = Date.now() - startTime;
-    balLog.debug( `Insert executed`, { 
+    log.debug( `Insert executed`, {
       operation: context?.operation,
       insertId: id,
       duration: `${duration}ms`
@@ -313,9 +313,9 @@ async function insertInternal(sql: string, params?: unknown[], context?: Operati
     return id;
   } catch (error) {
     const duration = Date.now() - startTime;
-    balLog.error( 'Insert failed', { 
-      sql: processedSql, 
-      params, 
+    log.error( 'Insert failed', {
+      sql: processedSql,
+      params,
       error,
       duration: `${duration}ms`,
       operation: context?.operation
@@ -328,13 +328,13 @@ async function insertInternal(sql: string, params?: unknown[], context?: Operati
 async function runInternal(sql: string, params?: unknown[], context?: OperationContext): Promise<{ changes: number }> {
   const startTime = Date.now();
   const processedSql = processSql(sql, db.type);
-  
-  balLog.debug( 'Executing run', { sql: processedSql, params, operation: context?.operation });
-  
+
+  log.debug( 'Executing run', { sql: processedSql, params, operation: context?.operation });
+
   try {
     const result = await db.run(processedSql, params);
     const duration = Date.now() - startTime;
-    balLog.debug( `Run executed`, { 
+    log.debug( `Run executed`, {
       operation: context?.operation,
       changes: result.changes,
       duration: `${duration}ms`
@@ -342,9 +342,9 @@ async function runInternal(sql: string, params?: unknown[], context?: OperationC
     return result;
   } catch (error) {
     const duration = Date.now() - startTime;
-    balLog.error( 'Run failed', { 
-      sql: processedSql, 
-      params, 
+    log.error( 'Run failed', {
+      sql: processedSql,
+      params,
       error,
       duration: `${duration}ms`,
       operation: context?.operation
@@ -484,10 +484,10 @@ export const UserOperations = {
   async update(id: number, updates: Record<string, unknown>): Promise<void> {
     const fields = Object.keys(updates);
     if (fields.length === 0) return;
-    
+
     const setClause = fields.map(f => `${f} = ?`).join(', ');
     const values = Object.values(updates);
-    
+
     return executeInternal(
       `UPDATE users SET ${setClause} WHERE id = ?`,
       [...values, id],
@@ -566,10 +566,10 @@ export const DnsAccountOperations = {
   async update(id: number, updates: Record<string, unknown>): Promise<void> {
     const fields = Object.keys(updates);
     if (fields.length === 0) return;
-    
+
     const setClause = fields.map(f => `${f} = ?`).join(', ');
     const values = Object.values(updates);
-    
+
     return executeInternal(
       `UPDATE dns_accounts SET ${setClause} WHERE id = ?`,
       [...values, id],
@@ -674,7 +674,7 @@ export const DomainOperations = {
 
     const builder = DomainQueryBuilder.forTokenAuth(ids, options);
     const { sql, params } = builder.build();
-    
+
     return queryInternal(sql, params, { operation: 'Domain.getByIds', table: 'domains' });
   },
 
@@ -682,7 +682,7 @@ export const DomainOperations = {
   async getAllForSuperAdmin(options?: { accountId?: number; keyword?: string }): Promise<QueryResult[]> {
     const builder = DomainQueryBuilder.forSuperAdmin(options);
     const { sql, params } = builder.build();
-    
+
     return queryInternal(sql, params, { operation: 'Domain.getAllForSuperAdmin', table: 'domains' });
   },
 
@@ -708,7 +708,7 @@ export const DomainOperations = {
 
     // 构建查询
     let builder = DomainQueryBuilder.forSuperAdmin({ accountId, keyword });
-    
+
     // 添加 enabled 过滤
     if (domainStatus === 'enabled') {
       builder = builder.whereDomainEnabled(true);
@@ -716,14 +716,14 @@ export const DomainOperations = {
       builder = builder.whereDomainEnabled(false);
     }
     // domainStatus === 'all' 时不过滤
-    
+
     // 添加 domain_type 过滤
     if (domainType) {
       builder = builder.whereDomainType(domainType);
     }
-    
+
     const { sql: baseSql, params: baseParams } = builder.build();
-    
+
     // 如果有置顶域名，添加置顶排序
     let orderByClause = '';
     if (pinnedDomainIds.length > 0) {
@@ -744,25 +744,25 @@ export const DomainOperations = {
     } else {
       orderByClause = 'd.id ASC';
     }
-    
+
     // 查询总数
     const countSql = `SELECT COUNT(*) as count FROM (${baseSql}) as subquery`;
-    const countResult = await queryInternal(countSql, baseParams, { 
-      operation: 'Domain.getAllForSuperAdminWithPagination.count', 
-      table: 'domains' 
+    const countResult = await queryInternal(countSql, baseParams, {
+      operation: 'Domain.getAllForSuperAdminWithPagination.count',
+      table: 'domains'
     });
     const total = Number((countResult[0] as any)?.count || 0);
-    
+
     // 查询分页数据
     const offset = (page - 1) * pageSize;
-    
+
     // 移除原有ORDER BY，添加置顶排
     const baseSqlWithoutOrderBy = baseSql.replace(/\s+ORDER\s+BY\s+[^)]+$/i, '');
-    
+
     // MySQL 不支持在 prepared statement 中对 LIMIT/OFFSET 使用参数化占位符
     // 需要直接将整数值拼接到 SQL 中（已验证为整数，安全）
     const paginatedSql = `${baseSqlWithoutOrderBy} ORDER BY ${orderByClause} LIMIT ${parseInt(String(pageSize), 10)} OFFSET ${parseInt(String(offset), 10)}`;
-    
+
     // Debug log
     console.log('[BusinessAdapter] getAllForSuperAdminWithPagination SQL:', {
       page,
@@ -771,12 +771,12 @@ export const DomainOperations = {
       orderByClause,
       sql: paginatedSql.substring(0, 300)
     });
-    
-    const list = await queryInternal(paginatedSql, baseParams, { 
-      operation: 'Domain.getAllForSuperAdminWithPagination.list', 
-      table: 'domains' 
+
+    const list = await queryInternal(paginatedSql, baseParams, {
+      operation: 'Domain.getAllForSuperAdminWithPagination.list',
+      table: 'domains'
     });
-    
+
     return { list, total };
   },
 
@@ -793,10 +793,10 @@ export const DomainOperations = {
   async update(id: number, updates: Record<string, unknown>): Promise<void> {
     const fields = Object.keys(updates);
     if (fields.length === 0) return;
-    
+
     const setClause = fields.map(f => `${f} = ?`).join(', ');
     const values = Object.values(updates);
-    
+
     return executeInternal(
       `UPDATE domains SET ${setClause} WHERE id = ?`,
       [...values, id],
@@ -875,9 +875,9 @@ export const DomainOperations = {
     isSuper?: boolean;
   }): Promise<QueryResult[]> {
     const { userId, teamIds, accountId, keyword, isSuper } = params;
-    
+
     let builder: DomainQueryBuilder;
-    
+
     if (isSuper) {
       // Super admin: use simplified query
       builder = DomainQueryBuilder.accessibleForSuperAdmin({ accountId, keyword });
@@ -885,14 +885,14 @@ export const DomainOperations = {
       // Regular user: full permission check with teams
       builder = DomainQueryBuilder.accessibleForUser(userId, teamIds, { accountId, keyword });
     }
-    
+
     const { sql, params: queryParams } = builder.build();
-    
-    return queryInternal(sql, queryParams, { 
-      operation: isSuper 
-        ? 'Domain.getAccessibleDomains.super' 
-        : 'Domain.getAccessibleDomains', 
-      table: 'domains' 
+
+    return queryInternal(sql, queryParams, {
+      operation: isSuper
+        ? 'Domain.getAccessibleDomains.super'
+        : 'Domain.getAccessibleDomains',
+      table: 'domains'
     });
   },
 
@@ -922,7 +922,7 @@ export const DomainOperations = {
 
     // 构建查询
     let builder = DomainQueryBuilder.accessibleForUser(userId, teamIds, { accountId, keyword });
-    
+
     // 添加 enabled 过滤
     if (domainStatus === 'enabled') {
       builder = builder.whereDomainEnabled(true);
@@ -930,14 +930,14 @@ export const DomainOperations = {
       builder = builder.whereDomainEnabled(false);
     }
     // domainStatus === 'all' 时不过滤
-    
+
     // 添加 domain_type 过滤
     if (domainType) {
       builder = builder.whereDomainType(domainType);
     }
-    
+
     const { sql: baseSql, params: baseParams } = builder.build();
-    
+
     // 如果有置顶域名，添加置顶排序
     let orderByClause = '';
     if (pinnedDomainIds.length > 0) {
@@ -958,27 +958,27 @@ export const DomainOperations = {
     } else {
       orderByClause = 'd.id ASC';
     }
-    
+
     // 查询总数
     const countSql = `SELECT COUNT(*) as count FROM (${baseSql}) as subquery`;
-    const countResult = await queryInternal(countSql, baseParams, { 
-      operation: 'Domain.getAccessibleDomainsWithPagination.count', 
-      table: 'domains' 
+    const countResult = await queryInternal(countSql, baseParams, {
+      operation: 'Domain.getAccessibleDomainsWithPagination.count',
+      table: 'domains'
     });
     const total = Number((countResult[0] as any)?.count || 0);
-    
+
     // 查询分页数据
     const offset = (page - 1) * pageSize;
-    
+
     // MySQL 不支持在 prepared statement 中对 LIMIT/OFFSET 使用参数化占位符
     // 需要直接将整数值拼接到 SQL 中（已验证为整数，安全）
     const paginatedSql = `${baseSql.replace(/ORDER BY [^)]+$/, '')} ORDER BY ${orderByClause} LIMIT ${parseInt(String(pageSize), 10)} OFFSET ${parseInt(String(offset), 10)}`;
-    
-    const list = await queryInternal(paginatedSql, baseParams, { 
-      operation: 'Domain.getAccessibleDomainsWithPagination.list', 
-      table: 'domains' 
+
+    const list = await queryInternal(paginatedSql, baseParams, {
+      operation: 'Domain.getAccessibleDomainsWithPagination.list',
+      table: 'domains'
     });
-    
+
     return { list, total };
   },
 
@@ -986,12 +986,12 @@ export const DomainOperations = {
   async checkUserDomainAccess(domainId: number, userId: number): Promise<boolean> {
     const builder = DomainQueryBuilder.checkUserAccess(domainId, userId);
     const { sql, params } = builder.build();
-    
-    const result = await getInternal<{ id: number }>(sql, params, { 
-      operation: 'Domain.checkUserDomainAccess', 
-      table: 'domains' 
+
+    const result = await getInternal<{ id: number }>(sql, params, {
+      operation: 'Domain.checkUserDomainAccess',
+      table: 'domains'
     });
-    
+
     return !!result;
   },
 
@@ -1023,7 +1023,7 @@ export const DomainOperations = {
   /** 获取 NS 监控可用的域名列表（Level 1 - ALL，不过滤 enabled 状态） */
   async getAvailableDomainsForNSMonitor(userId: number, isSuperAdmin: boolean): Promise<QueryResult[]> {
     let builder: DomainQueryBuilder;
-    
+
     if (isSuperAdmin) {
       // Super admin: reuse getAll() pattern but select specific columns
       builder = DomainQueryBuilder.all().select('d.id, d.name, d.account_id').orderByColumn('d.name');
@@ -1033,13 +1033,13 @@ export const DomainOperations = {
         .select('d.id, d.name, d.account_id')
         .orderByColumn('d.name');
     }
-    
+
     const { sql, params } = builder.build();
-    return queryInternal(sql, params, { 
-      operation: isSuperAdmin 
-        ? 'Domain.getAvailableDomainsForNSMonitor.super' 
-        : 'Domain.getAvailableDomainsForNSMonitor.user', 
-      table: 'domains' 
+    return queryInternal(sql, params, {
+      operation: isSuperAdmin
+        ? 'Domain.getAvailableDomainsForNSMonitor.super'
+        : 'Domain.getAvailableDomainsForNSMonitor.user',
+      table: 'domains'
     });
   },
 };
@@ -1083,10 +1083,10 @@ export const TeamOperations = {
   async update(id: number, updates: Record<string, unknown>): Promise<void> {
     const fields = Object.keys(updates);
     if (fields.length === 0) return;
-    
+
     const setClause = fields.map(f => `${f} = ?`).join(', ');
     const values = Object.values(updates);
-    
+
     return executeInternal(
       `UPDATE teams SET ${setClause} WHERE id = ?`,
       [...values, id],
@@ -1191,7 +1191,7 @@ export const SettingsOperations = {
       'key',
       ['value']
     );
-    
+
     return executeInternal(sql, params, { operation: 'Settings.set', table: 'system_settings' });
   },
 
@@ -1230,19 +1230,19 @@ export const AuditOperations = {
   async getLogs(options: { userId?: number; action?: string; limit?: number; offset?: number } = {}): Promise<QueryResult[]> {
     let sql = 'SELECT * FROM operation_logs WHERE 1=1';
     const params: unknown[] = [];
-    
+
     if (options.userId) {
       sql += ' AND user_id = ?';
       params.push(options.userId);
     }
-    
+
     if (options.action) {
       sql += ' AND action = ?';
       params.push(options.action);
     }
-    
+
     sql += ' ORDER BY created_at DESC';
-    
+
     // MySQL LIMIT/OFFSET 需要直接嵌入数
     const dbType = getDbType();
     if (options.limit) {
@@ -1253,7 +1253,7 @@ export const AuditOperations = {
         params.push(Number(options.limit));
       }
     }
-    
+
     if (options.offset) {
       if (dbType === 'mysql') {
         sql += ` OFFSET ${Number(options.offset)}`;
@@ -1262,7 +1262,7 @@ export const AuditOperations = {
         params.push(Number(options.offset));
       }
     }
-    
+
     return queryInternal(sql, params, { operation: 'Audit.getLogs', table: 'audit_logs' });
   },
 };
@@ -1455,7 +1455,7 @@ export const OAuthOperations = {
   async createState(state: string, mode: 'login' | 'bind', provider: string, userId: number | null, expiresAt: Date): Promise<void> {
     // 使用数据库兼容的日期格式
     const expiresStr = this.formatDateForDB(expiresAt);
-    log.debug('OAuth', 'Creating state', {
+    log.debug('Creating state', {
       state: state.substring(0, 16) + '...',
       mode,
       provider,
@@ -1477,7 +1477,7 @@ export const OAuthOperations = {
       { operation: 'OAuth.getState', table: 'oauth_states' }
     );
 
-    log.debug('OAuth', 'Getting state', {
+    log.debug('Getting state', {
       state: state.substring(0, 16) + '...',
       found: !!result,
       result
@@ -1917,9 +1917,9 @@ export const EmailTemplateOperations = {
 
 /** 在事务中执行函数 */
 export async function withTransaction<T>(fn: (trx: TransactionOperations) => Promise<T>): Promise<T> {
-  balLog.info( 'Starting transaction block');
+  log.info( 'Starting transaction block');
   const startTime = Date.now();
-  
+
   try {
     const result = await transaction(async (trx: {
       query: <U>(sql: string, params?: unknown[]) => Promise<U[]>;
@@ -1931,13 +1931,13 @@ export async function withTransaction<T>(fn: (trx: TransactionOperations) => Pro
       const trxOps = new TransactionOperations(trx);
       return fn(trxOps);
     });
-    
+
     const duration = Date.now() - startTime;
-    balLog.info( `Transaction block completed`, { duration: `${duration}ms` });
+    log.info( `Transaction block completed`, { duration: `${duration}ms` });
     return result;
   } catch (error) {
     const duration = Date.now() - startTime;
-    balLog.error( 'Transaction block failed', { error, duration: `${duration}ms` });
+    log.error( 'Transaction block failed', { error, duration: `${duration}ms` });
     throw error;
   }
 }
@@ -1958,31 +1958,31 @@ export class TransactionOperations {
 
   async query<T = QueryResult>(sql: string, params?: unknown[]): Promise<T[]> {
     const processedSql = processSql(sql, db.type);
-    balLog.debug( '[Transaction] Executing query', { sql: processedSql });
+    log.debug( '[Transaction] Executing query', { sql: processedSql });
     return this.trx.query<T>(processedSql, params);
   }
 
   async get<T = QueryResult>(sql: string, params?: unknown[]): Promise<T | undefined> {
     const processedSql = processSql(sql, db.type);
-    balLog.debug( '[Transaction] Executing get', { sql: processedSql });
+    log.debug( '[Transaction] Executing get', { sql: processedSql });
     return this.trx.get<T>(processedSql, params);
   }
 
   async execute(sql: string, params?: unknown[]): Promise<void> {
     const processedSql = processSql(sql, db.type);
-    balLog.debug( '[Transaction] Executing execute', { sql: processedSql });
+    log.debug( '[Transaction] Executing execute', { sql: processedSql });
     return this.trx.execute(processedSql, params);
   }
 
   async insert(sql: string, params?: unknown[]): Promise<number> {
     const processedSql = processSql(sql, db.type);
-    balLog.debug( '[Transaction] Executing insert', { sql: processedSql });
+    log.debug( '[Transaction] Executing insert', { sql: processedSql });
     return this.trx.insert(processedSql, params);
   }
 
   async run(sql: string, params?: unknown[]): Promise<{ changes: number }> {
     const processedSql = processSql(sql, db.type);
-    balLog.debug( '[Transaction] Executing run', { sql: processedSql });
+    log.debug( '[Transaction] Executing run', { sql: processedSql });
     return this.trx.run(processedSql, params);
   }
 }
@@ -2025,7 +2025,7 @@ export const SystemOperations = {
     return dbInfo;
   },
 
-  /** 
+  /**
    * 测试 SQLite 数据库连接并检查是否有现有数据
    * 注意：此方法使用直接连接进行初始化测试，不是标准业务查询
    */
@@ -2043,7 +2043,7 @@ export const SystemOperations = {
       try {
         fs.mkdirSync(dir, { recursive: true });
       } catch (err) {
-        log.warn('SystemOperations', 'Failed to create directory, may already exist', { dir, error: err });
+        log.warn('Failed to create directory, may already exist', { dir, error: err });
       }
     }
 
@@ -2051,10 +2051,10 @@ export const SystemOperations = {
     try {
       testDb = new Database(normalizedPath);
     } catch (err) {
-      log.error('SystemOperations', 'Failed to open SQLite database', { path: normalizedPath, error: err });
+      log.error('Failed to open SQLite database', { path: normalizedPath, error: err });
       throw err;
     }
-    
+
     // Check if tables exist
     let hasData = false;
     let hasUsers = false;
@@ -2072,18 +2072,18 @@ export const SystemOperations = {
     } catch {
       // No tables yet
     }
-    
+
     testDb.close();
     return { success: true, message: 'SQLite connection successful', hasExistingData: hasData, hasUsers };
   },
 
-  /** 
+  /**
    * 测试 MySQL 数据库连接并检查是否有现有数据
    * 注意：此方法使用直接连接进行初始化测试，不是标准业务查询
    */
   async testMysqlConnection(config: { host: string; port: number; user: string; password: string; database: string; ssl?: boolean }): Promise<{ success: boolean; message: string; hasExistingData: boolean; hasUsers?: boolean }> {
     const mysql = require('mysql2/promise');
-    
+
     const pool = mysql.createPool({
       host: config.host,
       port: config.port || 3306,
@@ -2115,18 +2115,18 @@ export const SystemOperations = {
     } catch {
       // No tables yet
     }
-    
+
     await pool.end();
     return { success: true, message: 'MySQL connection successful', hasExistingData: hasData, hasUsers };
   },
 
-  /** 
+  /**
    * 测试 PostgreSQL 数据库连接并检查是否有现有数据
    * 注意：此方法使用直接连接进行初始化测试，不是标准业务查询
    */
   async testPostgresqlConnection(config: { host: string; port: number; user: string; password: string; database: string; ssl?: boolean }): Promise<{ success: boolean; message: string; hasExistingData: boolean; hasUsers?: boolean }> {
     const { Pool } = require('pg');
-    
+
     const pool = new Pool({
       host: config.host,
       port: config.port || 5432,
@@ -2146,7 +2146,7 @@ export const SystemOperations = {
     let hasUsers = false;
     try {
       const tablesResult = await pool.query(`
-        SELECT table_name FROM information_schema.tables 
+        SELECT table_name FROM information_schema.tables
         WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
       `);
       const tables = tablesResult.rows as { table_name: string }[];
@@ -2162,7 +2162,7 @@ export const SystemOperations = {
     } catch {
       // No tables yet
     }
-    
+
     await pool.end();
     return { success: true, message: 'PostgreSQL connection successful', hasExistingData: hasData, hasUsers };
   },
@@ -2171,11 +2171,11 @@ export const SystemOperations = {
    * 统一测试数据库连接（根据类型自动选择
    * 注意：此方法使用直接连接进行初始化测试，不是标准业务查询
    */
-  async testConnection(config: { 
-    type: 'sqlite' | 'mysql' | 'postgresql'; 
-    sqlite?: { path: string }; 
-    mysql?: { host: string; port: number; user: string; password: string; database: string; ssl?: boolean }; 
-    postgresql?: { host: string; port: number; user: string; password: string; database: string; ssl?: boolean } 
+  async testConnection(config: {
+    type: 'sqlite' | 'mysql' | 'postgresql';
+    sqlite?: { path: string };
+    mysql?: { host: string; port: number; user: string; password: string; database: string; ssl?: boolean };
+    postgresql?: { host: string; port: number; user: string; password: string; database: string; ssl?: boolean }
   }): Promise<{ success: boolean; message: string; hasExistingData: boolean; hasUsers?: boolean }> {
     if (config.type === 'sqlite') {
       return this.testSqliteConnection(config.sqlite?.path || './data/dnsmgr.db');
@@ -2298,9 +2298,9 @@ export const SecretOperations = {
         );
       }
 
-      log.info('Secret', 'Runtime secrets rotated');
+      log.info('Runtime secrets rotated');
     } catch (error) {
-      log.error('Secret', 'Error rotating runtime secrets', { error });
+      log.error('Error rotating runtime secrets', { error });
       throw error;
     }
   },
@@ -2376,11 +2376,11 @@ export const SecurityPolicyOperations = {
     const dbType = process.env.DB_TYPE || 'sqlite';
     const enabledValue = dbType === 'postgresql' ? '$4' : '?';
     const enabledParam = dbType === 'postgresql' ? [userId, 'totp', 'webauthn', 1] : [userId, 'totp', 'webauthn', 1];
-    
+
     const sql = dbType === 'postgresql'
       ? 'SELECT COUNT(*) as count FROM user_2fa WHERE user_id = $1 AND type IN ($2, $3) AND enabled = $4'
       : 'SELECT COUNT(*) as count FROM user_2fa WHERE user_id = ? AND type IN (?, ?) AND enabled = ?';
-    
+
     const result = await getInternal<{ count: number }>(
       sql,
       enabledParam,
@@ -2578,7 +2578,7 @@ export const UserPreferencesOperations = {
       return [];
     } catch (error) {
       // 表或字段不存在时返回空数
-      log.warn('UserPreferences', 'Failed to get pinned domains, returning empty array', { userId, error });
+      log.warn('Failed to get pinned domains, returning empty array', { userId, error });
       return [];
     }
   },
@@ -2586,7 +2586,7 @@ export const UserPreferencesOperations = {
   /** 更新用户置顶的域名列*/
   async updatePinnedDomains(userId: number, domainIds: number[]): Promise<void> {
     const pinnedDomainsJson = JSON.stringify(domainIds);
-    
+
     // SQLite
     if (process.env.DB_TYPE === 'sqlite' || !process.env.DB_TYPE) {
       await executeInternal(
@@ -2950,12 +2950,12 @@ export const AuditExportOperations = {
     const dbType = getDbType();
     // Use CASE WHEN to display 'Root' for user_id = 0
     const listSql = dbType === 'postgresql'
-      ? `SELECT l.*, 
+      ? `SELECT l.*,
           CASE WHEN l.user_id = 0 THEN 'Root' ELSE u.username END as username,
           CASE WHEN l.user_id = 0 THEN '后端' ELSE u.nickname END as nickname
          FROM operation_logs l
          LEFT JOIN users u ON u.id = l.user_id WHERE ${where} ORDER BY l.id DESC LIMIT $${params.length + 1} OFFSET $${params.length + 2}`
-      : `SELECT l.*, 
+      : `SELECT l.*,
           CASE WHEN l.user_id = 0 THEN 'Root' ELSE u.username END as username,
           CASE WHEN l.user_id = 0 THEN '后端' ELSE u.nickname END as nickname
          FROM operation_logs l
@@ -3309,7 +3309,7 @@ export const WhoisOperations = {
   /** 确保 whois_cache 表存*/
   async ensureWhoisCacheTable(): Promise<void> {
     const dbType = db.type;
-    
+
     try {
       if (dbType === 'sqlite') {
         await executeInternal(`
@@ -3348,7 +3348,7 @@ export const WhoisOperations = {
     } catch (error) {
       const errorMsg = (error as Error).message || '';
       if (!errorMsg.includes('already exists') && !errorMsg.includes('ER_TABLE_EXISTS_ERROR')) {
-        balLog.warn( 'Failed to create whois_cache table', { error: errorMsg, dbType });
+        log.warn( 'Failed to create whois_cache table', { error: errorMsg, dbType });
       }
     }
   },
@@ -3356,24 +3356,24 @@ export const WhoisOperations = {
   /** 从数据库获取缓存WHOIS 结果 */
   async getCachedWhois(domain: string, cacheTtlSeconds: number): Promise<QueryResult | undefined> {
     const dbType = getDbType();
-    
+
     if (dbType === 'postgresql') {
       return await getInternal(
-        `SELECT whois_data, status, cached_at, expires_at FROM whois_cache WHERE domain_name = $1 AND 
+        `SELECT whois_data, status, cached_at, expires_at FROM whois_cache WHERE domain_name = $1 AND
          cached_at > NOW() - ($2 || ' seconds')::interval`,
         [domain, cacheTtlSeconds],
         { operation: 'Whois.getCachedWhois', table: 'whois_cache' }
       );
     } else if (dbType === 'mysql') {
       return await getInternal(
-        `SELECT whois_data, status, cached_at, expires_at FROM whois_cache WHERE domain_name = ? AND 
+        `SELECT whois_data, status, cached_at, expires_at FROM whois_cache WHERE domain_name = ? AND
          cached_at > DATE_SUB(NOW(), INTERVAL ? SECOND)`,
         [domain, cacheTtlSeconds],
         { operation: 'Whois.getCachedWhois', table: 'whois_cache' }
       );
     } else {
       return await getInternal(
-        `SELECT whois_data, status, cached_at, expires_at FROM whois_cache WHERE domain_name = ? AND 
+        `SELECT whois_data, status, cached_at, expires_at FROM whois_cache WHERE domain_name = ? AND
          cached_at > datetime('now', '-' || ? || ' seconds')`,
         [domain, cacheTtlSeconds],
         { operation: 'Whois.getCachedWhois', table: 'whois_cache' }
@@ -3393,7 +3393,7 @@ export const WhoisOperations = {
   ): Promise<void> {
     const whoisData = JSON.stringify({ expiryDate, apexExpiryDate, registrar, nameServers, raw: rawData });
     const dbType = getDbType();
-    
+
     if (dbType === 'postgresql') {
       await executeInternal(
         `INSERT INTO whois_cache (domain_name, whois_data, status, cached_at)
@@ -3449,7 +3449,7 @@ export const RenewableDomainOperations = {
   async getAll(): Promise<any[]> {
     const builder = RenewableDomainQueryBuilder.all();
     const { sql, params } = builder.build();
-    
+
     return await queryInternal(sql, params, { operation: 'RenewableDomain.getAll', table: 'renewable_domains' });
   },
 
@@ -3457,10 +3457,10 @@ export const RenewableDomainOperations = {
   async getAllEnabled(): Promise<any[]> {
     const dbType = getDbType();
     const enabledValue = dbType === 'postgresql' ? 'TRUE' : '1';
-    
+
     const builder = RenewableDomainQueryBuilder.allEnabled(enabledValue);
     const { sql, params } = builder.build();
-    
+
     return await queryInternal(sql, params, { operation: 'RenewableDomain.getAllEnabled', table: 'renewable_domains' });
   },
 
@@ -3468,7 +3468,7 @@ export const RenewableDomainOperations = {
   async getByAccountId(accountId: number): Promise<any[]> {
     const builder = RenewableDomainQueryBuilder.byAccountId(accountId);
     const { sql, params } = builder.build();
-    
+
     return await queryInternal(sql, params, { operation: 'RenewableDomain.getByAccountId', table: 'renewable_domains' });
   },
 
@@ -3476,10 +3476,10 @@ export const RenewableDomainOperations = {
   async getByProviderType(providerType: string): Promise<any[]> {
     const dbType = getDbType();
     const enabledValue = dbType === 'postgresql' ? 'TRUE' : '1';
-    
+
     const builder = RenewableDomainQueryBuilder.byProviderType(providerType, enabledValue);
     const { sql, params } = builder.build();
-    
+
     return await queryInternal(sql, params, { operation: 'RenewableDomain.getByProviderType', table: 'renewable_domains' });
   },
 
@@ -3497,7 +3497,7 @@ export const RenewableDomainOperations = {
     const dbType = getDbType();
     const enabledValue = dbType === 'postgresql' ? true : 1;
     const neverExpiresValue = dbType === 'postgresql' ? (data.never_expires ? true : false) : (data.never_expires ? 1 : 0);
-    
+
     const result = await insertInternal(
       'INSERT INTO renewable_domains (account_id, provider_type, domain_name, third_id, full_domain, expires_at, never_expires, enabled, remark) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
       [
@@ -3534,9 +3534,9 @@ export const RenewableDomainOperations = {
         addedCount++;
       } catch (error) {
         // 跳过重复的域名（UNIQUE 约束
-        log.warn('RenewableDomain', 'Skip duplicate domain', { 
+        log.warn('Skip duplicate domain', {
           domain: domain.full_domain,
-          error: (error as Error).message 
+          error: (error as Error).message
         });
       }
     }
@@ -3772,7 +3772,7 @@ export const NSMonitorOperations = {
   async getByDomain(userId: number, domainId: number): Promise<QueryResult | undefined> {
     // This method is deprecated - domain_id column has been removed
     // Use getByDomainName instead
-    balLog.warn( 'getByDomain is deprecated, use getByDomainName instead');
+    log.warn( 'getByDomain is deprecated, use getByDomainName instead');
     return undefined;
   },
 
@@ -3875,13 +3875,13 @@ export const RdapCacheOperations = {
 
     for (const entry of entries) {
       const serversJson = JSON.stringify(entry.servers);
-      
+
       if (dbType === 'postgresql') {
         // PostgreSQL 使用 ON CONFLICT
         await executeInternal(
-          `INSERT INTO rdap_server_cache (tld, servers, created_at, updated_at) 
+          `INSERT INTO rdap_server_cache (tld, servers, created_at, updated_at)
            VALUES ($1, $2, $3, $4)
-           ON CONFLICT (tld) DO UPDATE SET 
+           ON CONFLICT (tld) DO UPDATE SET
            servers = EXCLUDED.servers, updated_at = EXCLUDED.updated_at`,
           [entry.tld.toLowerCase(), serversJson, now, now],
           { operation: 'RdapCache.saveBatch', table: 'rdap_server_cache' }
@@ -3889,9 +3889,9 @@ export const RdapCacheOperations = {
       } else if (dbType === 'mysql') {
         // MySQL 使用 ON DUPLICATE KEY UPDATE
         await executeInternal(
-          `INSERT INTO rdap_server_cache (tld, servers, created_at, updated_at) 
+          `INSERT INTO rdap_server_cache (tld, servers, created_at, updated_at)
            VALUES (?, ?, ?, ?)
-           ON DUPLICATE KEY UPDATE 
+           ON DUPLICATE KEY UPDATE
            servers = VALUES(servers), updated_at = VALUES(updated_at)`,
           [entry.tld.toLowerCase(), serversJson, now, now],
           { operation: 'RdapCache.saveBatch', table: 'rdap_server_cache' }
@@ -3899,7 +3899,7 @@ export const RdapCacheOperations = {
       } else {
         // SQLite 使用 REPLACE 或先删除后插
         await executeInternal(
-          `INSERT OR REPLACE INTO rdap_server_cache (tld, servers, created_at, updated_at) 
+          `INSERT OR REPLACE INTO rdap_server_cache (tld, servers, created_at, updated_at)
            VALUES (?, ?, COALESCE((SELECT created_at FROM rdap_server_cache WHERE tld = ?), ?), ?)`,
           [entry.tld.toLowerCase(), serversJson, entry.tld.toLowerCase(), now, now],
           { operation: 'RdapCache.saveBatch', table: 'rdap_server_cache' }
@@ -3954,25 +3954,25 @@ export const SystemCacheOperations = {
 
     if (dbType === 'postgresql') {
       await executeInternal(
-        `INSERT INTO system_cache (cache_key, cache_value, expires_at, created_at, updated_at) 
+        `INSERT INTO system_cache (cache_key, cache_value, expires_at, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT (cache_key) DO UPDATE SET 
+         ON CONFLICT (cache_key) DO UPDATE SET
          cache_value = EXCLUDED.cache_value, expires_at = EXCLUDED.expires_at, updated_at = EXCLUDED.updated_at`,
         [key, value, expires, now, now],
         { operation: 'SystemCache.set', table: 'system_cache' }
       );
     } else if (dbType === 'mysql') {
       await executeInternal(
-        `INSERT INTO system_cache (cache_key, cache_value, expires_at, created_at, updated_at) 
+        `INSERT INTO system_cache (cache_key, cache_value, expires_at, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?)
-         ON DUPLICATE KEY UPDATE 
+         ON DUPLICATE KEY UPDATE
          cache_value = VALUES(cache_value), expires_at = VALUES(expires_at), updated_at = VALUES(updated_at)`,
         [key, value, expires, now, now],
         { operation: 'SystemCache.set', table: 'system_cache' }
       );
     } else {
       await executeInternal(
-        `INSERT OR REPLACE INTO system_cache (cache_key, cache_value, expires_at, created_at, updated_at) 
+        `INSERT OR REPLACE INTO system_cache (cache_key, cache_value, expires_at, created_at, updated_at)
          VALUES (?, ?, ?, COALESCE((SELECT created_at FROM system_cache WHERE cache_key = ?), ?), ?)`,
         [key, value, expires, key, now, now],
         { operation: 'SystemCache.set', table: 'system_cache' }
@@ -4027,9 +4027,9 @@ const PasswordResetOperations = {
       [normalizedEmail],
       { operation: 'PasswordReset.getCode', table: 'password_resets' }
     );
-    
+
     if (!row) return null;
-    
+
     return {
       code: row.code,
       expiresAt: new Date(row.expires_at).getTime(),
@@ -4090,7 +4090,7 @@ export const McpOperations = {
   /** 更新 MCP 全局配置 */
   async updateGlobalConfig(enabled: boolean, userId?: number): Promise<void> {
     const existing = await McpOperations.getGlobalConfig();
-    
+
     if (existing) {
       await executeInternal(
         'UPDATE mcp_global_config SET enabled = ?, updated_by = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
@@ -4132,14 +4132,14 @@ export const McpOperations = {
       [apiKey],
       { operation: 'Mcp.validateApiKey', table: 'mcp_user_api_keys' }
     );
-    
+
     if (!key) return null;
-    
+
     // 检查是否过期
     if (key.expires_at && new Date(key.expires_at) < new Date()) {
       return null;
     }
-    
+
     return key;
   },
 
@@ -4315,11 +4315,11 @@ export const McpOperations = {
       [clientId],
       { operation: 'Mcp.validateClientCredentials', table: 'mcp_oauth_clients' }
     );
-    
+
     if (!client) return null;
     if (client.client_secret !== clientSecret) return null;
     if (client.expires_at && new Date(client.expires_at) < new Date()) return null;
-    
+
     return { id: client.id, user_id: client.user_id, app_name: client.app_name, scope: client.scope };
   },
 
@@ -4428,14 +4428,14 @@ export const McpOperations = {
       [accessToken],
       { operation: 'Mcp.validateAccessToken', table: 'mcp_oauth_access_tokens' }
     );
-    
+
     if (!token) return null;
-    
+
     // 检查是否过期
     if (new Date(token.expires_at) < new Date()) {
       return null;
     }
-    
+
     return token;
   },
 
@@ -4734,19 +4734,19 @@ export const McpOperations = {
   }>> {
     let sql = 'SELECT * FROM mcp_audit_logs WHERE 1=1';
     const params: unknown[] = [];
-    
+
     if (options.userId) {
       sql += ' AND user_id = ?';
       params.push(options.userId);
     }
-    
+
     if (options.module) {
       sql += ' AND module = ?';
       params.push(options.module);
     }
-    
+
     sql += ' ORDER BY created_at DESC';
-    
+
     const dbType = getDbType();
     if (options.limit) {
       if (dbType === 'mysql') {
@@ -4756,7 +4756,7 @@ export const McpOperations = {
         params.push(Number(options.limit));
       }
     }
-    
+
     if (options.offset) {
       if (dbType === 'mysql') {
         sql += ` OFFSET ${Number(options.offset)}`;
@@ -4765,7 +4765,7 @@ export const McpOperations = {
         params.push(Number(options.offset));
       }
     }
-    
+
     return queryInternal<{
       id: number;
       user_id: number;

--- a/server/src/db/dal/connection.ts
+++ b/server/src/db/dal/connection.ts
@@ -13,8 +13,9 @@ import type { DatabaseConfig } from './config';
 import { getDatabaseConfig, validateConfig } from './config';
 import type { DatabaseDriver } from '../dl/types';
 import { initDriver, getCurrentDriver, closeDriver, DriverManager } from '../dl';
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 
+const log = createLogger('DAL').sub('Connection');
 /**
  * 驱动包装器
  * 将 DatabaseDriver 包装为 DatabaseConnection 接口
@@ -103,16 +104,16 @@ export class ConnectionManager {
     if (this.connection) {
       const isHealthy = await this.checkHealth();
       if (isHealthy) {
-        log.info('ConnectionManager', 'Returning existing healthy connection', { type: this.connection.type });
+        log.info('Returning existing healthy connection', { type: this.connection.type });
         return this.connection;
       }
       // 连接不健康，尝试重连
-      log.warn('ConnectionManager', 'Existing connection unhealthy, attempting reconnect');
+      log.warn('Existing connection unhealthy, attempting reconnect');
       await this.disconnect();
     }
 
     if (this.connectionPromise) {
-      log.info('ConnectionManager', 'Waiting for existing connection promise');
+      log.info('Waiting for existing connection promise');
       return this.connectionPromise;
     }
 
@@ -134,7 +135,7 @@ export class ConnectionManager {
   private async createConnectionWithRetry(config: DatabaseConfig): Promise<DatabaseConnection> {
     while (this.reconnectAttempts < this.maxReconnectAttempts) {
       try {
-        log.info('ConnectionManager', `Creating new ${config.type} connection...`, {
+        log.info(`Creating new ${config.type} connection...`, {
           attempt: this.reconnectAttempts + 1,
           maxAttempts: this.maxReconnectAttempts,
         });
@@ -147,20 +148,20 @@ export class ConnectionManager {
           },
         });
 
-        log.info('ConnectionManager', `${config.type} driver initialized successfully`);
+        log.info(`${config.type} driver initialized successfully`);
         return new DriverConnectionWrapper(driver);
       } catch (error) {
         this.reconnectAttempts++;
-        log.error('ConnectionManager', `Connection attempt ${this.reconnectAttempts} failed`, { error });
+        log.error(`Connection attempt ${this.reconnectAttempts} failed`, { error });
 
         if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-          log.error('ConnectionManager', 'Max reconnection attempts reached');
+          log.error('Max reconnection attempts reached');
           throw error;
         }
 
         // 指数退避
         const delay = this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
-        log.info('ConnectionManager', `Retrying connection in ${delay}ms...`);
+        log.info(`Retrying connection in ${delay}ms...`);
         await this.sleep(delay);
       }
     }
@@ -176,7 +177,7 @@ export class ConnectionManager {
     if (this.isShuttingDown) {
       return false;
     }
-    
+
     if (!this.connection) return false;
 
     try {
@@ -186,7 +187,7 @@ export class ConnectionManager {
     } catch (error) {
       // 只在非关闭状态下记录警告
       if (!this.isShuttingDown) {
-        log.warn('ConnectionManager', 'Health check failed', { error });
+        log.warn('Health check failed', { error });
       }
       return false;
     }
@@ -203,15 +204,15 @@ export class ConnectionManager {
         this.stopHealthCheck();
         return;
       }
-      
+
       const isHealthy = await this.checkHealth();
       if (!isHealthy && !this.isShuttingDown) {
-        log.warn('ConnectionManager', 'Health check detected unhealthy connection, attempting reconnect');
+        log.warn('Health check detected unhealthy connection, attempting reconnect');
         try {
           await this.disconnect();
           await this.connect();
         } catch (error) {
-          log.error('ConnectionManager', 'Auto-reconnect failed', { error });
+          log.error('Auto-reconnect failed', { error });
         }
       }
     }, 30000);
@@ -242,26 +243,26 @@ export class ConnectionManager {
    */
   async disconnect(): Promise<void> {
     if (this.isShuttingDown) {
-      log.warn('ConnectionManager', 'Disconnect already in progress');
+      log.warn('Disconnect already in progress');
       return;
     }
 
     this.isShuttingDown = true;
-    log.info('ConnectionManager', 'Gracefully shutting down connection...');
+    log.info('Gracefully shutting down connection...');
 
     // 停止健康检查
     this.stopHealthCheck();
 
     // 等待正在进行的连接完成
     if (this.connectionPromise) {
-      log.info('ConnectionManager', 'Waiting for pending connection to complete...');
+      log.info('Waiting for pending connection to complete...');
       try {
         await Promise.race([
           this.connectionPromise,
           new Promise((_, reject) => setTimeout(() => reject(new Error('Connection timeout')), 5000)),
         ]);
       } catch (error) {
-        log.warn('ConnectionManager', 'Pending connection did not complete in time', { error });
+        log.warn('Pending connection did not complete in time', { error });
       }
       this.connectionPromise = null;
     }
@@ -274,9 +275,9 @@ export class ConnectionManager {
     // 关闭驱动
     try {
       await closeDriver();
-      log.info('ConnectionManager', 'Driver closed successfully');
+      log.info('Driver closed successfully');
     } catch (error) {
-      log.error('ConnectionManager', 'Error closing driver', { error });
+      log.error('Error closing driver', { error });
     }
 
     this.isShuttingDown = false;

--- a/server/src/db/dl/base.ts
+++ b/server/src/db/dl/base.ts
@@ -18,8 +18,9 @@ import type {
   OrderBy,
 } from '../dal/types';
 import type { DatabaseDriver, DriverConfig, ConnectionStats } from './types';
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 
+const log = createLogger('DL').sub('Base');
 /** 抽象基础驱动类 */
 export abstract class BaseDriver implements DatabaseDriver {
   abstract readonly type: DatabaseType;
@@ -46,26 +47,26 @@ export abstract class BaseDriver implements DatabaseDriver {
     executor: () => Promise<T>
   ): Promise<T> {
     const startTime = Date.now();
-    
+
     try {
       const result = await executor();
       const duration = Date.now() - startTime;
-      
+
       // Check if query is slow
       if (duration > this.slowQueryThreshold) {
         this.logSlowQuery(operation, sql, params, duration);
       }
-      
+
       return result;
     } catch (error) {
       const duration = Date.now() - startTime;
       this._stats.errors++;
-      
+
       // Also log slow failed queries
       if (duration > this.slowQueryThreshold) {
         this.logSlowQuery(operation, sql, params, duration, error as Error);
       }
-      
+
       throw error;
     }
   }
@@ -86,17 +87,17 @@ export abstract class BaseDriver implements DatabaseDriver {
       threshold: `${this.slowQueryThreshold}ms`,
       sql: sql.substring(0, 200), // Limit SQL length
     };
-    
+
     if (params && params.length > 0) {
       logData.params = params;
     }
-    
+
     if (error) {
       logData.error = error.message;
     }
-    
+
     // Log slow query using unified logging system
-    log.warn('DB', `Slow Query: ${operation} took ${duration}ms (threshold: ${this.slowQueryThreshold}ms)`, {
+    log.warn(`Slow Query: ${operation} took ${duration}ms (threshold: ${this.slowQueryThreshold}ms)`, {
       sql: sql.substring(0, 200),
       params: params && params.length > 0 ? params : undefined,
       error: error?.message,
@@ -230,10 +231,10 @@ export abstract class BaseDriver implements DatabaseDriver {
     const params: unknown[] = [];
     const table = this.escapeIdentifier(query.table);
 
-    const columns = query.columns.length === 0 || query.columns[0] === '*' 
-      ? '*' 
+    const columns = query.columns.length === 0 || query.columns[0] === '*'
+      ? '*'
       : query.columns.map(c => this.escapeIdentifier(c)).join(', ');
-    
+
     let sql = `SELECT ${query.distinct ? 'DISTINCT ' : ''}${columns} FROM ${table}`;
 
     const joinsSql = this.compileJoins(query.joins);
@@ -262,7 +263,7 @@ export abstract class BaseDriver implements DatabaseDriver {
   compileInsert(query: InsertQuery): CompiledSQL {
     const table = this.escapeIdentifier(query.table);
     const entries = Object.entries(query.data);
-    
+
     const columns = entries.map(([key]) => this.escapeIdentifier(key)).join(', ');
     const placeholders = entries.map((_, i) => this.placeholder(i + 1)).join(', ');
     const params = entries.map(([, value]) => value);
@@ -278,14 +279,14 @@ export abstract class BaseDriver implements DatabaseDriver {
 
   compileBatchInsert(query: BatchInsertQuery): CompiledSQL {
     const table = this.escapeIdentifier(query.table);
-    
+
     if (query.data.length === 0) {
       return { sql: '', params: [] };
     }
 
     const keys = Object.keys(query.data[0]);
     const columns = keys.map(k => this.escapeIdentifier(k)).join(', ');
-    
+
     const params: unknown[] = [];
     const valueGroups: string[] = [];
 

--- a/server/src/db/dl/mysql.ts
+++ b/server/src/db/dl/mysql.ts
@@ -8,7 +8,7 @@ import { BaseDriver } from './base';
 import { registerDriver } from './types';
 import { createLogger } from '../../lib/logger';
 
-const dlLog = createLogger('DL').sub('MySQL');
+const log = createLogger('DL').sub('MySQL');
 
 /** MySQL 配置 */
 export interface MySQLDriverConfig {
@@ -37,11 +37,11 @@ export class MySQLDriver extends BaseDriver {
     try {
       // 动态导入 mysql2 模块
       const mysql = require('mysql2/promise');
-      
-      dlLog.info( 'Creating connection pool', { 
-        host: config.host, 
-        port: config.port, 
-        database: config.database 
+
+      log.info( 'Creating connection pool', {
+        host: config.host,
+        port: config.port,
+        database: config.database
       });
 
       this.pool = mysql.createPool({
@@ -59,13 +59,13 @@ export class MySQLDriver extends BaseDriver {
         connectTimeout: config.connectTimeout || 60000,
       });
 
-      dlLog.info( 'Connection pool created successfully');
+      log.info( 'Connection pool created successfully');
     } catch (error) {
-      dlLog.error( 'Failed to create connection pool', { 
-        host: config.host, 
-        port: config.port, 
+      log.error( 'Failed to create connection pool', {
+        host: config.host,
+        port: config.port,
         database: config.database,
-        error 
+        error
       });
       throw new Error(
         `Failed to initialize MySQL driver: ${error instanceof Error ? error.message : 'Unknown error'}`
@@ -90,13 +90,13 @@ export class MySQLDriver extends BaseDriver {
       const duration = Date.now() - startTime;
 
       if (duration > (this.config.slowQueryThreshold || 100)) {
-        dlLog.warn( 'Slow query detected', { sql: sql.substring(0, 100), duration });
+        log.warn( 'Slow query detected', { sql: sql.substring(0, 100), duration });
       }
 
       return rows as T[];
     } catch (error) {
       this._stats.errors++;
-      dlLog.error( 'Query error', { sql: sql.substring(0, 100), error });
+      log.error( 'Query error', { sql: sql.substring(0, 100), error });
       throw error;
     }
   }
@@ -152,7 +152,7 @@ export class MySQLDriver extends BaseDriver {
   }
 
   async close(): Promise<void> {
-    dlLog.info( 'Closing connection pool', { stats: this._stats });
+    log.info( 'Closing connection pool', { stats: this._stats });
     await this.pool.end();
   }
 

--- a/server/src/db/dl/postgresql.ts
+++ b/server/src/db/dl/postgresql.ts
@@ -6,8 +6,9 @@ import type { Transaction, ColumnType } from '../dal/types';
 import type { DriverConfig } from './types';
 import { BaseDriver } from './base';
 import { registerDriver } from './types';
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 
+const log = createLogger('DL').sub('Postgresql');
 /** PostgreSQL 配置 */
 export interface PostgreSQLDriverConfig {
   host: string;
@@ -34,11 +35,11 @@ export class PostgreSQLDriver extends BaseDriver {
     try {
       // 动态导入 pg 模块
       const { Pool } = require('pg');
-      
-      log.info('PostgreSQL', 'Creating connection pool', { 
-        host: config.host, 
-        port: config.port, 
-        database: config.database 
+
+      log.info('Creating connection pool', {
+        host: config.host,
+        port: config.port,
+        database: config.database
       });
 
       this.pool = new Pool({
@@ -54,13 +55,13 @@ export class PostgreSQLDriver extends BaseDriver {
       });
 
       this.setupPoolEvents();
-      log.info('PostgreSQL', 'Connection pool created successfully');
+      log.info('Connection pool created successfully');
     } catch (error) {
-      log.error('PostgreSQL', 'Failed to create connection pool', { 
-        host: config.host, 
-        port: config.port, 
+      log.error('Failed to create connection pool', {
+        host: config.host,
+        port: config.port,
         database: config.database,
-        error 
+        error
       });
       throw new Error(
         `Failed to initialize PostgreSQL driver: ${error instanceof Error ? error.message : 'Unknown error'}`
@@ -70,19 +71,19 @@ export class PostgreSQLDriver extends BaseDriver {
 
   private setupPoolEvents(): void {
     this.pool.on('error', (err: Error) => {
-      log.error('PostgreSQL', 'Unexpected pool error', { error: err });
+      log.error('Unexpected pool error', { error: err });
     });
 
     this.pool.on('connect', () => {
-      log.debug('PostgreSQL', 'New client connected');
+      log.debug('New client connected');
     });
 
     this.pool.on('acquire', () => {
-      log.debug('PostgreSQL', 'Client acquired from pool');
+      log.debug('Client acquired from pool');
     });
 
     this.pool.on('remove', () => {
-      log.debug('PostgreSQL', 'Client removed from pool');
+      log.debug('Client removed from pool');
     });
   }
 
@@ -113,13 +114,13 @@ export class PostgreSQLDriver extends BaseDriver {
       const duration = Date.now() - startTime;
 
       if (duration > (this.config.slowQueryThreshold || 100)) {
-        log.warn('PostgreSQL', 'Slow query detected', { sql: sql.substring(0, 100), duration });
+        log.warn('Slow query detected', { sql: sql.substring(0, 100), duration });
       }
 
       return result.rows as T[];
     } catch (error) {
       this._stats.errors++;
-      log.error('PostgreSQL', 'Query error', { sql: sql.substring(0, 100), error });
+      log.error('Query error', { sql: sql.substring(0, 100), error });
       throw error;
     }
   }
@@ -182,7 +183,7 @@ export class PostgreSQLDriver extends BaseDriver {
   }
 
   async close(): Promise<void> {
-    log.info('PostgreSQL', 'Closing connection pool', { stats: this._stats });
+    log.info('Closing connection pool', { stats: this._stats });
     await this.pool.end();
   }
 

--- a/server/src/db/dl/sqlite.ts
+++ b/server/src/db/dl/sqlite.ts
@@ -8,8 +8,9 @@ import { BaseDriver } from './base';
 import { registerDriver } from './types';
 import * as fs from 'fs';
 import * as path from 'path';
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 
+const log = createLogger('DL').sub('Sqlite');
 /** SQLite 配置 */
 export interface SQLiteDriverConfig {
   path: string;
@@ -41,7 +42,7 @@ export class SQLiteDriver extends BaseDriver {
         fs.mkdirSync(dir, { recursive: true });
       }
 
-      log.info('SQLite', 'Opening database', { path: config.path, cwd: process.cwd() });
+      log.info('Opening database', { path: config.path, cwd: process.cwd() });
 
       // 在 EXE 环境中，需要手动指定 better-sqlite3 的绑定文件路径
       // pkg 打包后，process.pkg 会被设置
@@ -49,7 +50,7 @@ export class SQLiteDriver extends BaseDriver {
       let bindingPath: string | null = null;
 
       if (isPkgEnvironment) {
-        log.info('SQLite', 'Detected PKG environment, setting up native bindings path');
+        log.info('Detected PKG environment, setting up native bindings path');
         // 尝试从 EXE 所在目录的 node_modules 加载绑定文件
         const exeDir = path.dirname(process.execPath);
         const possiblePaths = [
@@ -60,7 +61,7 @@ export class SQLiteDriver extends BaseDriver {
         ];
 
         for (const tryPath of possiblePaths) {
-          log.debug('SQLite', 'Checking binding path', { path: tryPath, exists: fs.existsSync(tryPath) });
+          log.debug('Checking binding path', { path: tryPath, exists: fs.existsSync(tryPath) });
           if (fs.existsSync(tryPath)) {
             bindingPath = tryPath;
             break;
@@ -68,9 +69,9 @@ export class SQLiteDriver extends BaseDriver {
         }
 
         if (bindingPath) {
-          log.info('SQLite', 'Found native binding', { path: bindingPath });
+          log.info('Found native binding', { path: bindingPath });
         } else {
-          log.warn('SQLite', 'Native binding not found in expected locations', { possiblePaths });
+          log.warn('Native binding not found in expected locations', { possiblePaths });
         }
       }
 
@@ -82,7 +83,7 @@ export class SQLiteDriver extends BaseDriver {
           // 通过修改 require.cache 来注入正确的绑定路径
           const bindingModulePath = 'better-sqlite3/build/Release/better_sqlite3.node';
           const resolvedPath = require.resolve(bindingModulePath);
-          log.info('SQLite', 'Pre-loading native binding', { bindingPath, resolvedPath });
+          log.info('Pre-loading native binding', { bindingPath, resolvedPath });
 
           // 清除旧的缓存并加载新的绑定
           delete require.cache[resolvedPath];
@@ -102,7 +103,7 @@ export class SQLiteDriver extends BaseDriver {
 
         Database = require('better-sqlite3');
       } catch (importError) {
-        log.error('SQLite', 'Failed to import better-sqlite3 module', {
+        log.error('Failed to import better-sqlite3 module', {
           error: importError,
           cwd: process.cwd(),
           execPath: process.execPath,
@@ -119,7 +120,7 @@ export class SQLiteDriver extends BaseDriver {
       }
 
       this.db = new Database(config.path);
-      log.info('SQLite', 'Database opened successfully');
+      log.info('Database opened successfully');
 
       // 配置 SQLite
       if (config.enableWAL !== false) {
@@ -132,7 +133,7 @@ export class SQLiteDriver extends BaseDriver {
         this.db.pragma(`busy_timeout = ${config.busyTimeout}`);
       }
     } catch (error) {
-      log.error('SQLite', 'Failed to open database', { path: config.path, error });
+      log.error('Failed to open database', { path: config.path, error });
       throw error;
     }
   }
@@ -158,7 +159,7 @@ export class SQLiteDriver extends BaseDriver {
         return [];
       } catch (error) {
         this._stats.errors++;
-        log.error('SQLite', 'Query error', { sql: sql.substring(0, 100), error });
+        log.error('Query error', { sql: sql.substring(0, 100), error });
         throw error;
       }
     });
@@ -172,7 +173,7 @@ export class SQLiteDriver extends BaseDriver {
         return stmt.get(...serializeParams(params || [])) as T | undefined;
       } catch (error) {
         this._stats.errors++;
-        log.error('SQLite', 'Get error', { sql: sql.substring(0, 100), error });
+        log.error('Get error', { sql: sql.substring(0, 100), error });
         throw error;
       }
     });
@@ -186,7 +187,7 @@ export class SQLiteDriver extends BaseDriver {
         stmt.run(...serializeParams(params || []));
       } catch (error) {
         this._stats.errors++;
-        log.error('SQLite', 'Execute error', { sql: sql.substring(0, 100), error });
+        log.error('Execute error', { sql: sql.substring(0, 100), error });
         throw error;
       }
     });
@@ -242,7 +243,7 @@ export class SQLiteDriver extends BaseDriver {
   }
 
   async close(): Promise<void> {
-    log.info('SQLite', 'Closing database', { stats: this._stats });
+    log.info('Closing database', { stats: this._stats });
     if (this.db) {
       this.db.close();
     }

--- a/server/src/db/dsm/backup-manager.ts
+++ b/server/src/db/dsm/backup-manager.ts
@@ -2,8 +2,9 @@ import fs from 'fs';
 import path from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 
+const log = createLogger('DSM').sub('BackupManager');
 const execAsync = promisify(exec);
 
 export class BackupManager {
@@ -31,49 +32,49 @@ export class BackupManager {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     const backupPath = path.join(this.backupDir, `backup_${dbType}_${timestamp}`);
 
-    log.info('Backup', `Starting database backup for ${dbType}...`);
+    log.info(`Starting database backup for ${dbType}...`);
 
     try {
       if (dbType === 'sqlite') {
         const dbPath = process.env.DB_PATH || './data/dnsmgr.db';
         if (!fs.existsSync(dbPath)) {
-          log.warn('Backup', 'SQLite database file not found, skipping backup.');
+          log.warn('SQLite database file not found, skipping backup.');
           return '';
         }
         fs.copyFileSync(dbPath, `${backupPath}.db`);
-        log.info('Backup', `SQLite backup saved to ${backupPath}.db`);
+        log.info(`SQLite backup saved to ${backupPath}.db`);
         return `${backupPath}.db`;
-      } 
+      }
       else if (dbType === 'mysql') {
         if (!(await this.checkToolExists('mysqldump'))) {
           const msg = 'mysqldump tool not found in PATH.';
           if (this.isBackupRequired) throw new Error(msg);
-          log.warn('Backup', `${msg} Skipping backup due to configuration.`);
+          log.warn(`${msg} Skipping backup due to configuration.`);
           return '';
         }
         const { DB_HOST, DB_USER, DB_PASSWORD, DB_NAME } = process.env;
         const cmd = `mysqldump --skip-ssl --default-auth=mysql_native_password -h ${DB_HOST} -u ${DB_USER} -p${DB_PASSWORD} ${DB_NAME} > ${backupPath}.sql`;
         await execAsync(cmd);
-        log.info('Backup', `MySQL backup saved to ${backupPath}.sql`);
+        log.info(`MySQL backup saved to ${backupPath}.sql`);
         return `${backupPath}.sql`;
       }
       else if (dbType === 'postgresql') {
         if (!(await this.checkToolExists('pg_dump'))) {
           const msg = 'pg_dump tool not found in PATH.';
           if (this.isBackupRequired) throw new Error(msg);
-          log.warn('Backup', `${msg} Skipping backup due to configuration.`);
+          log.warn(`${msg} Skipping backup due to configuration.`);
           return '';
         }
         const { DB_HOST, DB_USER, DB_PASSWORD, DB_NAME } = process.env;
         const cmd = `PGPASSWORD=${DB_PASSWORD} pg_dump -h ${DB_HOST} -U ${DB_USER} -d ${DB_NAME} -f ${backupPath}.sql`;
         await execAsync(cmd);
-        log.info('Backup', `PostgreSQL backup saved to ${backupPath}.sql`);
+        log.info(`PostgreSQL backup saved to ${backupPath}.sql`);
         return `${backupPath}.sql`;
       }
 
       throw new Error(`Unsupported database type for backup: ${dbType}`);
     } catch (error) {
-      log.error('Backup', 'Backup failed:', error);
+      log.error('Backup failed:', error);
       throw error;
     }
   }
@@ -90,7 +91,7 @@ export class BackupManager {
       const stats = fs.statSync(filePath);
       if (stats.mtime < cutoffDate) {
         fs.unlinkSync(filePath);
-        log.info('Backup', `Deleted old backup: ${file}`);
+        log.info(`Deleted old backup: ${file}`);
       }
     }
   }

--- a/server/src/db/dsm/column-validator.ts
+++ b/server/src/db/dsm/column-validator.ts
@@ -1,5 +1,6 @@
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 
+const log = createLogger('DSM').sub('ColumnValidator');
 export interface ColumnSpec {
   tableName: string;
   columnName: string;
@@ -37,7 +38,7 @@ export async function validateColumn(
         LIMIT 1
       `;
       const result = await conn.query(sql, [spec.tableName, spec.columnName]);
-      
+
       if (Array.isArray(result) && result.length > 0) {
         const row = result[0];
         actualType = row.COLUMN_TYPE || '';
@@ -52,7 +53,7 @@ export async function validateColumn(
         LIMIT 1
       `;
       const result = await conn.query(sql, [spec.tableName, spec.columnName]);
-      
+
       if (Array.isArray(result) && result.length > 0) {
         const row = result[0];
         actualType = row.data_type || '';
@@ -62,7 +63,7 @@ export async function validateColumn(
     } else if (dbType === 'sqlite') {
       const sql = `PRAGMA table_info(${spec.tableName})`;
       const result = await conn.execute(sql);
-      
+
       if (Array.isArray(result)) {
         const column = result.find((row: any) => row.name.replace(/["'`]/g, '') === spec.columnName);
         if (column) {
@@ -103,10 +104,10 @@ export async function validateColumn(
       issues,
     };
   } catch (error) {
-    log.error('ColumnValidator', `Failed to validate column ${spec.tableName}.${spec.columnName}`, {
+    log.error(`Failed to validate column ${spec.tableName}.${spec.columnName}`, {
       error: (error as Error).message,
     });
-    
+
     return {
       tableName: spec.tableName,
       columnName: spec.columnName,
@@ -125,20 +126,20 @@ export async function validateColumns(
   dbType: 'mysql' | 'postgresql' | 'sqlite'
 ): Promise<ColumnInfo[]> {
   const results: ColumnInfo[] = [];
-  
+
   for (const spec of specs) {
     const result = await validateColumn(conn, spec, dbType);
     results.push(result);
-    
+
     if (result.matchesExpected) {
-      log.debug('ColumnValidator', `✓ ${spec.tableName}.${spec.columnName} is valid`);
+      log.debug(`✓ ${spec.tableName}.${spec.columnName} is valid`);
     } else {
-      log.warn('ColumnValidator', `✗ ${spec.tableName}.${spec.columnName} has issues:`, {
+      log.warn(`✗ ${spec.tableName}.${spec.columnName} has issues:`, {
         issues: result.issues,
       });
     }
   }
-  
+
   return results;
 }
 
@@ -146,10 +147,10 @@ export function generateValidationReport(results: ColumnInfo[]): string {
   const total = results.length;
   const passed = results.filter(r => r.matchesExpected).length;
   const failed = total - passed;
-  
+
   let report = `\n=== Column Validation Report ===\n`;
   report += `Total: ${total}, Passed: ${passed}, Failed: ${failed}\n\n`;
-  
+
   if (failed > 0) {
     report += `FAILED COLUMNS:\n`;
     results.forEach(result => {
@@ -162,14 +163,14 @@ export function generateValidationReport(results: ColumnInfo[]): string {
     });
     report += '\n';
   }
-  
+
   report += `PASSED COLUMNS:\n`;
   results.forEach(result => {
     if (result.matchesExpected) {
       report += `  ✓ ${result.tableName}.${result.columnName} (${result.actualType})\n`;
     }
   });
-  
+
   return report;
 }
 
@@ -177,10 +178,10 @@ export const COMMON_COLUMN_SPECS = {
   ID: { expectedType: 'INT', expectedNullable: false },
   CREATED_AT: { expectedType: 'DATETIME', expectedNullable: false },
   UPDATED_AT: { expectedType: 'DATETIME', expectedNullable: false },
-  
+
   DOMAIN_NAME: { expectedType: 'VARCHAR', expectedNullable: false },
   DNS_TYPE: { expectedType: 'VARCHAR', expectedNullable: false },
   DNS_VALUE: { expectedType: 'TEXT', expectedNullable: false },
-  
+
   ENABLED_FLAG: { expectedType: 'TINYINT', expectedNullable: false, expectedDefault: '1' },
 };

--- a/server/src/db/dsm/data-migration-runner.ts
+++ b/server/src/db/dsm/data-migration-runner.ts
@@ -1,8 +1,9 @@
 import { getConnection } from '../dal/connection';
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 import { SchemaVersionManager } from './migration-manager';
 import { sqliteSchema } from './schemas/dialects/sqlite';
 
+const log = createLogger('DSM').sub('DataMigrationRunner');
 export interface DataMigration {
   id: string;
   description: string;
@@ -40,7 +41,7 @@ export class DataMigrationRunner {
     await this.ensureVersionTable();
 
     const executedIds = await this.getExecutedMigrationIds();
-    
+
     const sortedMigrations = this.topologicalSort();
 
     for (const migrationId of sortedMigrations) {
@@ -48,61 +49,61 @@ export class DataMigrationRunner {
       if (!migration) continue;
 
       if (executedIds.includes(migrationId)) {
-        log.debug('DSM-Migration', `Skipping already executed migration: ${migrationId}`);
+        log.debug(`Skipping already executed migration: ${migrationId}`);
         result.skipped.push(migrationId);
         continue;
       }
 
       let shouldExecute = true;
       try {
-        log.debug('DSM-Migration', `Checking condition for: ${migrationId}...`);
+        log.debug(`Checking condition for: ${migrationId}...`);
         shouldExecute = await migration.condition();
         if (shouldExecute) {
-          log.info('DSM-Migration', `✅ Condition met for ${migrationId}. Will execute.`);
+          log.info(`✅ Condition met for ${migrationId}. Will execute.`);
         } else {
-          log.debug('DSM-Migration', `⏭️ Condition not met for ${migrationId}. Skipping.`);
+          log.debug(`⏭️ Condition not met for ${migrationId}. Skipping.`);
         }
       } catch (e) {
-        log.error('DSM-Migration', `Condition check failed for ${migrationId}`, e);
+        log.error(`Condition check failed for ${migrationId}`, e);
         result.failed.push({ id: migrationId, error: e as Error });
         continue;
       }
 
       if (!shouldExecute) {
-        log.debug('DSM-Migration', `Condition not met, skipping: ${migrationId}`);
+        log.debug(`Condition not met, skipping: ${migrationId}`);
         result.skipped.push(migrationId);
         continue;
       }
 
       if (options.dryRun) {
-        log.warn('DSM-Migration [DRY RUN]', `🔍 Would execute: ${migrationId} - ${migration.description}`);
+        log.warn(`🔍 Would execute: ${migrationId} - ${migration.description}`);
         result.executed.push(migrationId);
       } else {
         const startTime = Date.now();
         try {
-          log.info('DSM-Migration', `🚀 Starting migration: ${migrationId}`);
-          log.debug('DSM-Migration', `Description: ${migration.description}`);
-          
+          log.info(`🚀 Starting migration: ${migrationId}`);
+          log.debug(`Description: ${migration.description}`);
+
           await migration.execute();
-          
+
           const duration = Date.now() - startTime;
-          log.info('DSM-Migration', `✨ Completed: ${migrationId} in ${duration}ms`);
-          
+          log.info(`✨ Completed: ${migrationId} in ${duration}ms`);
+
           await this.recordSuccess(migrationId, migration.description);
           result.executed.push(migrationId);
         } catch (e) {
-          log.error('DSM-Migration', `Failed to execute ${migrationId}`, e);
+          log.error(`Failed to execute ${migrationId}`, e);
           result.failed.push({ id: migrationId, error: e as Error });
         }
       }
     }
 
-    log.info('DSM-Migration', '--- Migration Summary ---');
-    log.info('DSM-Migration', `Executed: ${result.executed.length}, Skipped: ${result.skipped.length}, Failed: ${result.failed.length}`);
+    log.info('--- Migration Summary ---');
+    log.info(`Executed: ${result.executed.length}, Skipped: ${result.skipped.length}, Failed: ${result.failed.length}`);
     if (result.failed.length > 0) {
-      log.error('DSM-Migration', 'Failed migrations:', result.failed.map(f => f.id).join(', '));
+      log.error('Failed migrations:', result.failed.map(f => f.id).join(', '));
     }
-    log.info('DSM-Migration', '-----------------------');
+    log.info('-----------------------');
 
     return result;
   }
@@ -110,7 +111,7 @@ export class DataMigrationRunner {
   private async ensureVersionTable(): Promise<void> {
     const conn = getConnection();
     const type = conn.type;
-    
+
     if (type === 'sqlite') {
       await conn.execute(`CREATE TABLE IF NOT EXISTS schema_versions (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -161,7 +162,7 @@ export class DataMigrationRunner {
   private async recordSuccess(id: string, description: string): Promise<void> {
     const conn = getConnection();
     await conn.execute(
-      `INSERT INTO schema_versions (version, semantic_version, description, success, system_type) 
+      `INSERT INTO schema_versions (version, semantic_version, description, success, system_type)
        VALUES (?, ?, ?, 1, 'hidns-migration')`,
       [id, '1.0.0', description]
     );

--- a/server/src/db/dsm/init-dsm.ts
+++ b/server/src/db/dsm/init-dsm.ts
@@ -8,7 +8,7 @@ import { createLogger } from '../../lib/logger';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const dsmLog = createLogger('DSM');
+const log = createLogger('DSM').sub('Init');
 
 export async function initializeDSM(dryRun = false): Promise<void> {
   const reconciler = new SchemaReconciler();
@@ -17,61 +17,61 @@ export async function initializeDSM(dryRun = false): Promise<void> {
     const legacyCheck = await reconciler.detectLegacySystem();
     const isLegacy = legacyCheck.isLegacy;
     if (isLegacy) {
-      dsmLog.warn( `⚠️ Legacy system detected: ${legacyCheck.reason}`);
-      dsmLog.info( 'Running in legacy upgrade mode. Performing full reconciliation...');
+      log.warn( `⚠️ Legacy system detected: ${legacyCheck.reason}`);
+      log.info( 'Running in legacy upgrade mode. Performing full reconciliation...');
     } else {
-      dsmLog.info( 'No legacy system detected. Proceeding with standard DSM initialization.');
+      log.info( 'No legacy system detected. Proceeding with standard DSM initialization.');
     }
 
-    dsmLog.info( `Starting full database schema reconciliation${dryRun ? ' (DRY RUN)' : ''}...`);
-    
+    log.info( `Starting full database schema reconciliation${dryRun ? ' (DRY RUN)' : ''}...`);
+
     await reconciler.reconcile(COMPLETE_SCHEMA, { dryRun });
-    
+
     if (!dryRun) {
       // Data migrations are only needed when upgrading from a legacy system.
       // A brand new database already has the complete schema after reconciliation.
       if (isLegacy) {
-        dsmLog.info( 'Running data migrations for legacy upgrade...');
+        log.info( 'Running data migrations for legacy upgrade...');
         const runner = new DataMigrationRunner();
         registerDefaultMigrations(runner);
         const result = await runner.run({ dryRun });
-        
+
         if (result.failed.length > 0) {
-          dsmLog.error( 'Some migrations failed:', result.failed.map(f => f.id));
+          log.error( 'Some migrations failed:', result.failed.map(f => f.id));
         }
       } else {
-        dsmLog.info( 'New database detected. Skipping data migrations.');
+        log.info( 'New database detected. Skipping data migrations.');
       }
 
-      dsmLog.info( 'Running integrity check...');
+      log.info( 'Running integrity check...');
       const check = await reconciler.verify(COMPLETE_SCHEMA);
-      
+
       if (check.valid) {
-        dsmLog.info( '✅ All schemas are up to date and verified.');
+        log.info( '✅ All schemas are up to date and verified.');
       } else {
-        dsmLog.error( '❌ Integrity check failed:', check.issues);
+        log.error( '❌ Integrity check failed:', check.issues);
         throw new Error(`Schema integrity check failed: ${check.issues.join(', ')}`);
       }
 
       const conn = getConnection();
       const versionManager = new SchemaVersionManager(conn, sqliteSchema);
-      
+
       let appVersion = 'unknown';
       try {
         const pkgPath = path.join(__dirname, '../../package.json');
         const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
         appVersion = pkg.version || 'dev';
       } catch (e) {
-        dsmLog.warn( 'Failed to read package.json version');
+        log.warn( 'Failed to read package.json version');
       }
 
       await versionManager.recordDSMVersion(appVersion);
-      dsmLog.info( `✅ DSM version ${appVersion} recorded.`);
+      log.info( `✅ DSM version ${appVersion} recorded.`);
     } else {
-      dsmLog.warn( '⚠️ Dry run finished. No changes were made.');
+      log.warn( '⚠️ Dry run finished. No changes were made.');
     }
   } catch (error) {
-    dsmLog.error( '❌ Schema reconciliation failed:', error);
+    log.error( '❌ Schema reconciliation failed:', error);
     throw error;
   }
 }
@@ -101,7 +101,7 @@ function registerDefaultMigrations(runner: DataMigrationRunner): void {
     },
     execute: async () => {
       const conn = getConnection();
-      await conn.execute(`INSERT INTO security_policies 
+      await conn.execute(`INSERT INTO security_policies
         (require_2fa_global, min_password_length, session_timeout_hours, max_login_attempts)
         VALUES (0, 8, 24, 5)`);
     }
@@ -193,7 +193,7 @@ function registerDefaultMigrations(runner: DataMigrationRunner): void {
     execute: async () => {
       const conn = getConnection();
       const type = conn.type;
-      
+
       if (type === 'mysql') {
         await conn.execute('DROP TABLE IF EXISTS dns_accounts_new');
         await conn.execute(`CREATE TABLE dns_accounts_new (
@@ -202,10 +202,10 @@ function registerDefaultMigrations(runner: DataMigrationRunner): void {
           enabled TINYINT(1) NOT NULL DEFAULT 1, created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
           INDEX idx_created_by (created_by), INDEX idx_team_id (team_id)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`);
-        
+
         await conn.execute(`INSERT INTO dns_accounts_new (id, type, name, config, remark, created_by, team_id, enabled, created_at)
           SELECT id, type, name, config, remark, created_by, team_id, 1, created_at FROM dns_accounts`);
-        
+
         await conn.execute('SET FOREIGN_KEY_CHECKS = 0');
         await conn.execute('DROP TABLE dns_accounts');
         await conn.execute('ALTER TABLE dns_accounts_new RENAME TO dns_accounts');
@@ -238,7 +238,7 @@ function registerDefaultMigrations(runner: DataMigrationRunner): void {
       const type = conn.type;
 
       if (type === 'mysql') {
-        await conn.execute(`DELETE n1 FROM ns_monitor_domains n1 INNER JOIN ns_monitor_domains n2 
+        await conn.execute(`DELETE n1 FROM ns_monitor_domains n1 INNER JOIN ns_monitor_domains n2
           WHERE n1.id > n2.id AND n1.user_id = n2.user_id AND n1.domain_name = n2.domain_name`);
       } else {
         await conn.execute(`DELETE FROM ns_monitor_domains WHERE rowid NOT IN (
@@ -248,7 +248,7 @@ function registerDefaultMigrations(runner: DataMigrationRunner): void {
 
       if (type === 'sqlite') {
         await conn.execute('DROP TABLE IF EXISTS ns_monitor_domains_new');
-        await conn.execute(`CREATE TABLE ns_monitor_domains_new AS 
+        await conn.execute(`CREATE TABLE ns_monitor_domains_new AS
           SELECT id, user_id, domain_name, expected_ns, current_ns, encrypted_ns, plain_ns,
                  is_poisoned, status, enabled, last_check_at, last_alert_at, alert_count, created_at, updated_at
           FROM ns_monitor_domains`);

--- a/server/src/db/dsm/migration-manager.ts
+++ b/server/src/db/dsm/migration-manager.ts
@@ -1,6 +1,7 @@
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 import { calculateSchemaHash, SchemaDefinition } from './schemas';
 
+const log = createLogger('DSM').sub('MigrationManager');
 export interface SchemaVersion {
   major: number;
   minor: number;
@@ -29,7 +30,7 @@ export class SchemaVersionManager {
     this.conn = conn;
     this.schema = schema;
     this.schemaHash = calculateSchemaHash(schema);
-    
+
     this.semanticVersion = {
       major: version?.major ?? 1,
       minor: version?.minor ?? 5,
@@ -62,15 +63,15 @@ export class SchemaVersionManager {
 
   async ensureVersionTableExists(): Promise<void> {
     const dbType = (this.conn as any).type || 'unknown';
-    
+
     if (await this.hasVersionTable()) {
       return;
     }
-    
-    log.info('SchemaVersion', 'Creating schema_versions table...');
-    
+
+    log.info('Creating schema_versions table...');
+
     let createTableSQL = '';
-    
+
     switch (dbType) {
       case 'mysql':
         createTableSQL = `
@@ -91,7 +92,7 @@ export class SchemaVersionManager {
           ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
         `;
         break;
-      
+
       case 'postgresql':
         createTableSQL = `
           CREATE TABLE IF NOT EXISTS schema_versions (
@@ -107,7 +108,7 @@ export class SchemaVersionManager {
           )
         `;
         break;
-      
+
       case 'sqlite':
       default:
         createTableSQL = `
@@ -125,32 +126,32 @@ export class SchemaVersionManager {
         `;
         break;
     }
-    
+
     await this.conn.execute(createTableSQL);
-    log.info('SchemaVersion', 'schema_versions table created successfully');
+    log.info('schema_versions table created successfully');
   }
 
   async autoDetectAndPromote(description: string): Promise<boolean> {
     const dbType = (this.conn as any).type || 'unknown';
-    log.info('SchemaVersion', `Auto-detecting migration status for ${dbType}...`);
+    log.info(`Auto-detecting migration status for ${dbType}...`);
 
     try {
       const isMigrated = await this.checkMigrationIndicators(dbType);
-      
+
       if (isMigrated) {
-        log.info('SchemaVersion', 'Database appears to be already migrated, promoting status...');
-        
+        log.info('Database appears to be already migrated, promoting status...');
+
         await this.ensureVersionTableExists();
-        
+
         await this.recordSuccess(description, 0);
-        log.info('SchemaVersion', `Auto-promoted schema version ${this.schemaHash} as successful`);
+        log.info(`Auto-promoted schema version ${this.schemaHash} as successful`);
         return true;
       } else {
-        log.info('SchemaVersion', 'Database needs migration');
+        log.info('Database needs migration');
         return false;
       }
     } catch (error) {
-      log.error('SchemaVersion', 'Failed to auto-detect migration status', { error: (error as Error).message });
+      log.error('Failed to auto-detect migration status', { error: (error as Error).message });
       return false;
     }
   }
@@ -171,20 +172,20 @@ export class SchemaVersionManager {
   private async checkMySQLIndicators(): Promise<boolean> {
     try {
       const checkSql = `
-        SELECT COUNT(*) as count 
-        FROM INFORMATION_SCHEMA.COLUMNS 
+        SELECT COUNT(*) as count
+        FROM INFORMATION_SCHEMA.COLUMNS
         WHERE TABLE_NAME = 'dns_accounts' AND COLUMN_NAME = 'enabled'
       `;
       const result = await this.conn.execute(checkSql);
-      
+
       if (Array.isArray(result) && result.length > 0) {
         const count = (result[0] as any).count || (result[0] as any)['COUNT(*)'];
         return parseInt(String(count), 10) > 0;
       }
-      
+
       return false;
     } catch (error) {
-      log.warn('SchemaVersion', 'Failed to check MySQL indicators', { error: (error as Error).message });
+      log.warn('Failed to check MySQL indicators', { error: (error as Error).message });
       return false;
     }
   }
@@ -192,20 +193,20 @@ export class SchemaVersionManager {
   private async checkPostgreSQLIndicators(): Promise<boolean> {
     try {
       const checkSql = `
-        SELECT COUNT(*) as count 
-        FROM information_schema.columns 
+        SELECT COUNT(*) as count
+        FROM information_schema.columns
         WHERE table_name = 'dns_accounts' AND column_name = 'enabled'
       `;
       const result = await this.conn.execute(checkSql);
-      
+
       if (Array.isArray(result) && result.length > 0) {
         const count = (result[0] as any).count || (result[0] as any)['COUNT(*)'];
         return parseInt(String(count), 10) > 0;
       }
-      
+
       return false;
     } catch (error) {
-      log.warn('SchemaVersion', 'Failed to check PostgreSQL indicators', { error: (error as Error).message });
+      log.warn('Failed to check PostgreSQL indicators', { error: (error as Error).message });
       return false;
     }
   }
@@ -214,15 +215,15 @@ export class SchemaVersionManager {
     try {
       const checkSql = `PRAGMA table_info(dns_accounts)`;
       const result = await this.conn.execute(checkSql);
-      
+
       if (Array.isArray(result)) {
         const hasEnabledColumn = result.some((row: any) => row.name.replace(/["'`]/g, '') === 'enabled');
         return hasEnabledColumn;
       }
-      
+
       return false;
     } catch (error) {
-      log.warn('SchemaVersion', 'Failed to check SQLite indicators', { error: (error as Error).message });
+      log.warn('Failed to check SQLite indicators', { error: (error as Error).message });
       return false;
     }
   }
@@ -231,12 +232,12 @@ export class SchemaVersionManager {
     try {
       const sql = 'SELECT COUNT(*) as count FROM schema_versions WHERE version = ? AND success = 1';
       const result = await this.conn.execute(sql, [this.schemaHash]);
-      
+
       if (Array.isArray(result) && result.length > 0) {
         const count = (result[0] as any).count || (result[0] as any)['COUNT(*)'];
         return count > 0;
       }
-      
+
       return false;
     } catch (error) {
       if ((error as Error).message?.includes('schema_versions')) {
@@ -252,22 +253,22 @@ export class SchemaVersionManager {
   ): Promise<void> {
     const checkSql = 'SELECT COUNT(*) as cnt FROM schema_versions WHERE version = ?';
     const result = await this.conn.get(checkSql, [this.schemaHash]) as { cnt: number } | undefined;
-    
+
     if (result && Number(result.cnt || 0) > 0) {
-      log.debug('SchemaVersion', `Schema version ${this.schemaHash} already recorded, skipping`);
+      log.debug(`Schema version ${this.schemaHash} already recorded, skipping`);
       return;
     }
-    
-    const sql = `INSERT INTO schema_versions (version, semantic_version, description, success, execution_time_ms, system_type) 
+
+    const sql = `INSERT INTO schema_versions (version, semantic_version, description, success, execution_time_ms, system_type)
                  VALUES (?, ?, ?, 1, ?, 'hidns')`;
-    
+
     await this.conn.execute(sql, [
-      this.schemaHash, 
+      this.schemaHash,
       this.getSemanticVersion(),
-      description, 
+      description,
       executionTimeMs
     ]);
-    log.info('SchemaVersion', `Schema version ${this.getSemanticVersion()} (${this.schemaHash}) recorded as successful (HiDNS)`);
+    log.info(`Schema version ${this.getSemanticVersion()} (${this.schemaHash}) recorded as successful (HiDNS)`);
   }
 
   async recordFailure(
@@ -277,29 +278,29 @@ export class SchemaVersionManager {
   ): Promise<void> {
     const checkSql = 'SELECT COUNT(*) as cnt FROM schema_versions WHERE version = ?';
     const result = await this.conn.get(checkSql, [this.schemaHash]) as { cnt: number } | undefined;
-    
+
     if (result && Number(result.cnt || 0) > 0) {
-      log.debug('SchemaVersion', `Schema version ${this.schemaHash} already recorded, skipping failure record`);
+      log.debug(`Schema version ${this.schemaHash} already recorded, skipping failure record`);
       return;
     }
-    
-    const sql = `INSERT INTO schema_versions (version, semantic_version, description, success, error_message, execution_time_ms, system_type) 
+
+    const sql = `INSERT INTO schema_versions (version, semantic_version, description, success, error_message, execution_time_ms, system_type)
                  VALUES (?, ?, ?, 0, ?, ?, 'hidns')`;
-    
+
     await this.conn.execute(sql, [
       this.schemaHash,
       this.getSemanticVersion(),
-      description, 
-      errorMessage, 
+      description,
+      errorMessage,
       executionTimeMs
     ]);
-    log.error('SchemaVersion', `Schema version ${this.getSemanticVersion()} (${this.schemaHash}) recorded as failed (HiDNS): ${errorMessage}`);
+    log.error(`Schema version ${this.getSemanticVersion()} (${this.schemaHash}) recorded as failed (HiDNS): ${errorMessage}`);
   }
 
   async getAppliedMigrations(): Promise<MigrationRecord[]> {
     const sql = 'SELECT * FROM schema_versions ORDER BY applied_at ASC';
     const result = await this.conn.execute(sql);
-    
+
     if (!Array.isArray(result)) {
       return [];
     }
@@ -318,18 +319,18 @@ export class SchemaVersionManager {
   async getLastSuccessfulVersion(): Promise<string | null> {
     const sql = 'SELECT version FROM schema_versions WHERE success = 1 ORDER BY applied_at DESC LIMIT 1';
     const result = await this.conn.execute(sql);
-    
+
     if (Array.isArray(result) && result.length > 0) {
       return (result[0] as any).version;
     }
-    
+
     return null;
   }
 
   async recordDSMVersion(schemaVersion: string): Promise<void> {
     const exists = await this.isDSMVersionRecorded(schemaVersion);
     if (exists) {
-      log.debug('SchemaVersion', `DSM version ${schemaVersion} already recorded.`);
+      log.debug(`DSM version ${schemaVersion} already recorded.`);
       return;
     }
 
@@ -337,7 +338,7 @@ export class SchemaVersionManager {
       `Declarative Schema Management v${schemaVersion}`,
       0
     );
-    
+
     await this.conn.execute(
       `UPDATE schema_versions SET semantic_version = ? WHERE version = ?`,
       [schemaVersion, this.schemaHash]
@@ -346,7 +347,7 @@ export class SchemaVersionManager {
 
   async isDSMVersionRecorded(schemaVersion: string): Promise<boolean> {
     const result = await this.conn.get(
-      `SELECT COUNT(*) as cnt FROM schema_versions 
+      `SELECT COUNT(*) as cnt FROM schema_versions
        WHERE semantic_version = ? AND version LIKE 'DSM-%'`,
       [schemaVersion]
     );

--- a/server/src/db/dsm/schema-reconciler.ts
+++ b/server/src/db/dsm/schema-reconciler.ts
@@ -3,7 +3,7 @@ import { DatabaseSchema, TableDef, ColumnDef, TriggerDef, ViewDef, ProcedureDef 
 import { BackupManager } from './backup-manager';
 import { createLogger } from '../../lib/logger';
 
-const dsmLog = createLogger('DSM');
+const log = createLogger('DSM').sub('SchemaReconciler');
 
 export type DropTablePolicy = 'never' | 'dry-run-only' | 'safe-only' | 'always';
 
@@ -49,7 +49,7 @@ export class SchemaReconciler {
   async auditSchema(targetSchema: DatabaseSchema): Promise<{ valid: boolean; issues: string[] }> {
     const issues: string[] = [];
     const existingTables = await this.getAllTables();
-    
+
     for (const table of targetSchema.tables) {
       if (!existingTables.includes(table.name)) {
         issues.push(`Table missing in database: ${table.name}`);
@@ -127,12 +127,12 @@ export class SchemaReconciler {
         // Simple type mismatch check
         const targetSqlType = this.mapTypeToSQL(col.type, this.getDbType(), col.length);
         const actualDbType = (dbCol.type || dbCol.data_type || '').toUpperCase();
-        
+
         // Normalize and compare
         if (targetSqlType && actualDbType) {
           const normalizedTarget = targetSqlType.replace(/\(.*?\)/g, '').trim().toUpperCase();
           const normalizedActual = actualDbType.replace(/\(.*?\)/g, '').trim().toUpperCase();
-          
+
           const compatibleTypes = new Map<string, string[]>([
             ['INTEGER', ['INTEGER', 'INT', 'INT4', 'INT2', 'TINYINT', 'SMALLINT', 'BIGINT', 'SERIAL', 'BIGSERIAL']],
             ['BIGINT', ['BIGINT', 'BIGSERIAL', 'INTEGER', 'INT', 'INT4', 'INT8']],
@@ -191,15 +191,15 @@ export class SchemaReconciler {
       return this.conn.query(`PRAGMA table_info(${tableName})`);
     } else if (type === 'mysql') {
       return this.conn.query(
-        `SELECT COLUMN_NAME as name, DATA_TYPE as type, IS_NULLABLE as nullable, COLUMN_DEFAULT as defaultValue 
-         FROM INFORMATION_SCHEMA.COLUMNS 
+        `SELECT COLUMN_NAME as name, DATA_TYPE as type, IS_NULLABLE as nullable, COLUMN_DEFAULT as defaultValue
+         FROM INFORMATION_SCHEMA.COLUMNS
          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`,
         [tableName]
       );
     } else if (type === 'postgresql') {
       return this.conn.query(
-        `SELECT column_name as name, data_type as type, is_nullable as nullable, column_default as defaultValue 
-         FROM information_schema.columns 
+        `SELECT column_name as name, data_type as type, is_nullable as nullable, column_default as defaultValue
+         FROM information_schema.columns
          WHERE table_schema = 'public' AND table_name = $1`,
         [tableName]
       );
@@ -214,7 +214,7 @@ export class SchemaReconciler {
   private async dropColumn(table: string, column: string): Promise<void> {
     const dbType = this.getDbType();
     if (dbType === 'sqlite') {
-      dsmLog.warn( `Using table rebuild for SQLite DROP COLUMN: ${table}.${column}`);
+      log.warn( `Using table rebuild for SQLite DROP COLUMN: ${table}.${column}`);
       return;
     }
     await this.conn.execute(`ALTER TABLE ${this.escapeIdentifier(table)} DROP COLUMN ${this.escapeIdentifier(column)}`);
@@ -223,20 +223,20 @@ export class SchemaReconciler {
   private async modifyColumnType(table: string, column: string, newType: string, originCol?: ColumnDef, actualDbType?: string): Promise<void> {
     const dbType = this.getDbType();
     if (dbType === 'sqlite') {
-      dsmLog.warn( `Using table rebuild for SQLite type modification: ${table}.${column}`);
+      log.warn( `Using table rebuild for SQLite type modification: ${table}.${column}`);
       return;
     }
-    
+
     if (dbType === 'postgresql' && newType === 'SERIAL') {
-      dsmLog.warn( `Skipping type modification to SERIAL for ${table}.${column} (SERIAL is a pseudo-type)`);
+      log.warn( `Skipping type modification to SERIAL for ${table}.${column} (SERIAL is a pseudo-type)`);
       return;
     }
-    
+
     if (dbType === 'postgresql') {
       await this.conn.execute(`ALTER TABLE ${this.escapeIdentifier(table)} ALTER COLUMN ${this.escapeIdentifier(column)} DROP DEFAULT`);
-      
+
       let sql = `ALTER TABLE ${this.escapeIdentifier(table)} ALTER COLUMN ${this.escapeIdentifier(column)} TYPE ${newType}`;
-      
+
       if (newType === 'BOOLEAN' || newType === 'BIGINT' || newType === 'TIMESTAMPTZ' || newType === 'INTEGER') {
         if (newType === 'BOOLEAN' && actualDbType && ['SMALLINT', 'INT', 'INTEGER', 'INT2', 'INT4', 'TINYINT'].includes(actualDbType.toUpperCase().replace(/\(.*?\)/g, '').trim())) {
           sql += ` USING CASE WHEN ${this.escapeIdentifier(column)} != 0 THEN true ELSE false END`;
@@ -248,9 +248,9 @@ export class SchemaReconciler {
           sql += ` USING ${this.escapeIdentifier(column)}::${newType}`;
         }
       }
-      
+
       await this.conn.execute(sql);
-      
+
       if (originCol?.defaultValue !== undefined) {
         const defaultVal = this.formatDefaultValue(originCol.defaultValue, originCol.type, 'postgresql');
         await this.conn.execute(`ALTER TABLE ${this.escapeIdentifier(table)} ALTER COLUMN ${this.escapeIdentifier(column)} SET DEFAULT ${defaultVal}`);
@@ -279,7 +279,7 @@ export class SchemaReconciler {
         const msg = e.message?.toLowerCase() || '';
         const isTruncation = e.code === 'WARN_DATA_TRUNCATED' || e.code === 'ER_DATA_TOO_LONG' || msg.includes('data truncated') || msg.includes('data too long');
         if (isTruncation) {
-          dsmLog.warn( `Data truncation when modifying ${table}.${column}: ${e.message}. Skipping this column modification.`);
+          log.warn( `Data truncation when modifying ${table}.${column}: ${e.message}. Skipping this column modification.`);
         } else {
           throw e;
         }
@@ -336,10 +336,10 @@ export class SchemaReconciler {
   async reconcile(schema: DatabaseSchema, options: ReconcileOptions = {}): Promise<void> {
     const { dryRun = false, dropTablePolicy = 'always', forceBackup = true } = options;
     const dbType = this.getDbType();
-    dsmLog.info( `Starting reconciliation for ${dbType} (Version: ${schema.version})...`);
+    log.info( `Starting reconciliation for ${dbType} (Version: ${schema.version})...`);
 
     if (options.dryRun) {
-      dsmLog.warn( 'DRY RUN MODE: No changes will be applied to the database.');
+      log.warn( 'DRY RUN MODE: No changes will be applied to the database.');
     }
 
     // Only create backup if schema changes are actually needed
@@ -349,24 +349,24 @@ export class SchemaReconciler {
       if (isExistingDb) {
         const needsBackup = await this.detectChangesNeeded(schema);
         if (needsBackup) {
-          dsmLog.info( 'Schema changes detected. Creating backup before applying changes...');
+          log.info( 'Schema changes detected. Creating backup before applying changes...');
           try {
             await this.backupManager.createBackup(dbType);
             this.backupManager.cleanup(7); // keep backups for 7 days
           } catch (err) {
-            dsmLog.error( 'Backup failed! Aborting reconciliation to protect data.', err);
+            log.error( 'Backup failed! Aborting reconciliation to protect data.', err);
             const continueOnFail = process.env.DSM_BACKUP_REQUIRED !== 'true';
             if (continueOnFail) {
-              dsmLog.warn( 'DSM_BACKUP_REQUIRED is not set to true, continuing with reconciliation...');
+              log.warn( 'DSM_BACKUP_REQUIRED is not set to true, continuing with reconciliation...');
             } else {
               throw err;
             }
           }
         } else {
-          dsmLog.info( 'No schema changes detected. Skipping backup.');
+          log.info( 'No schema changes detected. Skipping backup.');
         }
       } else {
-        dsmLog.info( 'New database. Skipping backup pre-check.');
+        log.info( 'New database. Skipping backup pre-check.');
       }
     }
 
@@ -407,12 +407,12 @@ export class SchemaReconciler {
       }
     }
 
-    dsmLog.info( 'Reconciliation completed successfully.');
+    log.info( 'Reconciliation completed successfully.');
   }
 
   async verify(schema: DatabaseSchema): Promise<{ valid: boolean; issues: string[] }> {
     const issues: string[] = [];
-    
+
     for (const tableDef of schema.tables) {
       const exists = await this.tableExists(tableDef.name);
       if (!exists) {
@@ -422,7 +422,7 @@ export class SchemaReconciler {
 
       const existingCols = await this.getTableColumns(tableDef.name);
       const existingNames = new Set(existingCols.map((c: any) => c.name.replace(/["'`]/g, '')));
-      
+
       for (const col of tableDef.columns) {
         if (!existingNames.has(col.name)) {
           issues.push(`Missing column: ${tableDef.name}.${col.name}`);
@@ -447,10 +447,10 @@ export class SchemaReconciler {
     if (!exists) {
       const sql = this.generateCreateTableSQL(tableDef);
       if (dryRun) {
-        dsmLog.sub('DRY RUN').info( `Would create table: ${tableDef.name}`);
-        dsmLog.sub('DRY RUN').info( `SQL: ${sql}`);
+        log.sub('DRY RUN').info( `Would create table: ${tableDef.name}`);
+        log.sub('DRY RUN').info( `SQL: ${sql}`);
       } else {
-        dsmLog.info( `Creating new table: ${tableDef.name}`);
+        log.info( `Creating new table: ${tableDef.name}`);
         await this.execute(sql);
       }
       // Indexes are not included in CREATE TABLE; create them separately
@@ -459,7 +459,7 @@ export class SchemaReconciler {
         await this.syncForeignKeys(tableDef, dryRun);
       }
     } else {
-      dsmLog.debug( `Table ${tableDef.name} exists, checking columns and indexes...`);
+      log.debug( `Table ${tableDef.name} exists, checking columns and indexes...`);
       if (this.getDbType() === 'mysql') {
         await this.dropAllForeignKeys(tableDef.name);
       }
@@ -476,7 +476,7 @@ export class SchemaReconciler {
 
     const dbType = this.getDbType();
     const targetNames = new Set(targetTables.map(t => t.name.toLowerCase()));
-    
+
     let existingTables: string[] = [];
     if (dbType === 'sqlite') {
       const rows = await this.conn.query(`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`);
@@ -496,7 +496,7 @@ export class SchemaReconciler {
         }
 
         if (policy === 'dry-run-only') {
-          dsmLog.sub('DRY RUN').warn( `Would drop table (policy: dry-run-only): ${tableName}`);
+          log.sub('DRY RUN').warn( `Would drop table (policy: dry-run-only): ${tableName}`);
           continue;
         }
 
@@ -504,15 +504,15 @@ export class SchemaReconciler {
           const countRes = await this.conn.get(`SELECT COUNT(*) as cnt FROM ${this.escapeIdentifier(tableName)}`);
           const rowCount = (countRes as any)?.cnt || 0;
           if (rowCount > 0) {
-            dsmLog.warn( `Skipping non-empty table (policy: safe-only): ${tableName} (${rowCount} rows)`);
+            log.warn( `Skipping non-empty table (policy: safe-only): ${tableName} (${rowCount} rows)`);
             continue;
           }
         }
 
         if (dryRun) {
-          dsmLog.sub('DRY RUN').warn( `Would drop table: ${tableName}`);
+          log.sub('DRY RUN').warn( `Would drop table: ${tableName}`);
         } else {
-          dsmLog.warn( `Dropping obsolete table (policy: ${policy}): ${tableName}`);
+          log.warn( `Dropping obsolete table (policy: ${policy}): ${tableName}`);
           await this.dropTable(tableName);
         }
       }
@@ -533,16 +533,16 @@ export class SchemaReconciler {
   private async syncForeignKeys(tableDef: TableDef, dryRun: boolean): Promise<void> {
     const dbType = this.getDbType();
     if (!tableDef.foreignKeys || dbType === 'sqlite') return;
-    
+
     const existingFKs = await this.getTableForeignKeys(tableDef.name);
     const existingFKNames = new Set(existingFKs.map((fk: any) => fk.constraint_name));
-    
+
     const targetFKNames = new Set<string>();
 
     for (const fk of tableDef.foreignKeys) {
       const constraintName = `fk_${tableDef.name}_${fk.column}`;
       targetFKNames.add(constraintName);
-      
+
       if (!existingFKNames.has(constraintName)) {
         let sql = '';
         if (dbType === 'mysql' || dbType === 'postgresql') {
@@ -551,31 +551,31 @@ export class SchemaReconciler {
 
         if (sql) {
           if (dryRun) {
-            dsmLog.sub('DRY RUN').info( `Would add FK: ${constraintName}`);
+            log.sub('DRY RUN').info( `Would add FK: ${constraintName}`);
           } else {
             try {
               await this.execute(sql);
-              dsmLog.info( `Added foreign key constraint: ${constraintName}`);
+              log.info( `Added foreign key constraint: ${constraintName}`);
             } catch (e: any) {
               if (e.message?.includes('Duplicate key') || e.message?.includes('already exists')) {
-                dsmLog.debug( `FK ${constraintName} already exists.`);
+                log.debug( `FK ${constraintName} already exists.`);
               } else {
-                dsmLog.warn( `Failed to add FK ${constraintName}:`, e);
+                log.warn( `Failed to add FK ${constraintName}:`, e);
               }
             }
           }
         }
       } else {
-        dsmLog.debug( `FK ${constraintName} already exists, skipping.`);
+        log.debug( `FK ${constraintName} already exists, skipping.`);
       }
     }
 
     for (const existingFKName of existingFKNames) {
       if (!targetFKNames.has(existingFKName)) {
         if (dryRun) {
-          dsmLog.sub('DRY RUN').warn( `Would drop FK: ${existingFKName}`);
+          log.sub('DRY RUN').warn( `Would drop FK: ${existingFKName}`);
         } else {
-          dsmLog.warn( `Dropping obsolete FK: ${existingFKName}`);
+          log.warn( `Dropping obsolete FK: ${existingFKName}`);
           await this.dropForeignKey(tableDef.name, existingFKName);
         }
       }
@@ -586,18 +586,18 @@ export class SchemaReconciler {
     const dbType = this.getDbType();
     if (dbType === 'mysql') {
       return this.conn.query(
-        `SELECT CONSTRAINT_NAME as constraint_name, COLUMN_NAME as column_name, 
+        `SELECT CONSTRAINT_NAME as constraint_name, COLUMN_NAME as column_name,
          REFERENCED_TABLE_NAME as ref_table, REFERENCED_COLUMN_NAME as ref_column
-         FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE 
+         FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND REFERENCED_TABLE_NAME IS NOT NULL`,
         [tableName]
       );
     } else if (dbType === 'postgresql') {
       return this.conn.query(
-        `SELECT tc.constraint_name, kcu.column_name, 
+        `SELECT tc.constraint_name, kcu.column_name,
          ccu.table_name AS ref_table, ccu.column_name AS ref_column,
          rc.delete_rule
-         FROM information_schema.table_constraints AS tc 
+         FROM information_schema.table_constraints AS tc
          JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name
          JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name
          JOIN information_schema.referential_constraints AS rc ON rc.constraint_name = tc.constraint_name
@@ -614,7 +614,7 @@ export class SchemaReconciler {
       try {
         await this.conn.execute(`ALTER TABLE ${this.escapeIdentifier(tableName)} DROP FOREIGN KEY ${this.escapeIdentifier(constraintName)}`);
       } catch (err) {
-        dsmLog.debug( `FK ${constraintName} not found or already dropped`);
+        log.debug( `FK ${constraintName} not found or already dropped`);
       }
     } else if (dbType === 'postgresql') {
       await this.conn.execute(`ALTER TABLE ${this.escapeIdentifier(tableName)} DROP CONSTRAINT IF EXISTS ${this.escapeIdentifier(constraintName)}`);
@@ -626,14 +626,14 @@ export class SchemaReconciler {
     if (dbType === 'mysql') {
       return this.conn.query(
         `SELECT CONSTRAINT_NAME as constraint_name, TABLE_NAME as table_name, COLUMN_NAME as column_name
-         FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE 
+         FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
          WHERE TABLE_SCHEMA = DATABASE() AND REFERENCED_TABLE_NAME = ? AND REFERENCED_COLUMN_NAME IS NOT NULL`,
         [tableName]
       );
     } else if (dbType === 'postgresql') {
       return this.conn.query(
         `SELECT tc.constraint_name, tc.table_name, kcu.column_name
-         FROM information_schema.table_constraints AS tc 
+         FROM information_schema.table_constraints AS tc
          JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name
          JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name
          WHERE tc.constraint_type = 'FOREIGN KEY' AND ccu.table_name = $1`,
@@ -645,13 +645,13 @@ export class SchemaReconciler {
 
   private async dropAllForeignKeys(tableName: string): Promise<void> {
     const dbType = this.getDbType();
-    
+
     // Drop FKs defined on this table
     const fks = await this.getTableForeignKeys(tableName);
     for (const fk of fks) {
       await this.dropForeignKey(tableName, fk.constraint_name || fk.constraintName);
     }
-    
+
     // Also drop FKs from other tables that reference this table
     // This is necessary for MySQL column type changes, where existing FK constraints
     // referencing the column being modified will block ALTER TABLE MODIFY COLUMN
@@ -696,10 +696,10 @@ export class SchemaReconciler {
         const ifNotExists = dbType === 'mysql' ? '' : ' IF NOT EXISTS';
         const sql = `CREATE ${uniqueStr} INDEX${ifNotExists} ${this.escapeIdentifier(idx.name)} ON ${this.escapeIdentifier(tableDef.name)} (${cols})`;
         if (dryRun) {
-          dsmLog.sub('DRY RUN').info( `Would add index: ${idx.name}`);
-          dsmLog.sub('DRY RUN').info( `SQL: ${sql}`);
+          log.sub('DRY RUN').info( `Would add index: ${idx.name}`);
+          log.sub('DRY RUN').info( `SQL: ${sql}`);
         } else {
-          dsmLog.info( `Adding missing index: ${idx.name}`);
+          log.info( `Adding missing index: ${idx.name}`);
           await this.execute(sql);
         }
       }
@@ -715,24 +715,24 @@ export class SchemaReconciler {
       if (!existingNames.has(col.name)) {
         const def = this.getColumnDefinitionSQL(col);
         if (dryRun) {
-          dsmLog.sub('DRY RUN').info( `Would add column: ${tableDef.name}.${col.name}`);
+          log.sub('DRY RUN').info( `Would add column: ${tableDef.name}.${col.name}`);
         } else {
-          dsmLog.info( `Adding missing column: ${tableDef.name}.${col.name}`);
+          log.info( `Adding missing column: ${tableDef.name}.${col.name}`);
           try {
             await this.addColumn(tableDef.name, col.name, def);
           } catch (e: any) {
             const msg = e.message?.toLowerCase() || '';
             if (msg.includes('duplicate column')) {
-              dsmLog.warn( `Column ${tableDef.name}.${col.name} already exists, skipping.`);
+              log.warn( `Column ${tableDef.name}.${col.name} already exists, skipping.`);
             } else if (this.getDbType() === 'sqlite' && (msg.includes('unique column') || msg.includes('unique constraint'))) {
-              dsmLog.warn( `Cannot add UNIQUE column ${tableDef.name}.${col.name} via ALTER in SQLite. Skipping add and relying on rebuild.`);
+              log.warn( `Cannot add UNIQUE column ${tableDef.name}.${col.name} via ALTER in SQLite. Skipping add and relying on rebuild.`);
             } else if (this.getDbType() === 'sqlite' && (msg.includes('non-constant default') || msg.includes('default value'))) {
-              dsmLog.warn( `Cannot add column ${tableDef.name}.${col.name} with non-constant default via ALTER in SQLite. Skipping add and relying on rebuild.`);
+              log.warn( `Cannot add column ${tableDef.name}.${col.name} with non-constant default via ALTER in SQLite. Skipping add and relying on rebuild.`);
             } else if (col.unique && (e.code === 'ER_DUP_ENTRY' || msg.includes('duplicate entry'))) {
               // Adding a UNIQUE NOT NULL column to an existing table with rows will fail
               // because all rows get the same default value, violating UNIQUE.
               // Retry without UNIQUE constraint to allow the migration to proceed.
-              dsmLog.warn( `Cannot add UNIQUE column ${tableDef.name}.${col.name} due to existing data. Retrying without UNIQUE constraint.`);
+              log.warn( `Cannot add UNIQUE column ${tableDef.name}.${col.name} due to existing data. Retrying without UNIQUE constraint.`);
               const defWithoutUnique = this.getColumnDefinitionSQL({ ...col, unique: false });
               await this.addColumn(tableDef.name, col.name, defWithoutUnique);
             } else {
@@ -747,9 +747,9 @@ export class SchemaReconciler {
       const normalizedName = existingCol.name.replace(/["'`]/g, '').trim();
       if (!targetNames.has(normalizedName)) {
         if (dryRun) {
-          dsmLog.sub('DRY RUN').warn( `Would drop column: ${tableDef.name}.${existingCol.name}`);
+          log.sub('DRY RUN').warn( `Would drop column: ${tableDef.name}.${existingCol.name}`);
         } else {
-          dsmLog.warn( `Dropping obsolete column: ${tableDef.name}.${existingCol.name}`);
+          log.warn( `Dropping obsolete column: ${tableDef.name}.${existingCol.name}`);
           await this.dropColumn(tableDef.name, existingCol.name);
         }
       }
@@ -763,18 +763,18 @@ export class SchemaReconciler {
       if (existingCol) {
         const expectedType = this.mapTypeToSQL(col.type, this.getDbType(), col.length);
         const actualType = existingCol.type?.toUpperCase();
-        
+
         const isPostgresSerial = this.getDbType() === 'postgresql' && expectedType === 'SERIAL';
-        
+
         if (actualType && !isPostgresSerial && !this.isTypeCompatible(actualType, expectedType)) {
           if (this.getDbType() === 'sqlite') {
             needsRebuild = true;
             rebuildTargets.push({ name: col.name, type: expectedType });
           } else {
             if (dryRun) {
-              dsmLog.sub('DRY RUN').warn( `Would modify column type: ${tableDef.name}.${col.name} (${actualType} -> ${expectedType})`);
+              log.sub('DRY RUN').warn( `Would modify column type: ${tableDef.name}.${col.name} (${actualType} -> ${expectedType})`);
             } else {
-              dsmLog.warn( `Modifying column type: ${tableDef.name}.${col.name} (${actualType} -> ${expectedType})`);
+              log.warn( `Modifying column type: ${tableDef.name}.${col.name} (${actualType} -> ${expectedType})`);
               await this.modifyColumnType(tableDef.name, col.name, expectedType, col, existingCol.type);
             }
           }
@@ -785,16 +785,16 @@ export class SchemaReconciler {
         const targetNullable = col.nullable === true; // only explicit true means NULL; undefined/false means NOT NULL
         const actualNullableStr = typeof existingCol.nullable === 'string' ? existingCol.nullable.toUpperCase() : '';
         const actualNullable = actualNullableStr === 'YES' || existingCol.nullable === true;
-        
+
         if (targetNullable !== actualNullable) {
           if (this.getDbType() === 'sqlite') {
             needsRebuild = true;
             rebuildTargets.push({ name: col.name, type: expectedType });
           } else {
             if (dryRun) {
-              dsmLog.sub('DRY RUN').warn(`Would change column nullability: ${tableDef.name}.${col.name} (-> ${targetNullable ? 'NULL' : 'NOT NULL'})`);
+              log.sub('DRY RUN').warn(`Would change column nullability: ${tableDef.name}.${col.name} (-> ${targetNullable ? 'NULL' : 'NOT NULL'})`);
             } else {
-              dsmLog.warn( `Changing column nullability: ${tableDef.name}.${col.name} (-> ${targetNullable ? 'NULL' : 'NOT NULL'})`);
+              log.warn( `Changing column nullability: ${tableDef.name}.${col.name} (-> ${targetNullable ? 'NULL' : 'NOT NULL'})`);
               await this.modifyColumnType(tableDef.name, col.name, expectedType, col, existingCol.type);
             }
           }
@@ -810,18 +810,18 @@ export class SchemaReconciler {
   private async rebuildTableForSQLite(tableDef: TableDef, dryRun: boolean): Promise<void> {
     const tableName = tableDef.name;
     const tempName = `${tableName}_dsm_rebuild_${Date.now()}`;
-    
+
     const existingCols = await this.getTableColumns(tableName);
     const existingColNames = new Set(existingCols.map((c: any) => c.name.replace(/["'`]/g, '').trim()));
-    
+
     const keepCols = tableDef.columns.filter(c => {
       const normalizedName = c.name.replace(/["'`]/g, '').trim();
       return existingColNames.has(normalizedName);
     });
     const keepColNames = keepCols.map(c => this.escapeIdentifier(c.name));
-    
+
     if (keepColNames.length === 0) {
-      dsmLog.error( `No columns to keep during rebuild for ${tableName}. Aborting.`);
+      log.error( `No columns to keep during rebuild for ${tableName}. Aborting.`);
       return;
     }
 
@@ -838,7 +838,7 @@ export class SchemaReconciler {
         .replace(/\s+AUTOINCREMENT\s*/i, ' ')
         .trim();
     }).join(', ');
-    
+
     let fkClause = '';
     if (tableDef.foreignKeys && tableDef.foreignKeys.length > 0) {
       const fks = tableDef.foreignKeys
@@ -849,31 +849,31 @@ export class SchemaReconciler {
     }
 
     if (dryRun) {
-      dsmLog.sub('DRY RUN').info( `Would rebuild SQLite table: ${tableName}`);
+      log.sub('DRY RUN').info( `Would rebuild SQLite table: ${tableName}`);
       return;
     }
 
     try {
       await this.conn.execute('PRAGMA foreign_keys = OFF');
-      
+
       await this.conn.execute('BEGIN TRANSACTION');
-      
+
       await this.conn.execute(`CREATE TABLE ${this.escapeIdentifier(tempName)} (${newColDefs}${fkClause})`);
-      
+
       await this.conn.execute(
-        `INSERT INTO ${this.escapeIdentifier(tempName)} (${keepColNames.join(', ')}) 
+        `INSERT INTO ${this.escapeIdentifier(tempName)} (${keepColNames.join(', ')})
          SELECT ${keepColNames.join(', ')} FROM ${this.escapeIdentifier(tableName)}`
       );
-      
+
       await this.conn.execute(`DROP TABLE ${this.escapeIdentifier(tableName)}`);
       await this.conn.execute(`ALTER TABLE ${this.escapeIdentifier(tempName)} RENAME TO ${this.escapeIdentifier(tableName)}`);
-      
+
       if (tableDef.indexes) {
         const keptColumnNameSet = new Set(keepCols.map(c => c.name));
         for (const idx of tableDef.indexes) {
           const allColsExist = idx.columns.every(c => keptColumnNameSet.has(c));
           if (!allColsExist) {
-            dsmLog.warn( `Skipping index ${idx.name} during rebuild: referenced columns not kept in new table`);
+            log.warn( `Skipping index ${idx.name} during rebuild: referenced columns not kept in new table`);
             continue;
           }
           const cols = idx.columns.map(c => this.escapeIdentifier(c)).join(', ');
@@ -884,11 +884,11 @@ export class SchemaReconciler {
 
       await this.conn.execute('COMMIT');
       await this.conn.execute('PRAGMA foreign_keys = ON');
-      dsmLog.info( `Successfully rebuilt SQLite table: ${tableName}`);
+      log.info( `Successfully rebuilt SQLite table: ${tableName}`);
     } catch (err) {
       await this.conn.execute('ROLLBACK');
       await this.conn.execute('PRAGMA foreign_keys = ON');
-      dsmLog.error( `Failed to rebuild SQLite table ${tableName}:`, err);
+      log.error( `Failed to rebuild SQLite table ${tableName}:`, err);
       throw err;
     }
   }
@@ -896,9 +896,9 @@ export class SchemaReconciler {
   private generateCreateTableSQL(table: TableDef): string {
     const dbType = this.getDbType();
     const cols = table.columns.map(c => this.getColumnDefinitionSQL(c)).join(', ');
-    
+
     let sql = `CREATE TABLE IF NOT EXISTS ${this.escapeIdentifier(table.name)} (${cols}`;
-    
+
     if (table.foreignKeys && table.foreignKeys.length > 0) {
       const fkClauses = table.foreignKeys.map(fk => {
         return `FOREIGN KEY (${fk.column}) REFERENCES ${fk.refTable}(${fk.refColumn}) ON DELETE ${fk.onDelete || 'NO ACTION'}`;
@@ -926,7 +926,7 @@ export class SchemaReconciler {
       if (col.autoIncrement) {
         if (dbType === 'sqlite') def += ' AUTOINCREMENT';
         else if (dbType === 'mysql') def += ' AUTO_INCREMENT';
-        else if (dbType === 'postgresql') def = def.replace('INTEGER', 'SERIAL'); 
+        else if (dbType === 'postgresql') def = def.replace('INTEGER', 'SERIAL');
       }
     } else {
       if (!col.nullable) def += ' NOT NULL';
@@ -963,28 +963,28 @@ export class SchemaReconciler {
       if (typeof value === 'boolean') return value ? '1' : '0';
       return value.toString();
     }
-    
+
     if (type === 'boolean') {
       if (dbType === 'postgresql') return value ? 'TRUE' : 'FALSE';
       if (dbType === 'mysql') return value ? '1' : '0';
       return value ? '1' : '0';
     }
-    
+
     if (value === 'NOW()' || value === 'CURRENT_TIMESTAMP') {
       return dbType === 'postgresql' ? 'CURRENT_TIMESTAMP' : 'CURRENT_TIMESTAMP';
     }
 
     if (type === 'json') {
-      return `'${JSON.stringify(value).replace(/'/g, "''")}'`; 
+      return `'${JSON.stringify(value).replace(/'/g, "''")}'`;
     }
-    
+
     return `'${String(value).replace(/'/g, "''")}'`;
   }
 
   private async syncTrigger(trigger: TriggerDef, dryRun: boolean): Promise<void> {
     const dbType = this.getDbType();
     const exists = await this.triggerExists(trigger.name);
-    
+
     let sql = '';
     if (dbType === 'mysql') {
       sql = `CREATE OR REPLACE TRIGGER ${trigger.name} ${trigger.timing} ${trigger.event} ON ${trigger.table} FOR EACH ROW ${trigger.body}`;
@@ -996,7 +996,7 @@ export class SchemaReconciler {
           ${trigger.body}
         END;
         $$ LANGUAGE plpgsql;
-        
+
         DROP TRIGGER IF EXISTS ${trigger.name} ON ${trigger.table};
         CREATE TRIGGER ${trigger.name} ${trigger.timing} ${trigger.event} ON ${trigger.table} FOR EACH ROW EXECUTE FUNCTION ${funcName}();
       `;
@@ -1005,12 +1005,12 @@ export class SchemaReconciler {
     }
 
     if (dryRun) {
-      dsmLog.sub('DRY RUN').info( `Would sync trigger: ${trigger.name}`);
+      log.sub('DRY RUN').info( `Would sync trigger: ${trigger.name}`);
     } else {
       if (!exists) {
-        dsmLog.info( `Creating trigger: ${trigger.name}`);
+        log.info( `Creating trigger: ${trigger.name}`);
       } else {
-        dsmLog.info( `Updating trigger: ${trigger.name}`);
+        log.info( `Updating trigger: ${trigger.name}`);
       }
       await this.execute(sql);
     }
@@ -1033,11 +1033,11 @@ export class SchemaReconciler {
 
   private async syncView(view: ViewDef, dryRun: boolean): Promise<void> {
     const sql = `CREATE OR REPLACE VIEW ${this.escapeIdentifier(view.name)} AS ${view.query}`;
-    
+
     if (dryRun) {
-      dsmLog.sub('DRY RUN').info( `Would sync view: ${view.name}`);
+      log.sub('DRY RUN').info( `Would sync view: ${view.name}`);
     } else {
-      dsmLog.info( `Syncing view: ${view.name}`);
+      log.info( `Syncing view: ${view.name}`);
       await this.execute(sql);
     }
   }
@@ -1045,21 +1045,21 @@ export class SchemaReconciler {
   private async syncProcedure(proc: ProcedureDef, dryRun: boolean): Promise<void> {
     const dbType = this.getDbType();
     const params = proc.parameters || '';
-    
+
     let sql = '';
     if (dbType === 'mysql') {
       sql = `CREATE OR REPLACE PROCEDURE ${proc.name}${params} ${proc.body}`;
     } else if (dbType === 'postgresql') {
       sql = `CREATE OR REPLACE FUNCTION ${proc.name}${params} ${proc.body}`;
     } else if (dbType === 'sqlite') {
-      dsmLog.warn( `SQLite does not support stored procedures. Skipping: ${proc.name}`);
+      log.warn( `SQLite does not support stored procedures. Skipping: ${proc.name}`);
       return;
     }
 
     if (dryRun) {
-      dsmLog.sub('DRY RUN').info( `Would sync procedure: ${proc.name}`);
+      log.sub('DRY RUN').info( `Would sync procedure: ${proc.name}`);
     } else {
-      dsmLog.info( `Syncing procedure: ${proc.name}`);
+      log.info( `Syncing procedure: ${proc.name}`);
       await this.execute(sql);
     }
   }

--- a/server/src/db/dsm/schema/migration.ts
+++ b/server/src/db/dsm/schema/migration.ts
@@ -1,6 +1,7 @@
 import type { DatabaseConnection, Transaction } from '../../dal/types';
-import { log } from '../../../lib/logger';
+import { createLogger } from '../../../lib/logger';
 
+const log = createLogger('DSM').sub('Migration');
 export interface Migration {
   readonly version: number;
   readonly name: string;
@@ -108,7 +109,7 @@ export class MigrationManager {
 
     const pending = await this.getPendingMigrations();
     if (pending.length === 0) {
-      log.info('Migration', 'No pending migrations');
+      log.info('No pending migrations');
       return;
     }
 
@@ -116,10 +117,10 @@ export class MigrationManager {
       ? pending.filter(m => m.version <= targetVersion)
       : pending;
 
-    log.info('Migration', `Running ${migrationsToRun.length} migration(s)...`);
+    log.info(`Running ${migrationsToRun.length} migration(s)...`);
 
     for (const migration of migrationsToRun) {
-      log.info('Migration', `Applying: ${migration.version} - ${migration.name}`);
+      log.info(`Applying: ${migration.version} - ${migration.name}`);
 
       await this.connection.execute('BEGIN TRANSACTION');
       try {
@@ -132,15 +133,15 @@ export class MigrationManager {
         );
 
         await this.connection.execute('COMMIT');
-        log.info('Migration', `Applied: ${migration.version} - ${migration.name}`);
+        log.info(`Applied: ${migration.version} - ${migration.name}`);
       } catch (error) {
         await this.connection.execute('ROLLBACK');
-        log.error('Migration', `Failed: ${migration.version} - ${migration.name}`, { error });
+        log.error(`Failed: ${migration.version} - ${migration.name}`, { error });
         throw error;
       }
     }
 
-    log.info('Migration', 'Migration completed');
+    log.info('Migration completed');
   }
 
   async rollback(steps: number = 1): Promise<void> {
@@ -148,26 +149,26 @@ export class MigrationManager {
 
     const applied = await this.getAppliedMigrations();
     if (applied.length === 0) {
-      log.info('Migration', 'No migrations to rollback');
+      log.info('No migrations to rollback');
       return;
     }
 
     const toRollback = applied.slice(-steps);
-    log.info('Migration', `Rolling back ${toRollback.length} migration(s)...`);
+    log.info(`Rolling back ${toRollback.length} migration(s)...`);
 
     for (const record of toRollback.reverse()) {
       const migration = this.migrations.find(m => m.version === record.version);
       if (!migration) {
-        log.warn('Migration', `Migration ${record.version} not found, skipping`);
+        log.warn(`Migration ${record.version} not found, skipping`);
         continue;
       }
 
       if (!migration.down) {
-        log.warn('Migration', `Migration ${record.version} has no down method, skipping`);
+        log.warn(`Migration ${record.version} has no down method, skipping`);
         continue;
       }
 
-      log.info('Migration', `Rolling back: ${migration.version} - ${migration.name}`);
+      log.info(`Rolling back: ${migration.version} - ${migration.name}`);
 
       await this.connection.execute('BEGIN TRANSACTION');
       try {
@@ -177,15 +178,15 @@ export class MigrationManager {
           [migration.version]
         );
         await this.connection.execute('COMMIT');
-        log.info('Migration', `Rolled back: ${migration.version} - ${migration.name}`);
+        log.info(`Rolled back: ${migration.version} - ${migration.name}`);
       } catch (error) {
         await this.connection.execute('ROLLBACK');
-        log.error('Migration', `Rollback failed: ${migration.version} - ${migration.name}`, { error });
+        log.error(`Rollback failed: ${migration.version} - ${migration.name}`, { error });
         throw error;
       }
     }
 
-    log.info('Migration', 'Rollback completed');
+    log.info('Rollback completed');
   }
 
   async reset(): Promise<void> {

--- a/server/src/db/dsm/sql-compat.ts
+++ b/server/src/db/dsm/sql-compat.ts
@@ -1,5 +1,6 @@
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 
+const log = createLogger('DSM').sub('SqlCompat');
 export type DatabaseType = 'sqlite' | 'mysql' | 'postgresql';
 
 export function getDbType(): DatabaseType {
@@ -8,32 +9,32 @@ export function getDbType(): DatabaseType {
 
 export function processSql(sql: string, dbType: DatabaseType = getDbType()): string {
   const originalSql = sql;
-  
+
   if (dbType === 'postgresql') {
     let index = 0;
     sql = sql.replace(/\?/g, () => `$${++index}`);
   }
-  
+
   if (dbType === 'mysql') {
     sql = processMySqlCompat(sql);
   }
-  
+
   if (sql !== originalSql) {
-    log.debug('SQLCompat', 'SQL processed', { 
-      original: originalSql.substring(0, 200), 
+    log.debug('SQL processed', {
+      original: originalSql.substring(0, 200),
       processed: sql.substring(0, 200),
-      dbType 
+      dbType
     });
   }
-  
+
   return sql;
 }
 
 function processMySqlCompat(sql: string): string {
   sql = convertOnConflictToOnDuplicateKey(sql);
-  
+
   sql = escapeMySqlKeywords(sql);
-  
+
   return sql;
 }
 
@@ -52,34 +53,34 @@ function convertOnConflictToOnDuplicateKey(sql: string): string {
 
 function escapeMySqlKeywords(sql: string): string {
   const keywords = ['key', 'value'];
-  
+
   keywords.forEach(keyword => {
     const regex = new RegExp(`(?<!"\`)\\b${keyword}\\b(?!"\`)`, 'gi');
-    
+
     sql = sql.replace(regex, (match, offset) => {
       const beforeContext = sql.substring(Math.max(0, offset - 30), offset).toUpperCase();
       const afterContext = sql.substring(offset + match.length, Math.min(sql.length, offset + match.length + 30)).toUpperCase();
-      
+
       if (beforeContext.includes('ON DUPLICATE') && keyword.toLowerCase() === 'key') {
         return match;
       }
-      
+
       if ((beforeContext.includes('FOREIGN') || beforeContext.includes('PRIMARY')) && keyword.toLowerCase() === 'key') {
         return match;
       }
-      
+
       if (beforeContext.includes('ORDER') || beforeContext.includes('GROUP')) {
         return match;
       }
-      
+
       if (beforeContext.includes('VALUES(') || beforeContext.includes('VALUES (')) {
         return match;
       }
-      
+
       return `\`${keyword}\``;
     });
   });
-  
+
   return sql;
 }
 
@@ -92,7 +93,7 @@ export function buildUpsertSql(
   dbType: DatabaseType = getDbType()
 ): { sql: string; params: unknown[] } {
   const allColumns = [...columns, 'updated_at'];
-  
+
   if (dbType === 'mysql') {
     const columnList = allColumns.map(col => col === 'key' || col === 'value' ? `\`${col}\`` : col).join(', ');
     const placeholders = allColumns.map(() => '?').join(', ');
@@ -100,7 +101,7 @@ export function buildUpsertSql(
       const escaped = col === 'key' || col === 'value' ? `\`${col}\`` : col;
       return `${escaped} = VALUES(${escaped})`;
     }).join(', ');
-    
+
     const sql = `INSERT INTO ${table} (${columnList}) VALUES (${placeholders}) ON DUPLICATE KEY UPDATE ${updates}, updated_at = NOW()`;
     return { sql, params: [...values, 'NOW()'] };
   } else if (dbType === 'postgresql') {
@@ -109,7 +110,7 @@ export function buildUpsertSql(
     const updates = updateColumns.map(col => {
       return `${col} = EXCLUDED.${col}`;
     }).join(', ');
-    
+
     const sql = `INSERT INTO ${table} (${columnList}) VALUES (${placeholders}) ON CONFLICT(${conflictKey}) DO UPDATE SET ${updates}, updated_at = NOW()`;
     return { sql, params: [...values, 'NOW()'] };
   } else {
@@ -118,7 +119,7 @@ export function buildUpsertSql(
     const updates = updateColumns.map(col => {
       return `${col} = excluded.${col}`;
     }).join(', ');
-    
+
     const sql = `INSERT INTO ${table} (${columnList}) VALUES (${placeholders}) ON CONFLICT(${conflictKey}) DO UPDATE SET ${updates}, updated_at = CURRENT_TIMESTAMP`;
     return { sql, params: [...values, 'CURRENT_TIMESTAMP'] };
   }

--- a/server/src/db/init.ts
+++ b/server/src/db/init.ts
@@ -7,62 +7,63 @@ import { getDatabaseConfig } from './dal/config';
 import fs from 'fs';
 import path from 'path';
 import { initializeDSM } from './dsm/init-dsm';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('DAL').sub('Init');
 export async function initSchema(): Promise<void> {
   const config = getDatabaseConfig();
-  
+
   // Special handling for SQLite: check if database file exists
   if (config.type === 'sqlite') {
     const dbPath = (config as any).path;
     const dbFileExists = fs.existsSync(dbPath);
-    
+
     if (!dbFileExists) {
       // Database file doesn't exist - this is a fresh install
       // Don't create the file yet, let the web initialization handle it
-      log.info('DB', 'SQLite database file not found, entering initialization mode');
-      log.info('DB', 'Please complete the web initialization wizard to configure the database');
+      log.info('SQLite database file not found, entering initialization mode');
+      log.info('Please complete the web initialization wizard to configure the database');
       return;
     }
-    
+
     // File exists, continue with normal checks
-    log.info('DB', 'SQLite database file found, checking system status...');
+    log.info('SQLite database file found, checking system status...');
   }
-  
+
   const conn = getConnection();
   const type = conn.type;
 
   // Step 1: Check if schema_versions table exists AND is HiDNS system
   const isHiDNSSystem = await checkHiDNSSystem(conn);
-  
+
   if (isHiDNSSystem) {
     // System is already initialized as HiDNS, check if users exist
-    log.info('DB', 'HiDNS system detected via schema_versions');
-    
+    log.info('HiDNS system detected via schema_versions');
+
     const hasUsers = await checkUsersExist(conn);
     if (!hasUsers) {
-      log.warn('DB', 'HiDNS system found but no users exist, entering initialization mode');
-      log.info('DB', 'Please complete the web initialization wizard to create admin user');
+      log.warn('HiDNS system found but no users exist, entering initialization mode');
+      log.info('Please complete the web initialization wizard to create admin user');
       return;
     }
-    
-    log.info('DB', 'HiDNS system fully initialized, running migration checks...');
+
+    log.info('HiDNS system fully initialized, running migration checks...');
     // Continue to migration handling below - will call initSchemaAsync
   } else {
     // Not a HiDNS system, check if it's a legacy system or first-time setup
-    
+
     // Step 2: Check if this is a legacy system that needs migration detection
     const isLegacySystem = await checkLegacySystem(conn);
-    
+
     if (isLegacySystem) {
-      log.info('DB', 'Legacy system detected, running migration detection...');
+      log.info('Legacy system detected, running migration detection...');
       // Migration will be handled by handleMySQLMigrations/handleSQLiteMigrations
       // which includes auto-detection and promotion logic
       return;
     }
-    
+
     // Step 3: First-time initialization - create all tables
-    log.info('DB', 'First-time initialization, creating schema...');
+    log.info('First-time initialization, creating schema...');
 
     switch (type) {
       case 'mysql':
@@ -76,16 +77,16 @@ export async function initSchema(): Promise<void> {
         await initSQLiteSchema(conn);
         break;
     }
-    
-    log.info('DB', 'Initial schema setup complete');
+
+    log.info('Initial schema setup complete');
     // DO NOT return here! Continue to migration checks to handle legacy databases
   }
 
   // Step 4: Run DSM for HiDNS systems
-  log.info('DB', 'Running DSM reconciliation...');
+  log.info('Running DSM reconciliation...');
   await initializeDSM();
-  
-  log.info('DB', 'DSM reconciliation completed');
+
+  log.info('DSM reconciliation completed');
 }
 
 /**
@@ -95,47 +96,47 @@ async function checkHiDNSSystem(conn: DatabaseConnection): Promise<boolean> {
   try {
     const dbType = conn.type;
     let sql = '';
-    
+
     switch (dbType) {
       case 'mysql':
-        sql = `SELECT COUNT(*) as count FROM information_schema.tables 
+        sql = `SELECT COUNT(*) as count FROM information_schema.tables
                WHERE table_schema = DATABASE() AND table_name = 'schema_versions'`;
         break;
       case 'postgresql':
-        sql = `SELECT COUNT(*) as count FROM information_schema.tables 
+        sql = `SELECT COUNT(*) as count FROM information_schema.tables
                WHERE table_name = 'schema_versions'`;
         break;
       case 'sqlite':
-        sql = `SELECT COUNT(*) as count FROM sqlite_master 
+        sql = `SELECT COUNT(*) as count FROM sqlite_master
                WHERE type='table' AND name='schema_versions'`;
         break;
     }
-    
+
     const result = await conn.execute(sql);
     if (Array.isArray(result) && result.length > 0) {
       const count = (result[0] as any).count || (result[0] as any)['COUNT(*)'];
       const tableExists = parseInt(String(count), 10) > 0;
-      
+
       if (!tableExists) {
         return false;
       }
-      
+
       // Table exists, check if it has HiDNS marker
       const versionCheck = await conn.execute(
         "SELECT COUNT(*) as count FROM schema_versions WHERE system_type = 'hidns' LIMIT 1"
       );
-      
+
       if (Array.isArray(versionCheck) && versionCheck.length > 0) {
         const versionCount = (versionCheck[0] as any).count || (versionCheck[0] as any)['COUNT(*)'];
         return parseInt(String(versionCount), 10) > 0;
       }
-      
+
       return false;
     }
-    
+
     return false;
   } catch (error) {
-    log.debug('DB', 'HiDNS system check failed', { error: (error as Error).message });
+    log.debug('HiDNS system check failed', { error: (error as Error).message });
     return false;
   }
 }
@@ -152,7 +153,7 @@ async function checkUsersExist(conn: DatabaseConnection): Promise<boolean> {
     }
     return false;
   } catch (error) {
-    log.warn('DB', 'Failed to check users table', { error: (error as Error).message });
+    log.warn('Failed to check users table', { error: (error as Error).message });
     return false;
   }
 }
@@ -164,35 +165,35 @@ async function checkUsersExist(conn: DatabaseConnection): Promise<boolean> {
 async function checkLegacySystem(conn: DatabaseConnection): Promise<boolean> {
   try {
     const dbType = conn.type;
-    
+
     // Check for 4 critical tables:
     // 1. domains (域名列表)
     // 2. users (用户列表)
     // 3. ns_monitor_domains (NS表)
     // 4. whois_cache (WHOIS缓存表)
-    
+
     const requiredTables = ['domains', 'users', 'ns_monitor_domains', 'whois_cache'];
     let existingCount = 0;
-    
+
     for (const tableName of requiredTables) {
       const exists = await checkTableExists(conn, tableName);
       if (exists) {
         existingCount++;
       }
     }
-    
+
     // If all 4 tables exist but schema_versions doesn't, it's a legacy system
     const isLegacy = existingCount === requiredTables.length;
-    
+
     if (isLegacy) {
-      log.info('DB', `Legacy system detected: all ${requiredTables.length} core tables exist`);
+      log.info(`Legacy system detected: all ${requiredTables.length} core tables exist`);
     } else {
-      log.debug('DB', `Not a legacy system: ${existingCount}/${requiredTables.length} core tables found`);
+      log.debug(`Not a legacy system: ${existingCount}/${requiredTables.length} core tables found`);
     }
-    
+
     return isLegacy;
   } catch (error) {
-    log.warn('DB', 'Failed to check legacy system status', { error: (error as Error).message });
+    log.warn('Failed to check legacy system status', { error: (error as Error).message });
     return false;
   }
 }
@@ -204,41 +205,41 @@ async function checkTableExists(conn: DatabaseConnection, tableName: string): Pr
   try {
     // Whitelist validation to prevent SQL injection
     const allowedTables = [
-      'users', 'dns_accounts', 'domains', 'domain_records', 'teams', 
+      'users', 'dns_accounts', 'domains', 'domain_records', 'teams',
       'team_members', 'team_accounts', 'api_tokens', 'token_domain_permissions',
       'domain_permissions', 'oauth_states', 'audit_logs', 'security_policies',
       'trusted_devices', 'renewable_domains', 'ns_monitors', 'rdap_cache',
       'system_cache', 'password_resets'
     ];
-    
+
     if (!allowedTables.includes(tableName)) {
       throw new Error(`Invalid table name: ${tableName}`);
     }
-    
+
     const dbType = conn.type;
     let sql = '';
-    
+
     switch (dbType) {
       case 'mysql':
-        sql = `SELECT COUNT(*) as count FROM information_schema.tables 
+        sql = `SELECT COUNT(*) as count FROM information_schema.tables
                WHERE table_schema = DATABASE() AND table_name = ?`;
         break;
       case 'postgresql':
-        sql = `SELECT COUNT(*) as count FROM information_schema.tables 
+        sql = `SELECT COUNT(*) as count FROM information_schema.tables
                WHERE table_name = ?`;
         break;
       case 'sqlite':
-        sql = `SELECT COUNT(*) as count FROM sqlite_master 
+        sql = `SELECT COUNT(*) as count FROM sqlite_master
                WHERE type='table' AND name=?`;
         break;
     }
-    
+
     const result = await conn.execute(sql, [tableName]);
     if (Array.isArray(result) && result.length > 0) {
       const count = (result[0] as any).count || (result[0] as any)['COUNT(*)'];
       return parseInt(String(count), 10) > 0;
     }
-    
+
     return false;
   } catch (error) {
     return false;
@@ -252,31 +253,31 @@ async function checkVersionTableExists(conn: DatabaseConnection): Promise<boolea
   try {
     const dbType = conn.type;
     let sql = '';
-    
+
     switch (dbType) {
       case 'mysql':
-        sql = `SELECT COUNT(*) as count FROM information_schema.tables 
+        sql = `SELECT COUNT(*) as count FROM information_schema.tables
                WHERE table_schema = DATABASE() AND table_name = 'schema_versions'`;
         break;
       case 'postgresql':
-        sql = `SELECT COUNT(*) as count FROM information_schema.tables 
+        sql = `SELECT COUNT(*) as count FROM information_schema.tables
                WHERE table_name = 'schema_versions'`;
         break;
       case 'sqlite':
-        sql = `SELECT COUNT(*) as count FROM sqlite_master 
+        sql = `SELECT COUNT(*) as count FROM sqlite_master
                WHERE type='table' AND name='schema_versions'`;
         break;
     }
-    
+
     const result = await conn.execute(sql);
     if (Array.isArray(result) && result.length > 0) {
       const count = (result[0] as any).count || (result[0] as any)['COUNT(*)'];
       return parseInt(String(count), 10) > 0;
     }
-    
+
     return false;
   } catch (error) {
-    log.debug('DB', 'schema_versions table does not exist', { error: (error as Error).message });
+    log.debug('schema_versions table does not exist', { error: (error as Error).message });
     return false;
   }
 }
@@ -293,12 +294,12 @@ async function initSQLiteSchema(conn: DatabaseConnection): Promise<void> {
     // 先检查列是否存在，避免不必要的 SQL 执行
     const columns = await conn.query('PRAGMA table_info(dns_accounts)') as any[];
     const hasEnabledColumn = columns.some((col: any) => col.name.replace(/["'`]/g, '') === 'enabled');
-    
+
     if (!hasEnabledColumn) {
       await conn.execute("ALTER TABLE dns_accounts ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1");
-      log.info('DB', 'Added enabled column to dns_accounts table');
+      log.info('Added enabled column to dns_accounts table');
     } else {
-      log.debug('DB', 'enabled column already exists in dns_accounts table');
+      log.debug('enabled column already exists in dns_accounts table');
     }
   } catch (e) {
     // 如果 PRAGMA 查询失败，回退到旧的方式
@@ -312,7 +313,7 @@ async function initSQLiteSchema(conn: DatabaseConnection): Promise<void> {
     await conn.execute(sql);
   }
 
-  log.info('DB', 'SQLite schema initialized');
+  log.info('SQLite schema initialized');
 }
 
 async function initMySQLSchema(conn: DatabaseConnection): Promise<void> {
@@ -335,7 +336,7 @@ async function initMySQLSchema(conn: DatabaseConnection): Promise<void> {
     }
   }
 
-  log.info('DB', 'MySQL schema initialized');
+  log.info('MySQL schema initialized');
 }
 
 async function initPostgreSQLSchema(conn: DatabaseConnection): Promise<void> {
@@ -351,5 +352,5 @@ async function initPostgreSQLSchema(conn: DatabaseConnection): Promise<void> {
     }
   }
 
-  log.info('DB', 'PostgreSQL schema initialized');
+  log.info('PostgreSQL schema initialized');
 }

--- a/server/src/lib/dns/DnsHelper.ts
+++ b/server/src/lib/dns/DnsHelper.ts
@@ -8,7 +8,9 @@ import {
   getProviderInfoList,
   providerDefinitionMap,
 } from './providers/registry';
-import { log } from '../logger';
+import { createLogger } from '../logger';
+
+const log = createLogger('DNS').sub('Helper');
 
 export type { ProviderCapabilities, ProviderConfigField, ProviderInfo };
 
@@ -55,13 +57,13 @@ function createLoggingAdapter(adapter: DnsAdapter, providerType: string): DnsAda
       const methodName = String(prop);
       return async (...args: unknown[]) => {
         const start = Date.now();
-        log.providerRequest(providerType, methodName, '', sanitizeArgs(args));
+        log.sub('AdapterProxy').sub(providerType).sub(methodName).tag('CALL').debug('Adapter method called', { args: sanitizeArgs(args) });
         try {
           const result = await original.apply(target, args);
-          log.providerResponse(providerType, Date.now() - start, true, { method: methodName });
+          log.sub('AdapterProxy').sub(providerType).sub(methodName).tag('SUCCESS').debug('Adapter method completed', { durationMs: Date.now() - start });
           return result;
         } catch (e) {
-          log.providerError(providerType, { method: methodName, error: e instanceof Error ? e.message : String(e) });
+          log.sub('AdapterProxy').sub(providerType).sub(methodName).tag('FAILED').error('Adapter method failed', { durationMs: Date.now() - start, error: e });
           throw e;
         }
       };
@@ -85,12 +87,12 @@ export function createAdapter(type: string, config: Record<string, string>, doma
 
   // 对于腾讯 EO 适配器，设置 Zone ID 和域名
   if (type === 'tencenteo' && adapter instanceof TencenteoAdapter) {
-    log.debug('DnsHelper', 'Creating TencentEO adapter', { domain, zoneId, hasZoneId: !!zoneId, hasDomain: !!domain });
+    log.sub('AdapterFactory').sub('TencentEO').debug('Creating adapter', { domain, zoneId, hasZoneId: !!zoneId, hasDomain: !!domain });
     if (zoneId && domain) {
       adapter.setZoneInfo(zoneId, domain);
-      log.debug('DnsHelper', 'TencentEO adapter ZoneInfo set', { zoneId, domain });
+      log.sub('AdapterFactory').sub('TencentEO').tag('SUCCESS').debug('ZoneInfo set', { zoneId, domain });
     } else {
-      log.warn('DnsHelper', 'TencentEO adapter missing zoneId or domain', { zoneId, domain });
+      log.sub('AdapterFactory').sub('TencentEO').tag('VALIDATION').warn('Missing zoneId or domain', { zoneId, domain });
     }
   }
 

--- a/server/src/lib/dns/ns-lookup.ts
+++ b/server/src/lib/dns/ns-lookup.ts
@@ -5,9 +5,10 @@
  */
 
 import { dnsResolver, DNSQueryType, DNSResolverResult } from './resolver';
-import { log } from '../logger';
+import { createLogger } from '../logger';
 import { normalizeDomain } from '../../utils/domain';
 
+const log = createLogger('DNS').sub('NsLookup');
 // 查询超时时间（毫秒）
 const DNS_TIMEOUT = 10000;
 
@@ -30,7 +31,7 @@ export async function resolveNsRecords(domain: string): Promise<NSLookupResult> 
   const normalizedDomain = normalizeDomain(domain).replace(/\.$/, '');
 
   if (!normalizedDomain || normalizedDomain.includes(' ')) {
-    log.warn('NSLookup', 'Invalid domain provided', { domain, normalizedDomain });
+    log.warn('Invalid domain provided', { domain, normalizedDomain });
     return { nsRecords: [], isPoisoned: false };
   }
 
@@ -39,7 +40,7 @@ export async function resolveNsRecords(domain: string): Promise<NSLookupResult> 
     const validationResult = await dnsResolver.resolveNSWithValidation(normalizedDomain);
 
     if (validationResult.nsRecords.length > 0) {
-      log.info('NSLookup', 'NS records resolved', {
+      log.info('NS records resolved', {
         domain: normalizedDomain,
         count: validationResult.nsRecords.length,
         servers: validationResult.nsRecords,
@@ -57,7 +58,7 @@ export async function resolveNsRecords(domain: string): Promise<NSLookupResult> 
     }
 
     // 如果没有 NS 记录，尝试查询 A 记录（可能是子域名）
-    log.debug('NSLookup', 'No NS records found, trying A record', {
+    log.debug('No NS records found, trying A record', {
       domain: normalizedDomain,
     });
 
@@ -68,7 +69,7 @@ export async function resolveNsRecords(domain: string): Promise<NSLookupResult> 
     });
 
     if (aResult.success && aResult.records && aResult.records.length > 0) {
-      log.info('NSLookup', 'A records found (subdomain)', {
+      log.info('A records found (subdomain)', {
         domain: normalizedDomain,
         ips: aResult.records.map(r => r.data),
         source: aResult.source,
@@ -77,14 +78,14 @@ export async function resolveNsRecords(domain: string): Promise<NSLookupResult> 
       return { nsRecords: [], isPoisoned: false };
     }
   } catch (error) {
-    log.error('NSLookup', 'DNS resolution failed', {
+    log.error('DNS resolution failed', {
       domain: normalizedDomain,
       error: error instanceof Error ? error.message : String(error),
     });
   }
 
   // 所有查询都失败
-  log.error('NSLookup', 'Failed to resolve NS records', {
+  log.error('Failed to resolve NS records', {
     domain: normalizedDomain,
   });
 
@@ -164,7 +165,7 @@ export async function resolveNsRecordsBatch(domains: string[]): Promise<Map<stri
 
   const poisonedCount = Array.from(results.values()).filter(r => r.isPoisoned).length;
 
-  log.info('NSLookup', 'Batch NS resolution completed', {
+  log.info('Batch NS resolution completed', {
     total: domains.length,
     successful: Array.from(results.values()).filter(r => r.nsRecords.length > 0).length,
     poisoned: poisonedCount,

--- a/server/src/lib/dns/providers/_example/adapter.ts
+++ b/server/src/lib/dns/providers/_example/adapter.ts
@@ -1,9 +1,10 @@
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, fetchWithFallback, resolveDomainIdHelper, normalizeRrName, safeString, toNumber, Dict } from '../internal';
 /**
  * Example DNS Provider Adapter - 示例 DNS 提供商适配器
- * 
+ *
  * 这个文件展示了如何实现一个新的 DNS 提供商适配器。
  * 复制此文件并重命名，然后按照注释实现各个方法。
- * 
+ *
  * 实现步骤：
  * 1) 定义配置接口（Config Interface）
  * 2) 实现适配器类，继承 BaseAdapter
@@ -12,12 +13,9 @@
  * 5) 在 index.ts 中导出适配器
  */
 
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
-import { resolveDomainIdHelper, normalizeRrName, safeString, toNumber, Dict } from '../internal';
 import { buildAuthHeaders, authenticatedRequest, type ExampleAuthConfig } from './auth';
 
+const log = createProviderAdapterLogger('Example');
 // ==================== 配置接口示例 ====================
 
 /**
@@ -84,8 +82,8 @@ export class ExampleAdapter implements DnsAdapter {
       body = JSON.stringify(params);
     }
 
-    log.providerRequest('Example', method, url);
-    
+    log.sub('API').tag('REQUEST').debug('Provider request', { method: method, url: url, params: undefined });
+
     const options: RequestInit = {
       method,
       headers: buildAuthHeaders(this.config),
@@ -153,7 +151,7 @@ export class ExampleAdapter implements DnsAdapter {
       return { total: data.total || list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Example', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/_example/auth.ts
+++ b/server/src/lib/dns/providers/_example/auth.ts
@@ -1,9 +1,10 @@
+import { fetchWithFallback } from '../internal';
 /**
  * Example Provider Authentication - 示例提供商认证模块
- * 
+ *
  * 这个文件展示了如何实现 DNS 提供商的认证逻辑。
  * 复制此文件并重命名，然后按照注释实现各个方法。
- * 
+ *
  * 实现步骤：
  * 1) 定义认证配置接口（AuthConfig Interface）
  * 2) 实现 buildAuthHeaders：构建认证请求头
@@ -11,14 +12,13 @@
  * 4) 实现 validateCredentials：验证凭证有效性
  */
 
-import { fetchWithFallback } from '../internal';
 
 // ==================== 认证配置接口 ====================
 
 /**
  * 认证配置接口
  * 根据提供商的认证要求定义所需字段
- * 
+ *
  * 常见认证方式：
  * 1. API Key + Secret: apiKey, apiSecret
  * 2. Bearer Token: apiToken
@@ -37,20 +37,20 @@ export interface ExampleAuthConfig {
 /**
  * 构建认证请求头
  * 根据提供商的认证要求设置头部
- * 
+ *
  * 常见认证方式示例：
- * 
+ *
  * 1. Bearer Token:
  *    headers['Authorization'] = `Bearer ${config.apiToken}`;
- * 
+ *
  * 2. Basic Auth:
  *    const credentials = Buffer.from(`${username}:${password}`).toString('base64');
  *    headers['Authorization'] = `Basic ${credentials}`;
- * 
+ *
  * 3. Custom Headers:
  *    headers['X-API-Key'] = config.apiKey;
  *    headers['X-API-Secret'] = config.apiSecret;
- * 
+ *
  * 4. Query Parameters (在 authenticatedRequest 中处理):
  *    将认证参数添加到 URL 查询字符串中
  */
@@ -65,7 +65,7 @@ export function buildAuthHeaders(config: ExampleAuthConfig): Record<string, stri
 /**
  * 发送认证请求
  * 使用认证配置发送 HTTP 请求
- * 
+ *
  * @param url 请求 URL
  * @param config 认证配置
  * @param options 请求选项
@@ -95,7 +95,7 @@ export async function authenticatedRequest(
 /**
  * 验证凭证有效性
  * 通过调用提供商 API 验证凭证是否正确
- * 
+ *
  * @param config 认证配置
  * @returns 凭证是否有效
  */
@@ -105,7 +105,7 @@ export async function validateCredentials(config: ExampleAuthConfig): Promise<bo
     // 通常调用一个简单的 API，如获取域名列表或用户信息
     const baseUrl = 'https://api.example.com/v1';
     const url = `${baseUrl}/user/info`;
-    
+
     const response = await authenticatedRequest(url, config, {
       method: 'GET',
     });
@@ -135,7 +135,7 @@ export function generateSignature(params: Record<string, string>, secret: string
   // 按字母顺序排序参数
   const sortedKeys = Object.keys(params).sort();
   const queryString = sortedKeys.map(key => `${key}=${params[key]}`).join('&');
-  
+
   // 生成 HMAC-SHA256 签名
   return crypto
     .createHmac('sha256', secret)

--- a/server/src/lib/dns/providers/aliyun/adapter.ts
+++ b/server/src/lib/dns/providers/aliyun/adapter.ts
@@ -1,17 +1,6 @@
-import { 
-  DnsRecord, 
-  DomainInfo, 
-  PageResult,
-  AliyunRpcAdapter,
-  asArray,
-  Dict,
-  normalizeRrName,
-  safeString,
-  toNumber,
-  toRecordStatus,
-  log,
-} from '../internal';
+import { createProviderAdapterLogger, DnsRecord, DomainInfo, PageResult, AliyunRpcAdapter, asArray, Dict, normalizeRrName, safeString, toNumber, toRecordStatus } from '../internal';
 
+const log = createProviderAdapterLogger('Aliyun');
 export class AliyunAdapter extends AliyunRpcAdapter {
   private readonly domain: string;
 
@@ -83,7 +72,7 @@ export class AliyunAdapter extends AliyunRpcAdapter {
       return { total: toNumber(data.TotalCount, list.length), list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Aliyun', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/aliyunesa/adapter.ts
+++ b/server/src/lib/dns/providers/aliyunesa/adapter.ts
@@ -1,9 +1,7 @@
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, asArray, BaseAdapter, Dict, normalizeRrName, resolveDomainIdHelper, safeString, toNumber, toRecordStatus, uuid, fetchWithFallback } from '../internal';
 import crypto from 'node:crypto';
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { asArray, BaseAdapter, Dict, normalizeRrName, resolveDomainIdHelper, safeString, toNumber, toRecordStatus, uuid } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('AliyunESA');
 class AliyunEsaRpcClient {
   private useProxy: boolean;
   constructor(
@@ -122,7 +120,7 @@ export class AliyunesaAdapter extends BaseAdapter {
       return { total: toNumber(data.TotalCount, list.length), list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Aliyunesa', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/baidu/adapter.ts
+++ b/server/src/lib/dns/providers/baidu/adapter.ts
@@ -1,9 +1,7 @@
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, asArray, BaseAdapter, Dict, normalizeRrName, safeString, toNumber, toRecordStatus, uuid, fetchWithFallback } from '../internal';
 import crypto from 'node:crypto';
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { asArray, BaseAdapter, Dict, normalizeRrName, safeString, toNumber, toRecordStatus, uuid } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('Baidu');
 class BaiduCloudClient {
   private readonly useProxy: boolean;
 
@@ -181,7 +179,7 @@ export class BaiduAdapter extends BaseAdapter {
       return { total: list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Baidu', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/bt/adapter.ts
+++ b/server/src/lib/dns/providers/bt/adapter.ts
@@ -1,9 +1,7 @@
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, BaseAdapter, Dict, resolveDomainIdHelper, safeString, toNumber, fetchWithFallback } from '../internal';
 import crypto from 'node:crypto';
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { BaseAdapter, Dict, resolveDomainIdHelper, safeString, toNumber } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('Bt');
 interface BtConfig {
   AccountID: string;
   AccessKey: string;
@@ -86,7 +84,7 @@ export class BtAdapter extends BaseAdapter {
       return { total: data.total || list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Bt', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }
@@ -105,21 +103,21 @@ export class BtAdapter extends BaseAdapter {
     }
 
     try {
-      log.debug('Bt', `Resolving domainId for domain: ${this.config.domain}`);
+      log.debug(`Resolving domainId for domain: ${this.config.domain}`);
       const result = await this.getDomainList(this.config.domain, 1, 1);
       if (result.list.length > 0) {
         const thirdId = result.list[0].ThirdId;
         const parts = thirdId.split('|');
         const domainId = parts[0];
         const domainType = parts[1] || '1';
-        log.debug('Bt', `Resolved domainId: ${domainId}, domainType: ${domainType} for domain: ${this.config.domain}`);
+        log.debug(`Resolved domainId: ${domainId}, domainType: ${domainType} for domain: ${this.config.domain}`);
         // 缓存 domainId 和 domainType 避免重复查询
         this.config.domainId = domainId;
         this.config.domainType = domainType;
         return domainId;
       }
     } catch (error) {
-      log.error('Bt', `Failed to resolve domainId for domain: ${this.config.domain}`, { error });
+      log.error(`Failed to resolve domainId for domain: ${this.config.domain}`, { error });
     }
 
     return null;

--- a/server/src/lib/dns/providers/caihongdns/adapter.ts
+++ b/server/src/lib/dns/providers/caihongdns/adapter.ts
@@ -1,9 +1,7 @@
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { log } from '../internal';
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, fetchWithFallback, resolveDomainIdHelper } from '../internal';
 import crypto from 'crypto';
-import { fetchWithFallback } from '../internal';
-import { resolveDomainIdHelper } from '../internal';
 
+const log = createProviderAdapterLogger('CaihongDns');
 interface CaihongDnsConfig {
   baseUrl: string;
   uid: string;
@@ -88,7 +86,7 @@ export class CaihongDnsAdapter implements DnsAdapter {
     const url = `${baseUrl}/api${normalizedPath}`;
     const authParams = this.getAuthParams();
 
-    log.providerRequest('CaihongDns', method, url, { ...body, ...authParams, sign: '***' });
+    log.sub('API').tag('REQUEST').debug('Provider request', { method: method, url: url, params: { ...body, ...authParams, sign: '***' } });
 
     try {
       const headers: Record<string, string> = {
@@ -126,23 +124,23 @@ export class CaihongDnsAdapter implements DnsAdapter {
       } catch (parseError) {
         // If JSON parsing fails, return error with raw response
         const errorMsg = `Invalid JSON response: ${responseText.substring(0, 200)}`;
-        log.providerError('CaihongDns', [{ message: errorMsg }]);
+        log.sub('API').tag('ERROR').error('Provider error', [{ message: errorMsg }]);
         return { code: -1, msg: errorMsg };
       }
 
       // Check if response has error code
       const hasError = data.code !== undefined && data.code !== 0;
-      log.providerResponse('CaihongDns', res.status, !hasError, { code: data.code, msg: data.msg, hasData: data.rows !== undefined });
+      log.sub('API').tag('RESPONSE').debug('Provider response', { status: res.status, success: !hasError, data: { code: data.code, msg: data.msg, hasData: data.rows !== undefined } });
 
       if (hasError) {
         this.error = data.msg || 'API error';
-        log.providerError('CaihongDns', [{ message: this.error }]);
+        log.sub('API').tag('ERROR').error('Provider error', [{ message: this.error }]);
       }
 
       return data;
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.providerError('CaihongDns', [{ message: this.error }]);
+      log.sub('API').tag('ERROR').error('Provider error', [{ message: this.error }]);
       return { code: -1, msg: this.error };
     }
   }

--- a/server/src/lib/dns/providers/cloudflare/adapter.ts
+++ b/server/src/lib/dns/providers/cloudflare/adapter.ts
@@ -1,13 +1,7 @@
-﻿import { 
-  DnsAdapter, 
-  DnsRecord, 
-  DomainInfo, 
-  PageResult,
-  resolveDomainIdHelper,
-  log,
-} from '../internal';
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, resolveDomainIdHelper } from '../internal';
 import { buildAuthHeaders, authenticatedRequest, type CloudflareAuthConfig } from './auth';
 
+const log = createProviderAdapterLogger('Cloudflare');
 interface CfZone {
   id: string;
   name: string;
@@ -56,37 +50,37 @@ export class CloudflareAdapter implements DnsAdapter {
 
   private async request<T>(method: string, path: string, body?: unknown): Promise<CfApiResponse<T>> {
     const url = `${this.baseUrl}${path}`;
-    log.providerRequest('Cloudflare', method, url, body);
-    
+    log.sub('API').tag('REQUEST').debug('Provider request', { method: method, url: url, params: body });
+
     const options: RequestInit = {
       method,
       body: body ? JSON.stringify(body) : undefined,
     };
-    
+
     // authenticatedRequest 会自动添加授权头
     const res = await authenticatedRequest(url, this.config, options);
     const data = (await res.json()) as CfApiResponse<T>;
-    log.providerResponse('Cloudflare', res.status, data.success, { resultCount: Array.isArray(data.result) ? data.result.length : 0 });
+    log.sub('API').tag('RESPONSE').debug('Provider response', { status: res.status, success: data.success, data: { resultCount: Array.isArray(data.result) ? data.result.length : 0 } });
     if (!data.success) {
       // Log detailed error information
       if (data.errors?.length) {
         this.error = data.errors[0].message;
-        log.providerError('Cloudflare', {
+        log.sub('API').tag('ERROR').error('Provider error', {
           status: res.status,
           errors: data.errors.map((e) => e.message),
         });
       } else if (res.status === 404) {
         this.error = `Resource not found (404): ${path}`;
-        log.providerError('Cloudflare', { 
-          status: 404, 
-          path, 
+        log.sub('API').tag('ERROR').error('Provider error', {
+          status: 404,
+          path,
           message: 'Zone or record not found',
           zoneId: this.config.zoneId,
           domain: this.config.domain
         });
       } else {
         this.error = `API request failed with status ${res.status}`;
-        log.providerError('Cloudflare', { status: res.status, path });
+        log.sub('API').tag('ERROR').error('Provider error', { status: res.status, path });
       }
     }
     return data;
@@ -112,16 +106,16 @@ export class CloudflareAdapter implements DnsAdapter {
    */
   private async validateZone(zoneId: string): Promise<boolean> {
     try {
-      log.debug('Cloudflare', `Validating zone: ${zoneId}`);
+      log.debug(`Validating zone: ${zoneId}`);
       const res = await this.request<CfZone>('GET', `/zones/${zoneId}`);
       if (!res.success) {
-        log.warn('Cloudflare', `Zone validation failed:`, res.errors);
+        log.warn(`Zone validation failed:`, res.errors);
         return false;
       }
-      log.debug('Cloudflare', `Zone validated successfully: ${res.result.name} (${zoneId})`);
+      log.debug(`Zone validated successfully: ${res.result.name} (${zoneId})`);
       return true;
     } catch (e) {
-      log.error('Cloudflare', `Zone validation error:`, e);
+      log.error(`Zone validation error:`, e);
       return false;
     }
   }
@@ -131,12 +125,12 @@ export class CloudflareAdapter implements DnsAdapter {
    * 当 config.zoneId 未设置时，尝试通过域名搜索获取
    */
   private async resolveZoneId(): Promise<string | null> {
-    log.debug('Cloudflare', `resolveZoneId called. Current config:`, {
+    log.debug(`resolveZoneId called. Current config:`, {
       zoneId: this.config.zoneId,
       domainId: (this.config as any).domainId,
       domain: this.config.domain
     });
-    
+
     // 如果已有 zoneId，先验证其格式是否正确
     const existingZoneId = this.config.zoneId || (this.config as any).domainId;
     if (existingZoneId) {
@@ -144,27 +138,27 @@ export class CloudflareAdapter implements DnsAdapter {
       // 如果是 32 位且看起来像 MD5（全部小写），可能需要重新获取
       const isValidFormat = /^[a-f0-9]{32,40}$/i.test(existingZoneId);
       if (!isValidFormat) {
-        log.warn('Cloudflare', `Existing zoneId has invalid format: ${existingZoneId}. Will attempt to fetch from API.`);
+        log.warn(`Existing zoneId has invalid format: ${existingZoneId}. Will attempt to fetch from API.`);
         // 清除无效的 zoneId，强制重新获取
         this.config.zoneId = undefined;
         (this.config as any).domainId = undefined;
       }
     }
-    
+
     return resolveDomainIdHelper(this.config, this.getDomainList.bind(this), 'Cloudflare');
   }
 
   async getDomainList(keyword?: string, page = 1, pageSize = 50): Promise<PageResult<DomainInfo>> {
     let path = `/zones?page=${page}&per_page=${pageSize}`;
     if (keyword) path += `&name=${encodeURIComponent(keyword)}`;
-    log.debug('Cloudflare', `getDomainList: page=${page}, pageSize=${pageSize}, keyword=${keyword || 'none'}`);
+    log.debug(`getDomainList: page=${page}, pageSize=${pageSize}, keyword=${keyword || 'none'}`);
     const res = await this.request<CfZone[]>('GET', path);
     if (!res.success) {
-      log.error('Cloudflare', 'getDomainList failed', res.errors);
+      log.error('getDomainList failed', res.errors);
       return { total: 0, list: [] };
     }
     const total = res.result_info?.total_count ?? res.result.length;
-    log.debug('Cloudflare', `getDomainList success: total=${total}, returned=${res.result.length}`);
+    log.debug(`getDomainList success: total=${total}, returned=${res.result.length}`);
     return {
       total,
       list: res.result.map((z) => ({
@@ -186,25 +180,25 @@ export class CloudflareAdapter implements DnsAdapter {
     _status?: number
   ): Promise<PageResult<DnsRecord>> {
     const zoneId = await this.resolveZoneId();
-    log.debug('Cloudflare', `getDomainRecords: zoneId=${zoneId || 'null'}, domain=${this.config.domain}, page=${page}, pageSize=${pageSize}`);
+    log.debug(`getDomainRecords: zoneId=${zoneId || 'null'}, domain=${this.config.domain}, page=${page}, pageSize=${pageSize}`);
     if (!zoneId) {
-      log.warn('Cloudflare', `getDomainRecords: zoneId is null, returning empty result. Config:`, {
+      log.warn(`getDomainRecords: zoneId is null, returning empty result. Config:`, {
         zoneId: this.config.zoneId,
         domainId: (this.config as any).domainId,
         domain: this.config.domain
       });
       return { total: 0, list: [] };
     }
-    
+
     // 先验证 Zone ID 是否有效
-    log.debug('Cloudflare', `Validating zoneId: ${zoneId} for domain: ${this.config.domain}`);
+    log.debug(`Validating zoneId: ${zoneId} for domain: ${this.config.domain}`);
     const zoneValid = await this.validateZone(zoneId);
     if (!zoneValid) {
-      log.error('Cloudflare', `Zone validation failed for zoneId: ${zoneId}. The zone may not exist or API token may lack permissions.`);
+      log.error(`Zone validation failed for zoneId: ${zoneId}. The zone may not exist or API token may lack permissions.`);
       this.error = `Zone validation failed. Please check if zoneId '${zoneId}' is correct and API token has proper permissions.`;
       return { total: 0, list: [] };
     }
-    
+
     let path = `/zones/${zoneId}/dns_records?page=${page}&per_page=${pageSize}`;
     if (type) path += `&type=${encodeURIComponent(type)}`;
     // Cloudflare requires full record name for filtering (including zone name).

--- a/server/src/lib/dns/providers/common.ts
+++ b/server/src/lib/dns/providers/common.ts
@@ -1,4 +1,4 @@
-﻿import crypto from 'node:crypto';
+import crypto from 'node:crypto';
 import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../DnsInterface';
 import {
   Dict,
@@ -6,7 +6,9 @@ import {
   hmacSignSha1,
   requestJson,
 } from './http';
-import { log } from '../../logger';
+import { createLogger } from '../../logger';
+
+const log = createLogger('DNS').sub('Provider').sub('Common');
 
 export type { Dict };
 
@@ -91,24 +93,24 @@ export async function resolveDomainIdHelper(
   }
 
   try {
-    log.debug(providerName, `Resolving domainId for domain: ${config.domain}`);
+    log.sub(providerName).debug(`Resolving domainId for domain: ${config.domain}`);
     const result = await getDomainList(config.domain, 1, 1);
     if (result.list.length > 0) {
       const domainId = result.list[0].ThirdId;
-      log.debug(providerName, `Resolved domainId: ${domainId} for domain: ${config.domain}`);
+      log.sub(providerName).debug(`Resolved domainId: ${domainId} for domain: ${config.domain}`);
       // 缓存 domainId 避免重复查询
       config.domainId = domainId;
       return domainId;
     } else {
-      log.warn(providerName, `No domain found for: ${config.domain}. Available domains will be listed.`);
+      log.sub(providerName).warn(`No domain found for: ${config.domain}. Available domains will be listed.`);
       // 尝试列出所有域名帮助调试
       const allDomains = await getDomainList(undefined, 1, 10);
       if (allDomains.list.length > 0) {
-        log.warn(providerName, `Available domains:`, allDomains.list.map(d => d.Domain).join(', '));
+        log.sub(providerName).warn('Available domains', { domains: allDomains.list.map(d => d.Domain).join(', ') });
       }
     }
   } catch (error) {
-    log.error(providerName, `Failed to resolve domainId for domain: ${config.domain}`, { error });
+    log.sub(providerName).error(`Failed to resolve domainId for domain: ${config.domain}`, { error });
   }
 
   return null;
@@ -220,13 +222,13 @@ export abstract class AliyunRpcAdapter extends BaseAdapter {
     query.set('Signature', signature);
 
     const url = `${this.endpoint()}?${query.toString()}`;
-    log.providerRequest('Aliyun', 'GET', url);
+    log.sub('API').tag('REQUEST').debug('Provider request', { method: 'GET', url: url, params: undefined });
     const result = await requestJson<T>(url, {
       method: 'GET',
       parseError: (payload) => {
         const data = (payload ?? {}) as Dict;
         if (data.Code || data.Message) {
-          log.providerError('Aliyun', data);
+          log.sub('API').tag('ERROR').error('Provider error', data);
           return safeString(data.Message) || safeString(data.Code) || `Aliyun action ${action} failed`;
         }
         return undefined;
@@ -234,7 +236,7 @@ export abstract class AliyunRpcAdapter extends BaseAdapter {
       useProxy: this.useProxy,
       providerName: 'Aliyun',
     });
-    log.providerResponse('Aliyun', 200, true, { action, hasData: result !== null });
+    log.sub('API').tag('RESPONSE').debug('Provider response', { status: 200, success: true, data: { action, hasData: result !== null } });
     return result;
   }
 }
@@ -296,7 +298,7 @@ export abstract class TencentCloudAdapter extends BaseAdapter {
       `SignedHeaders=${signedHeaders}, Signature=${signature}`;
 
     const url = `https://${host}`;
-    log.providerRequest('TencentCloud', 'POST', url, { action });
+    log.sub('API').tag('REQUEST').debug('Provider request', { method: 'POST', url: url, params: { action } });
     const data = await requestJson<Dict>(url, {
       method: 'POST',
       headers: {
@@ -317,10 +319,10 @@ export abstract class TencentCloudAdapter extends BaseAdapter {
     if (error) {
       const code = safeString(error?.Code);
       const msg = safeString(error?.Message) || `TencentCloud action ${action} failed`;
-      log.providerError('TencentCloud', error);
+      log.sub('API').tag('ERROR').error('Provider error', error);
       throw new Error(code ? `${code}: ${msg}` : msg);
     }
-    log.providerResponse('TencentCloud', 200, true, { action, hasData: response !== null });
+    log.sub('API').tag('RESPONSE').debug('Provider response', { status: 200, success: true, data: { action, hasData: response !== null } });
     return response as T;
   }
 }

--- a/server/src/lib/dns/providers/dnshe/adapter.ts
+++ b/server/src/lib/dns/providers/dnshe/adapter.ts
@@ -1,21 +1,8 @@
-import { 
-  DnsAdapter, 
-  DnsRecord, 
-  DomainInfo, 
-  PageResult,
-  asArray, 
-  Dict, 
-  normalizeRrName, 
-  safeString, 
-  BaseAdapter, 
-  toNumber, 
-  toRecordStatus,
-  log,
-  fetchWithFallback,
-} from '../internal';
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, asArray, Dict, normalizeRrName, safeString, BaseAdapter, toNumber, toRecordStatus, fetchWithFallback } from '../internal';
 import { renewSubdomain as renewSubdomainApi } from './renewal';
 import { getWhois as getWhoisApi } from './whois';
 
+const log = createProviderAdapterLogger('DNSHE');
 interface DnsheConfig {
   apiKey: string;
   apiSecret: string;
@@ -106,7 +93,7 @@ export class DnsheAdapter extends BaseAdapter implements DnsAdapter {
     queryParams?: Record<string, string | number>
   ): Promise<DnsheApiResponse<T>> {
     let url = `${this.baseUrl}?m=domain_hub&endpoint=${endpoint}&action=${action}`;
-    
+
     // Add query parameters for GET requests
     if (queryParams && method === 'GET') {
       const params = new URLSearchParams();
@@ -115,7 +102,7 @@ export class DnsheAdapter extends BaseAdapter implements DnsAdapter {
       });
       url += `&${params.toString()}`;
     }
-    
+
     const options: RequestInit = {
       method,
       headers: this.getHeaders(),
@@ -127,12 +114,12 @@ export class DnsheAdapter extends BaseAdapter implements DnsAdapter {
 
     const res = await fetchWithFallback(url, options, this.config.useProxy, 'DNSHE');
     const data = (await res.json()) as DnsheApiResponse<T>;
-    
+
     if (!data.success) {
       this.error = data.error || data.message || 'Unknown error';
-      log.error('DNSHE', `Request failed: ${endpoint}/${action}`, { error: this.error });
+      log.error(`Request failed: ${endpoint}/${action}`, { error: this.error });
     }
-    
+
     return data;
   }
 
@@ -155,7 +142,7 @@ export class DnsheAdapter extends BaseAdapter implements DnsAdapter {
         include_total: 1,
         ...(keyword && { search: keyword }),
       });
-      
+
       if (!res.success || !res.subdomains) {
         return { total: 0, list: [] };
       }
@@ -175,7 +162,7 @@ export class DnsheAdapter extends BaseAdapter implements DnsAdapter {
       return { total, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Dnshe', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }
@@ -193,7 +180,7 @@ export class DnsheAdapter extends BaseAdapter implements DnsAdapter {
     try {
       if (!this.config.subdomainId) {
         this.error = 'Subdomain ID not configured';
-        log.error('DNSHE', 'getDomainRecords failed: subdomainId not set');
+        log.error('getDomainRecords failed: subdomainId not set');
         return { total: 0, list: [] };
       }
 
@@ -205,9 +192,9 @@ export class DnsheAdapter extends BaseAdapter implements DnsAdapter {
         undefined,
         { subdomain_id: toNumber(this.config.subdomainId, 0) }
       );
-      
+
       if (!res.success || !res.records) {
-        log.error('DNSHE', 'getDomainRecords failed: API returned no records', { success: res.success });
+        log.error('getDomainRecords failed: API returned no records', { success: res.success });
         return { total: 0, list: [] };
       }
 
@@ -215,7 +202,7 @@ export class DnsheAdapter extends BaseAdapter implements DnsAdapter {
 
       if (keyword) {
         const lowerKeyword = keyword.toLowerCase();
-        list = list.filter((r) => 
+        list = list.filter((r) =>
           r.Name.toLowerCase().includes(lowerKeyword) ||
           r.Value.toLowerCase().includes(lowerKeyword)
         );
@@ -241,11 +228,11 @@ export class DnsheAdapter extends BaseAdapter implements DnsAdapter {
       const offset = (page - 1) * pageSize;
       list = list.slice(offset, offset + pageSize);
 
-      log.info('DNSHE', 'getDomainRecords success', { total, page, pageSize });
+      log.info('getDomainRecords success', { total, page, pageSize });
       return { total, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('DNSHE', 'getDomainRecords exception', { error: this.error });
+      log.error('getDomainRecords exception', { error: this.error });
       return { total: 0, list: [] };
     }
   }
@@ -265,7 +252,7 @@ export class DnsheAdapter extends BaseAdapter implements DnsAdapter {
         undefined,
         { subdomain_id: toNumber(this.config.subdomainId, 0) }
       );
-      
+
       if (!res.success || !res.records) {
         return null;
       }
@@ -315,19 +302,19 @@ export class DnsheAdapter extends BaseAdapter implements DnsAdapter {
       }
 
       const res = await this.request<{ record_id: number }>('dns_records', 'create', 'POST', body);
-      log.info('DNSHE', 'Add record response', { 
-        success: res.success, 
+      log.info('Add record response', {
+        success: res.success,
         record_id: res.record_id,
         fullResponse: JSON.stringify(res)
       });
       if (!res.success) {
-        log.error('DNSHE', 'Add record failed', { response: res });
+        log.error('Add record failed', { response: res });
         return null;
       }
 
       const recordId = res.record_id;
       if (!recordId) {
-        log.error('DNSHE', 'No record_id in response', { response: res });
+        log.error('No record_id in response', { response: res });
         return null;
       }
 
@@ -457,7 +444,7 @@ export class DnsheAdapter extends BaseAdapter implements DnsAdapter {
   private mapRecord(r: DnsheRecord): DnsRecord {
     // Use full_domain from DNSHE API directly
     const domain = r.full_domain || this.config.domain || '';
-    
+
     // Extract record name from full domain
     let name: string;
     if (r.name === '@' || r.name === domain) {

--- a/server/src/lib/dns/providers/dnshe/renewal.ts
+++ b/server/src/lib/dns/providers/dnshe/renewal.ts
@@ -1,6 +1,7 @@
-import { log } from '../internal';
+import { createProviderRenewalLogger } from '../internal';
 import { authenticatedRequest, DnsheAuthConfig } from './auth';
 
+const log = createProviderRenewalLogger('DNSHE');
 export interface DnsheSubdomain {
   id: number;
   subdomain: string;
@@ -40,33 +41,33 @@ export async function listSubdomains(
   try {
     const baseUrl = 'https://api005.dnshe.com/index.php';
     const url = `${baseUrl}?m=domain_hub&endpoint=subdomains&action=list`;
-    
-    log.providerRequest('DNSHE', 'GET', 'subdomains/list');
-    
+
+    log.sub('API').tag('REQUEST').debug('Provider request', { method: 'GET', url: 'subdomains/list', params: undefined });
+
     const response = await authenticatedRequest(url, config, {
       method: 'GET',
     });
 
     if (!response.ok) {
       const text = await response.text();
-      log.providerError('DNSHE', { 
-        status: response.status, 
-        error: `List subdomains request failed: ${text}` 
+      log.sub('API').tag('ERROR').error('Provider error', {
+        status: response.status,
+        error: `List subdomains request failed: ${text}`
       });
       return null;
     }
 
     const data = await response.json();
-    log.providerResponse('DNSHE', response.status, data.success, { count: data.count });
-    
+    log.sub('API').tag('RESPONSE').debug('Provider response', { status: response.status, success: data.success, data: { count: data.count } });
+
     if (!data.success) {
-      log.providerError('DNSHE', { message: data.message || data.error });
+      log.sub('API').tag('ERROR').error('Provider error', { message: data.message || data.error });
       return null;
     }
 
     return data as DnsheSubdomainListResult;
   } catch (error) {
-    log.providerError('DNSHE', { error: error instanceof Error ? error.message : String(error) });
+    log.sub('API').tag('ERROR').error('Provider error', { error: error instanceof Error ? error.message : String(error) });
     return null;
   }
 }
@@ -81,25 +82,25 @@ export async function renewSubdomain(
   try {
     const baseUrl = 'https://api005.dnshe.com/index.php';
     const url = `${baseUrl}?m=domain_hub&endpoint=subdomains&action=renew`;
-    
-    log.providerRequest('DNSHE', 'POST', 'subdomains/renew', { 
+
+    log.sub('API').tag('REQUEST').debug('Provider request', { method: 'POST', url: 'subdomains/renew', params: {
       subdomain_id: subdomainId,
       apiKeyPrefix: config.apiKey?.substring(0, 8) + '...',
       useProxy: config.useProxy
-    });
-    
+    } });
+
     const startTime = Date.now();
     const response = await authenticatedRequest(url, config, {
       method: 'POST',
       body: JSON.stringify({ subdomain_id: subdomainId }),
     });
     const duration = Date.now() - startTime;
-    
-    log.info('DNSHE', 'Renewal API response time', { duration: `${duration}ms`, status: response.status });
+
+    log.info('Renewal API response time', { duration: `${duration}ms`, status: response.status });
 
     if (!response.ok) {
       const text = await response.text();
-      
+
       // Try to parse as JSON for better error details
       let errorDetail = text;
       try {
@@ -108,9 +109,9 @@ export async function renewSubdomain(
       } catch (e) {
         // Keep original text if not JSON
       }
-      
-      log.providerError('DNSHE', { 
-        status: response.status, 
+
+      log.sub('API').tag('ERROR').error('Provider error', {
+        status: response.status,
         error: `Renewal request failed: ${errorDetail}`,
         duration: `${duration}ms`,
         subdomainId,
@@ -120,7 +121,7 @@ export async function renewSubdomain(
     }
 
     const data = await response.json();
-    log.providerResponse('DNSHE', response.status, data.success, { 
+    log.sub('API').tag('RESPONSE').debug('Provider response', { status: response.status, success: data.success, data: {
       subdomain_id: subdomainId,
       success: data.success,
       message: data.message || data.error,
@@ -128,17 +129,17 @@ export async function renewSubdomain(
       new_expires_at: data.new_expires_at,
       remaining_days: data.remaining_days,
       charged_amount: data.charged_amount
-    });
-    
+    } });
+
     if (!data.success) {
-      log.providerError('DNSHE', { 
+      log.sub('API').tag('ERROR').error('Provider error', {
         message: data.message || data.error,
         subdomain_id: subdomainId
       });
       return null;
     }
 
-    log.info('DNSHE', 'Renewal successful', {
+    log.info('Renewal successful', {
       subdomain_id: data.subdomain_id,
       subdomain: data.subdomain,
       previousExpiresAt: data.previous_expires_at,
@@ -150,7 +151,7 @@ export async function renewSubdomain(
 
     return data as DnsheRenewalResult;
   } catch (error) {
-    log.providerError('DNSHE', { 
+    log.sub('API').tag('ERROR').error('Provider error', {
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
       subdomainId

--- a/server/src/lib/dns/providers/dnshe/scheduler.ts
+++ b/server/src/lib/dns/providers/dnshe/scheduler.ts
@@ -1,11 +1,12 @@
+import { createProviderRenewalLogger } from '../internal';
 /**
  * DNSHE 域名续期调度器实现
  */
 
 import { RenewalScheduler, RenewableDomain, RenewalResult } from '../../../../service/renewalScheduler';
 import { listSubdomains, renewSubdomain, DnsheAuthConfig } from './index';
-import { log } from '../internal';
 
+const log = createProviderRenewalLogger('DNSHE');
 export class DnsheRenewalScheduler implements RenewalScheduler {
   readonly type = 'dnshe';
 
@@ -17,9 +18,9 @@ export class DnsheRenewalScheduler implements RenewalScheduler {
   async listRenewableDomains(config: DnsheAuthConfig): Promise<RenewableDomain[]> {
     try {
       const result = await listSubdomains(config);
-      
+
       if (!result || !result.success || !result.subdomains) {
-        log.warn('DnsheRenewalScheduler', 'Failed to list subdomains');
+        log.warn('Failed to list subdomains');
         return [];
       }
 
@@ -32,7 +33,7 @@ export class DnsheRenewalScheduler implements RenewalScheduler {
         // expires_at 将在续期时通过 renewSubdomain API 获取
       }));
     } catch (error) {
-      log.error('DnsheRenewalScheduler', 'Error listing renewable domains', {
+      log.error('Error listing renewable domains', {
         error: error instanceof Error ? error.message : String(error),
       });
       return [];
@@ -45,9 +46,9 @@ export class DnsheRenewalScheduler implements RenewalScheduler {
   async renewDomain(config: DnsheAuthConfig, domainId: number | string): Promise<RenewalResult | null> {
     try {
       const result = await renewSubdomain(config, Number(domainId));
-      
+
       if (!result) {
-        log.error('DnsheRenewalScheduler', 'Renewal failed', { domainId });
+        log.error('Renewal failed', { domainId });
         return null;
       }
 
@@ -61,7 +62,7 @@ export class DnsheRenewalScheduler implements RenewalScheduler {
         message: result.message,
       };
     } catch (error) {
-      log.error('DnsheRenewalScheduler', 'Error renewing domain', {
+      log.error('Error renewing domain', {
         domainId,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/server/src/lib/dns/providers/dnshe/whois.ts
+++ b/server/src/lib/dns/providers/dnshe/whois.ts
@@ -1,6 +1,7 @@
-import { log } from '../internal';
+import { createProviderWhoisLogger } from '../internal';
 import { authenticatedRequest, DnsheAuthConfig } from './auth';
 
+const log = createProviderWhoisLogger('DNSHE');
 export interface DnsheWhoisResult {
   success: boolean;
   message?: string;
@@ -21,33 +22,33 @@ export async function getWhois(
   try {
     const baseUrl = 'https://api005.dnshe.com/index.php';
     const url = `${baseUrl}?m=domain_hub&endpoint=whois&domain=${encodeURIComponent(domain)}`;
-    
-    log.providerRequest('DNSHE', 'GET', 'whois', { domain });
-    
+
+    log.sub('API').tag('REQUEST').debug('Provider request', { method: 'GET', url: 'whois', params: { domain } });
+
     const response = await authenticatedRequest(url, config, {
       method: 'GET',
     });
 
     if (!response.ok) {
       const text = await response.text();
-      log.providerError('DNSHE', { 
-        status: response.status, 
-        error: `WHOIS request failed: ${text}` 
+      log.sub('API').tag('ERROR').error('Provider error', {
+        status: response.status,
+        error: `WHOIS request failed: ${text}`
       });
       return null;
     }
 
     const data = await response.json();
-    log.providerResponse('DNSHE', response.status, data.success, { domain });
-    
+    log.sub('API').tag('RESPONSE').debug('Provider response', { status: response.status, success: data.success, data: { domain } });
+
     if (!data.success) {
-      log.providerError('DNSHE', { message: data.message || data.error });
+      log.sub('API').tag('ERROR').error('Provider error', { message: data.message || data.error });
       return null;
     }
 
     return data as DnsheWhoisResult;
   } catch (error) {
-    log.providerError('DNSHE', { error: error instanceof Error ? error.message : String(error) });
+    log.sub('API').tag('ERROR').error('Provider error', { error: error instanceof Error ? error.message : String(error) });
     return null;
   }
 }

--- a/server/src/lib/dns/providers/dnshe/whoisScheduler.ts
+++ b/server/src/lib/dns/providers/dnshe/whoisScheduler.ts
@@ -1,3 +1,4 @@
+import { createProviderWhoisLogger } from '../internal';
 /**
  * DNSHE WHOIS 查询调度器实现
  */
@@ -5,8 +6,8 @@
 import { WhoisScheduler, WhoisSchedulerResult } from '../../../../service/whois';
 import { getWhois } from './whois';
 import { DnsheAuthConfig } from './auth';
-import { log } from '../internal';
 
+const log = createProviderWhoisLogger('DNSHE');
 export class DnsheWhoisScheduler implements WhoisScheduler {
   readonly type = 'dnshe';
 
@@ -16,9 +17,9 @@ export class DnsheWhoisScheduler implements WhoisScheduler {
   async queryWhois(config: DnsheAuthConfig, domain: string): Promise<WhoisSchedulerResult | null> {
     try {
       const result = await getWhois(config, domain);
-      
+
       if (!result || !result.success) {
-        log.warn('DnsheWhoisScheduler', 'WHOIS query failed', { domain });
+        log.warn('WHOIS query failed', { domain });
         return null;
       }
 
@@ -39,7 +40,7 @@ export class DnsheWhoisScheduler implements WhoisScheduler {
         raw_data: result.raw_data,
       };
     } catch (error) {
-      log.error('DnsheWhoisScheduler', 'Error querying WHOIS', {
+      log.error('Error querying WHOIS', {
         domain,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/server/src/lib/dns/providers/dnsla/adapter.ts
+++ b/server/src/lib/dns/providers/dnsla/adapter.ts
@@ -1,8 +1,6 @@
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { BaseAdapter, Dict, resolveDomainIdHelper, safeString, toNumber } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, BaseAdapter, Dict, resolveDomainIdHelper, safeString, toNumber, fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('Dnsla');
 interface DnslaConfig {
   apiid: string;
   apisecret: string;
@@ -96,7 +94,7 @@ export class DnslaAdapter extends BaseAdapter {
       return { total: data.total || list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Dnsla', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/dnspod/adapter.ts
+++ b/server/src/lib/dns/providers/dnspod/adapter.ts
@@ -1,17 +1,6 @@
-import { 
-  DnsRecord, 
-  DomainInfo, 
-  PageResult,
-  asArray,
-  Dict,
-  normalizeRrName,
-  safeString,
-  TencentCloudAdapter,
-  toNumber,
-  toRecordStatus,
-  log,
-} from '../internal';
+import { createProviderAdapterLogger, DnsRecord, DomainInfo, PageResult, asArray, Dict, normalizeRrName, safeString, TencentCloudAdapter, toNumber, toRecordStatus } from '../internal';
 
+const log = createProviderAdapterLogger('Dnspod');
 export class DnspodAdapter extends TencentCloudAdapter {
   private readonly domain: string;
 
@@ -106,7 +95,7 @@ export class DnspodAdapter extends TencentCloudAdapter {
       return { total, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Dnspod', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }
@@ -302,13 +291,13 @@ export class DnspodAdapter extends TencentCloudAdapter {
 
       walk(asArray<Dict>(data.LineList));
       if (lines.length > 0) {
-        log.info('Dnspod', 'getRecordLines success (category)', { domain: this.domain, count: lines.length });
+        log.info('getRecordLines success (category)', { domain: this.domain, count: lines.length });
         return lines;
       }
     } catch (e) {
-      log.warn('Dnspod', 'getRecordLines category failed', { 
-        domain: this.domain, 
-        error: e instanceof Error ? e.message : String(e) 
+      log.warn('getRecordLines category failed', {
+        domain: this.domain,
+        error: e instanceof Error ? e.message : String(e)
       });
     }
 
@@ -324,17 +313,17 @@ export class DnspodAdapter extends TencentCloudAdapter {
       }));
       const merged = [...lines, ...groups].filter((x) => x.id && x.name);
       if (merged.length > 0) {
-        log.info('Dnspod', 'getRecordLines success (list)', { domain: this.domain, count: merged.length });
+        log.info('getRecordLines success (list)', { domain: this.domain, count: merged.length });
         return merged;
       }
     } catch (e) {
-      log.warn('Dnspod', 'getRecordLines list failed', { 
-        domain: this.domain, 
-        error: e instanceof Error ? e.message : String(e) 
+      log.warn('getRecordLines list failed', {
+        domain: this.domain,
+        error: e instanceof Error ? e.message : String(e)
       });
     }
 
-    log.warn('Dnspod', 'getRecordLines fallback to default', { domain: this.domain });
+    log.warn('getRecordLines fallback to default', { domain: this.domain });
     return [{ id: '0', name: '默认' }];
   }
 

--- a/server/src/lib/dns/providers/gcore/adapter.ts
+++ b/server/src/lib/dns/providers/gcore/adapter.ts
@@ -1,14 +1,8 @@
-import { 
-  DnsAdapter, 
-  DnsRecord, 
-  DomainInfo, 
-  PageResult,
-  resolveDomainIdHelper,
-  log,
-} from '../internal';
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, resolveDomainIdHelper } from '../internal';
 import { buildAuthHeaders, type GcoreAuthConfig } from './auth';
 import { requestJson } from '../http';
 
+const log = createProviderAdapterLogger('Gcore');
 interface GcoreZone {
   id: number;
   name: string;
@@ -64,7 +58,7 @@ export class GcoreAdapter implements DnsAdapter {
 
   private async request<T>(method: string, path: string, body?: unknown): Promise<GcoreApiResponse<T>> {
     const url = `${this.baseUrl}${path}`;
-    log.providerRequest('Gcore', method, url, body);
+    log.sub('API').tag('REQUEST').debug('Provider request', { method: method, url: url, params: body });
 
     try {
       const raw = await requestJson<GcoreApiResponse<T>>(url, {
@@ -76,15 +70,15 @@ export class GcoreAdapter implements DnsAdapter {
         parseError: parseGcoreError,
       });
       const data: GcoreApiResponse<T> = Array.isArray(raw) ? { results: raw, total: raw.length } : (raw ?? {});
-      log.providerResponse('Gcore', 200, true, {
+      log.sub('API').tag('RESPONSE').debug('Provider response', { status: 200, success: true, data: {
         hasResult: !!data.zones || !!data.rrsets || !!data.result || !!data.results,
         total: data.total_amount ?? data.total,
-      });
+      } });
       return data;
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : String(e);
       this.error = errorMessage;
-      log.providerError('Gcore', { error: errorMessage });
+      log.sub('API').tag('ERROR').error('Provider error', { error: errorMessage });
       return {} as GcoreApiResponse<T>;
     }
   }
@@ -131,7 +125,7 @@ export class GcoreAdapter implements DnsAdapter {
       return { total: res.total_amount ?? list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Gcore', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/hidns/adapter.ts
+++ b/server/src/lib/dns/providers/hidns/adapter.ts
@@ -1,8 +1,6 @@
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
-import { resolveDomainIdHelper } from '../internal';
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, fetchWithFallback, resolveDomainIdHelper } from '../internal';
 
+const log = createProviderAdapterLogger('HiDNS');
 interface HiDNSConfig {
   baseUrl: string;
   apiToken: string;
@@ -70,27 +68,27 @@ export class HiDNSAdapter implements DnsAdapter {
     const baseUrl = this.config.baseUrl.replace(/\/api\/?$/, '');
     const normalizedPath = path.startsWith('/') ? path : `/${path}`;
     const url = `${baseUrl}/api${normalizedPath}`;
-    log.providerRequest('HiDNS', method, url, body);
-    
+    log.sub('API').tag('REQUEST').debug('Provider request', { method: method, url: url, params: body });
+
     try {
       const res = await fetchWithFallback(url, {
         method,
         headers: this.getHeaders(),
         body: body ? JSON.stringify(body) : undefined,
       }, this.config.useProxy, 'HiDNS');
-      
+
       const data = (await res.json()) as HiDNSApiResponse<T>;
-      log.providerResponse('HiDNS', res.status, data.code === 0, { resultCount: data.data && typeof data.data === 'object' && 'list' in data.data ? (data.data as any).list?.length : 0 });
-      
+      log.sub('API').tag('RESPONSE').debug('Provider response', { status: res.status, success: data.code === 0, data: { resultCount: data.data && typeof data.data === 'object' && 'list' in data.data ? (data.data as any).list?.length : 0 } });
+
       if (data.code !== 0) {
         this.error = data.msg || 'API error';
-        log.providerError('HiDNS', [{ message: this.error }]);
+        log.sub('API').tag('ERROR').error('Provider error', [{ message: this.error }]);
       }
-      
+
       return data;
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.providerError('HiDNS', [{ message: this.error }]);
+      log.sub('API').tag('ERROR').error('Provider error', [{ message: this.error }]);
       return { code: -1, data: {} as T, msg: this.error };
     }
   }
@@ -116,13 +114,13 @@ export class HiDNSAdapter implements DnsAdapter {
       if (keyword) {
         path += `&keyword=${encodeURIComponent(keyword)}`;
       }
-      
+
       // HiDNS API can return either { total, list } or direct array
       const res = await this.request<any>('GET', path);
-      
-      log.debug('HiDNS', 'getDomainList response', { 
-        code: res.code, 
-        hasData: !!res.data, 
+
+      log.debug('getDomainList response', {
+        code: res.code,
+        hasData: !!res.data,
         dataType: typeof res.data,
         isObject: typeof res.data === 'object' && !Array.isArray(res.data),
         isArray: Array.isArray(res.data),
@@ -130,9 +128,9 @@ export class HiDNSAdapter implements DnsAdapter {
         dataLength: Array.isArray(res.data) ? res.data.length : (res.data?.list?.length || 0),
         rawData: JSON.stringify(res.data).substring(0, 200)
       });
-      
+
       if (res.code !== 0) {
-        log.error('HiDNS', 'getDomainList failed', { code: res.code, msg: res.msg });
+        log.error('getDomainList failed', { code: res.code, msg: res.msg });
         return { total: 0, list: [] };
       }
 
@@ -144,17 +142,17 @@ export class HiDNSAdapter implements DnsAdapter {
         // Format 1: Direct array (when using API Token or format=array)
         domains = res.data;
         total = domains.length;
-        log.debug('HiDNS', 'Detected array format response');
+        log.debug('Detected array format response');
       } else if (res.data && typeof res.data === 'object' && 'list' in res.data) {
         // Format 2: Paginated object { total, list, page, pageSize }
         domains = res.data.list;
         total = res.data.total || domains.length;
-        log.debug('HiDNS', 'Detected paginated object format response');
+        log.debug('Detected paginated object format response');
       } else {
-        log.error('HiDNS', 'getDomainList invalid data structure', { data: res.data });
+        log.error('getDomainList invalid data structure', { data: res.data });
         return { total: 0, list: [] };
       }
-      
+
       // Apply keyword filter if provided (server-side filtering may not work)
       let filteredDomains = domains;
       if (keyword) {
@@ -172,7 +170,7 @@ export class HiDNSAdapter implements DnsAdapter {
       };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('HiDNS', 'getDomainList exception', { error: this.error });
+      log.error('getDomainList exception', { error: this.error });
       return { total: 0, list: [] };
     }
   }
@@ -254,7 +252,7 @@ export class HiDNSAdapter implements DnsAdapter {
 
       // HiDNS API 没有单独的获取单条记录接口，从列表中查找
       const res = await this.request<{ total: number; list: HiDNSRecord[] }>('GET', `/domains/${domainId}/records?page=1&pageSize=1000`);
-      
+
       if (res.code !== 0) {
         return null;
       }

--- a/server/src/lib/dns/providers/huawei/adapter.ts
+++ b/server/src/lib/dns/providers/huawei/adapter.ts
@@ -1,9 +1,7 @@
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, asArray, BaseAdapter, Dict, normalizeRrName, resolveDomainIdHelper, safeString, toNumber, toRecordStatus, uuid, fetchWithFallback } from '../internal';
 import crypto from 'node:crypto';
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { asArray, BaseAdapter, Dict, normalizeRrName, resolveDomainIdHelper, safeString, toNumber, toRecordStatus, uuid } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('Huawei');
 class HuaweiCloudClient {
   private readonly useProxy: boolean;
 
@@ -113,7 +111,7 @@ class HuaweiCloudClient {
       if (queryStr) url += '?' + queryStr;
     }
 
-    log.providerRequest('Huawei', method, url);
+    log.sub('API').tag('REQUEST').debug('Provider request', { method: method, url: url, params: undefined });
     const res = await fetchWithFallback(url, {
       method,
       headers,
@@ -123,10 +121,10 @@ class HuaweiCloudClient {
     const data = (await res.json()) as Dict;
     if (!res.ok || data.error_msg || data.message || (data.error as Dict)?.error_msg) {
       const err = safeString(data.error_msg) || safeString(data.message) || safeString((data.error as Dict)?.error_msg) || `HuaweiCloud request failed: ${res.status}`;
-      log.providerError('Huawei', data);
+      log.sub('API').tag('ERROR').error('Provider error', data);
       throw new Error(err);
     }
-    log.providerResponse('Huawei', res.status, true);
+    log.sub('API').tag('RESPONSE').debug('Provider response', { status: res.status, success: true, data: undefined });
 
     return data as T;
   }
@@ -190,7 +188,7 @@ export class HuaweiAdapter extends BaseAdapter {
       return { total: data.metadata?.total_count || list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Huawei', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/huoshan/adapter.ts
+++ b/server/src/lib/dns/providers/huoshan/adapter.ts
@@ -1,9 +1,7 @@
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, BaseAdapter, Dict, resolveDomainIdHelper, safeString, toNumber, fetchWithFallback } from '../internal';
 import crypto from 'node:crypto';
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { BaseAdapter, Dict, resolveDomainIdHelper, safeString, toNumber } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('Huoshan');
 interface HuoshanConfig {
   AccessKeyId: string;
   SecretAccessKey: string;
@@ -186,7 +184,7 @@ export class HuoshanAdapter extends BaseAdapter {
       return { total: data.Total || list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Huoshan', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/internal.ts
+++ b/server/src/lib/dns/providers/internal.ts
@@ -1,19 +1,31 @@
 /**
  * DNS Providers Internal Module
- * 
+ *
  * This module re-exports external dependencies for internal use within DNS providers.
  * It provides a centralized place to manage external dependencies and simplifies imports.
- * 
+ *
  * Usage in provider files:
  * ```typescript
- * import { log, fetchWithFallback, BaseAdapter, ... } from './internal';
+ * import { createProviderAdapterLogger, fetchWithFallback, BaseAdapter } from './internal';
  * ```
  */
 
 // ============================================================================
 // Logger
 // ============================================================================
-export { log } from '../../logger';
+import { createLogger } from '../../logger';
+
+const log = createLogger('DNS');
+
+export const createDnsLogger = () => log;
+export const createDnsHelperLogger = () => log.sub('Helper');
+export const createDnsResolverLogger = (resolver: string) => log.sub('Resolver').sub(resolver);
+export const createProviderLogger = (provider: string) => log.sub('Provider').sub(provider);
+export const createProviderAdapterLogger = (provider: string) => createProviderLogger(provider).sub('Adapter');
+export const createProviderAuthLogger = (provider: string) => createProviderLogger(provider).sub('Auth');
+export const createProviderApiLogger = (provider: string) => createProviderLogger(provider).sub('API');
+export const createProviderRenewalLogger = (provider: string) => createProviderLogger(provider).sub('Renewal');
+export const createProviderWhoisLogger = (provider: string) => createProviderLogger(provider).sub('Whois');
 
 // ============================================================================
 // HTTP Utilities
@@ -24,15 +36,15 @@ export { requestXml } from './http';
 // ============================================================================
 // Common Types and Utilities
 // ============================================================================
-export { 
-  asArray, 
-  Dict, 
-  normalizeRrName, 
-  safeString, 
-  BaseAdapter, 
+export {
+  asArray,
+  Dict,
+  normalizeRrName,
+  safeString,
+  BaseAdapter,
   AliyunRpcAdapter,
   TencentCloudAdapter,
-  toNumber, 
+  toNumber,
   toRecordStatus,
   resolveDomainIdHelper,
   uuid,
@@ -44,17 +56,17 @@ export {
 // ============================================================================
 // DNS Interface Types
 // ============================================================================
-export type { 
-  DnsAdapter, 
-  DnsRecord, 
-  DomainInfo, 
+export type {
+  DnsAdapter,
+  DnsRecord,
+  DomainInfo,
   PageResult,
 } from '../DnsInterface';
 
 // ============================================================================
 // Helper Functions
 // ============================================================================
-export { 
+export {
   createAdapter,
   getProvider,
   getProviders,

--- a/server/src/lib/dns/providers/jdcloud/adapter.ts
+++ b/server/src/lib/dns/providers/jdcloud/adapter.ts
@@ -1,9 +1,7 @@
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, BaseAdapter, Dict, resolveDomainIdHelper, safeString, toNumber, uuid, fetchWithFallback } from '../internal';
 import crypto from 'node:crypto';
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { BaseAdapter, Dict, resolveDomainIdHelper, safeString, toNumber, uuid } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('Jdcloud');
 interface JdcloudConfig {
   AccessKeyId: string;
   AccessKeySecret: string;
@@ -175,7 +173,7 @@ export class JdcloudAdapter extends BaseAdapter {
       return { total: data.totalCount || list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Jdcloud', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/namesilo/adapter.ts
+++ b/server/src/lib/dns/providers/namesilo/adapter.ts
@@ -1,6 +1,6 @@
-import { DnsRecord, DomainInfo, PageResult } from '../internal';
-import { asArray, BaseAdapter, normalizeRrName, safeString, toNumber, requestXml, log } from '../internal';
+import { createProviderAdapterLogger, DnsRecord, DomainInfo, PageResult, asArray, BaseAdapter, normalizeRrName, safeString, toNumber, requestXml } from '../internal';
 
+const log = createProviderAdapterLogger('Namesilo');
 interface NamesiloConfig {
   apikey: string;
   domain?: string;
@@ -77,7 +77,7 @@ export class NamesiloAdapter extends BaseAdapter {
       return { total: list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Namesilo', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/powerdns/adapter.ts
+++ b/server/src/lib/dns/providers/powerdns/adapter.ts
@@ -1,8 +1,6 @@
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { BaseAdapter, Dict, resolveDomainIdHelper, safeString, toNumber } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, BaseAdapter, Dict, resolveDomainIdHelper, safeString, toNumber, fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('Powerdns');
 interface PowerdnsConfig {
   serverUrl: string;
   apiKey: string;
@@ -112,7 +110,7 @@ export class PowerdnsAdapter extends BaseAdapter {
       return { total: list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Powerdns', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/qingcloud/adapter.ts
+++ b/server/src/lib/dns/providers/qingcloud/adapter.ts
@@ -1,9 +1,7 @@
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, BaseAdapter, Dict, resolveDomainIdHelper, safeString, toNumber, fetchWithFallback } from '../internal';
 import crypto from 'node:crypto';
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { BaseAdapter, Dict, resolveDomainIdHelper, safeString, toNumber } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('Qingcloud');
 interface QingcloudConfig {
   access_key_id: string;
   secret_access_key: string;
@@ -99,7 +97,7 @@ export class QingcloudAdapter extends BaseAdapter {
       return { total: data.total_count || list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Qingcloud', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/rainyun/adapter.ts
+++ b/server/src/lib/dns/providers/rainyun/adapter.ts
@@ -1,8 +1,6 @@
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { asArray, BaseAdapter, Dict, normalizeRrName, resolveDomainIdHelper, safeString, toNumber, toRecordStatus } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, asArray, BaseAdapter, Dict, normalizeRrName, resolveDomainIdHelper, safeString, toNumber, toRecordStatus, fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('Rainyun');
 interface RainyunConfig {
   apiKey: string;
   domain?: string;
@@ -124,7 +122,7 @@ export class RainyunAdapter extends BaseAdapter {
       };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Rainyun', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/spaceship/adapter.ts
+++ b/server/src/lib/dns/providers/spaceship/adapter.ts
@@ -1,8 +1,6 @@
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { BaseAdapter, Dict, safeString, toNumber } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, BaseAdapter, Dict, safeString, toNumber, fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('Spaceship');
 interface SpaceshipConfig {
   apiKey: string;
   apiSecret: string;
@@ -84,7 +82,7 @@ export class SpaceshipAdapter extends BaseAdapter {
       return { total: data.total || list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Spaceship', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/providers/tencenteo/adapter.ts
+++ b/server/src/lib/dns/providers/tencenteo/adapter.ts
@@ -1,17 +1,6 @@
-import { DnsRecord, DomainInfo, PageResult } from '../internal';
-import {
-  asArray,
-  buildSrvValue,
-  Dict,
-  isSrv,
-  normalizeRrName,
-  parseSrvValue,
-  safeString,
-  TencentCloudAdapter,
-  toNumber,
-} from '../internal';
-import { log } from '../internal';
+import { createProviderAdapterLogger, DnsRecord, DomainInfo, PageResult, asArray, buildSrvValue, Dict, isSrv, normalizeRrName, parseSrvValue, safeString, TencentCloudAdapter, toNumber } from '../internal';
 
+const log = createProviderAdapterLogger('TencentEO');
 export class TencenteoAdapter extends TencentCloudAdapter {
   private zoneId: string = '';
   private domain: string = '';
@@ -41,7 +30,7 @@ export class TencenteoAdapter extends TencentCloudAdapter {
   setZoneInfo(zoneId: string, domain: string): void {
     this.zoneId = zoneId;
     this.domain = domain;
-    log.debug('TencenteoAdapter', 'ZoneInfo set', { zoneId, domain });
+    log.debug('ZoneInfo set', { zoneId, domain });
   }
 
   private fqdn(name: string): string {
@@ -107,7 +96,7 @@ export class TencenteoAdapter extends TencentCloudAdapter {
       return { total: toNumber(data.TotalCount, list.length), list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('Tencenteo', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }
@@ -123,10 +112,10 @@ export class TencenteoAdapter extends TencentCloudAdapter {
     _status?: number
   ): Promise<PageResult<DnsRecord>> {
     try {
-      log.debug('TencenteoAdapter', 'getDomainRecords called', { zoneId: this.zoneId, domain: this.domain, page, pageSize });
+      log.debug('getDomainRecords called', { zoneId: this.zoneId, domain: this.domain, page, pageSize });
       if (!this.zoneId) {
         this.error = 'Zone ID not set';
-        log.warn('TencenteoAdapter', 'Zone ID not set when getting domain records', { domain: this.domain });
+        log.warn('Zone ID not set when getting domain records', { domain: this.domain });
         return { total: 0, list: [] };
       }
       const offset = (page - 1) * pageSize;

--- a/server/src/lib/dns/providers/vps8/adapter.ts
+++ b/server/src/lib/dns/providers/vps8/adapter.ts
@@ -1,9 +1,6 @@
-import { DnsRecord, DomainInfo, PageResult } from '../internal';
-import { BaseAdapter, safeString, toNumber } from '../internal';
-import { Dict } from '../internal';
-import { fetchWithFallback } from '../internal';
-import { log } from '../internal';
+import { createProviderAdapterLogger, DnsRecord, DomainInfo, PageResult, BaseAdapter, safeString, toNumber, Dict, fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('VPS8');
 interface Vps8Config {
   apiKey: string;
   client: string;
@@ -36,11 +33,11 @@ export class Vps8Adapter extends BaseAdapter {
   private async request<T>(endpoint: string, params: Record<string, unknown> = {}): Promise<T> {
     const url = `${this.baseUrl}/${endpoint}`;
     const body = JSON.stringify(params);
-    
+
     try {
       // HTTP Basic Auth: username="client" (fixed literal string), password=apiKey
       const credentials = Buffer.from(`client:${this.config.apiKey}`).toString('base64');
-      
+
       const res = await fetchWithFallback(url, {
         method: 'POST',
         headers: {
@@ -49,10 +46,10 @@ export class Vps8Adapter extends BaseAdapter {
         },
         body,
       }, this.config.useProxy, 'VPS8');
-      
+
       const text = await res.text();
       let payload: unknown = undefined;
-      
+
       if (text) {
         try {
           payload = JSON.parse(text);
@@ -60,14 +57,14 @@ export class Vps8Adapter extends BaseAdapter {
           throw new Error(`Invalid JSON response: ${text.slice(0, 200)}`);
         }
       }
-      
+
       const data = payload as Vps8Response<T>;
-      
+
       // 如果响应有 error 字段且不为 null，抛出错误
       if (data.error && data.error.code && data.error.code !== 200) {
         throw new Error(safeString(data.error.message) || 'VPS8 API request failed');
       }
-      
+
       return (data.result ?? {}) as T;
     } catch (error) {
       if (error instanceof Error) {
@@ -89,19 +86,19 @@ export class Vps8Adapter extends BaseAdapter {
 
   async getDomainList(keyword?: string, _page = 1, _pageSize = 50): Promise<PageResult<DomainInfo>> {
     try {
-      log.debug('VPS8', 'Fetching domain list', { 
+      log.debug('Fetching domain list', {
         client: this.config.client,
         apiKeyLength: this.config.apiKey.length,
-        baseUrl: this.baseUrl 
+        baseUrl: this.baseUrl
       });
-      
-      const response = await this.request<Array<{ 
-        domain: string; 
+
+      const response = await this.request<Array<{
+        domain: string;
         id?: string;
         expires_at?: string;
         created_at?: string;
       }>>('domain_list', {});
-      
+
       let list = (response || []).map((item) => ({
         Domain: safeString(item.domain),
         ThirdId: safeString(item.id) || safeString(item.domain),
@@ -116,7 +113,7 @@ export class Vps8Adapter extends BaseAdapter {
       return { total: list.length, list };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('VPS8', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }
@@ -209,7 +206,7 @@ export class Vps8Adapter extends BaseAdapter {
       return safeString(response.id) || 'success';
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('VPS8', 'addDomainRecord failed', this.error);
+      log.error('addDomainRecord failed', this.error);
       return null;
     }
   }
@@ -230,7 +227,7 @@ export class Vps8Adapter extends BaseAdapter {
         return false;
       }
 
-      log.debug('VPS8', 'Updating record', { recordId, domain: this.config.domain });
+      log.debug('Updating record', { recordId, domain: this.config.domain });
 
       const params: Record<string, unknown> = {
         domain: this.config.domain,
@@ -244,13 +241,13 @@ export class Vps8Adapter extends BaseAdapter {
       }
 
       await this.request('record_update', params);
-      log.debug('VPS8', 'Record updated successfully', { recordId });
+      log.debug('Record updated successfully', { recordId });
       return true;
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('VPS8', 'updateDomainRecord failed', { 
-        recordId, 
-        error: this.error 
+      log.error('updateDomainRecord failed', {
+        recordId,
+        error: this.error
       });
       return false;
     }
@@ -262,20 +259,20 @@ export class Vps8Adapter extends BaseAdapter {
         return false;
       }
 
-      log.debug('VPS8', 'Deleting record', { recordId, domain: this.config.domain });
+      log.debug('Deleting record', { recordId, domain: this.config.domain });
 
       await this.request('record_delete', {
         domain: this.config.domain,
         id: recordId,
       });
-      
-      log.debug('VPS8', 'Record deleted successfully', { recordId });
+
+      log.debug('Record deleted successfully', { recordId });
       return true;
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('VPS8', 'deleteDomainRecord failed', { 
-        recordId, 
-        error: this.error 
+      log.error('deleteDomainRecord failed', {
+        recordId,
+        error: this.error
       });
       return false;
     }

--- a/server/src/lib/dns/providers/west/adapter.ts
+++ b/server/src/lib/dns/providers/west/adapter.ts
@@ -1,9 +1,7 @@
+import { createProviderAdapterLogger, DnsAdapter, DnsRecord, DomainInfo, PageResult, asArray, BaseAdapter, Dict, normalizeRrName, safeString, toNumber, fetchWithFallback } from '../internal';
 import crypto from 'node:crypto';
-import { DnsAdapter, DnsRecord, DomainInfo, PageResult } from '../internal';
-import { asArray, BaseAdapter, Dict, normalizeRrName, safeString, toNumber } from '../internal';
-import { log } from '../internal';
-import { fetchWithFallback } from '../internal';
 
+const log = createProviderAdapterLogger('West');
 interface WestConfig {
   username: string;
   apiPassword: string;
@@ -177,7 +175,7 @@ export class WestAdapter extends BaseAdapter implements DnsAdapter {
       };
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
-      log.error('West', 'getDomainList failed', this.error);
+      log.error('getDomainList failed', this.error);
       return { total: 0, list: [] };
     }
   }

--- a/server/src/lib/dns/resolver/doh-resolver.ts
+++ b/server/src/lib/dns/resolver/doh-resolver.ts
@@ -6,8 +6,9 @@ import * as https from 'https';
 import * as http from 'http';
 import { URL } from 'url';
 import { DNSQueryType, DNSResponse, DNSRecord } from './types';
-import { log } from '../../logger';
+import { createLogger } from '../../logger';
 
+const log = createLogger('DNS').sub('Resolver').sub('Doh');
 // DNS 查询包编码（简化版，用于 DoH）
 export function encodeDNSQuery(domain: string, type: DNSQueryType): Buffer {
   // 构造 DNS 查询包
@@ -287,7 +288,7 @@ export async function queryDoH(
       source: dohUrl,
     };
   } catch (error) {
-    log.error('DoHResolver', `DoH query failed for ${domain}`, {
+    log.error(`DoH query failed for ${domain}`, {
       error: error instanceof Error ? error.message : String(error),
       url: dohUrl,
     });
@@ -336,7 +337,7 @@ export async function queryDoHWire(
           response.source = dohUrl;
           resolve(response);
         } catch (error) {
-          log.error('DoHResolver', `Failed to decode DoH response for ${domain}`, {
+          log.error(`Failed to decode DoH response for ${domain}`, {
             error: error instanceof Error ? error.message : String(error),
           });
           resolve(null);
@@ -345,7 +346,7 @@ export async function queryDoHWire(
     });
 
     req.on('error', (error) => {
-      log.error('DoHResolver', `DoH request failed for ${domain}`, {
+      log.error(`DoH request failed for ${domain}`, {
         error: error.message,
       });
       resolve(null);

--- a/server/src/lib/dns/resolver/dot-resolver.ts
+++ b/server/src/lib/dns/resolver/dot-resolver.ts
@@ -5,8 +5,9 @@
 import * as tls from 'tls';
 import { DNSQueryType, DNSResponse } from './types';
 import { encodeDNSQuery, decodeDNSResponse } from './doh-resolver';
-import { log } from '../../logger';
+import { createLogger } from '../../logger';
 
+const log = createLogger('DNS').sub('Resolver').sub('Dot');
 /**
  * 使用 DoT 查询 DNS
  */
@@ -21,7 +22,7 @@ export async function queryDoT(
     const port = parseInt(portStr) || 853;
 
     const queryBuffer = encodeDNSQuery(domain, type);
-    
+
     // DoT 需要在数据前添加 2 字节的长度前缀（与 TCP DNS 相同）
     const dotBuffer = Buffer.alloc(2 + queryBuffer.length);
     dotBuffer.writeUInt16BE(queryBuffer.length, 0);
@@ -38,7 +39,7 @@ export async function queryDoT(
 
     // 设置超时
     timer = setTimeout(() => {
-      log.debug('DoTResolver', `DoT query timeout: ${domain} @ ${serverAddress}`);
+      log.debug(`DoT query timeout: ${domain} @ ${serverAddress}`);
       cleanup();
       socket.end();
       resolve(null);
@@ -55,7 +56,7 @@ export async function queryDoT(
     socket.setTimeout(timeout);
 
     socket.on('secureConnect', () => {
-      log.debug('DoTResolver', `DoT TLS connection established: ${host}:${port}`);
+      log.debug(`DoT TLS connection established: ${host}:${port}`);
       socket.write(dotBuffer);
     });
 
@@ -77,7 +78,7 @@ export async function queryDoT(
           socket.end();
           resolve(response);
         } catch (error) {
-          log.error('DoTResolver', `Failed to decode DoT response: ${domain}`, {
+          log.error(`Failed to decode DoT response: ${domain}`, {
             error: error instanceof Error ? error.message : String(error),
           });
           cleanup();
@@ -88,7 +89,7 @@ export async function queryDoT(
     });
 
     socket.on('error', (error) => {
-      log.error('DoTResolver', `DoT socket error: ${domain}`, {
+      log.error(`DoT socket error: ${domain}`, {
         error: error.message,
       });
       cleanup();
@@ -96,7 +97,7 @@ export async function queryDoT(
     });
 
     socket.on('timeout', () => {
-      log.debug('DoTResolver', `DoT socket timeout: ${domain}`);
+      log.debug(`DoT socket timeout: ${domain}`);
       cleanup();
       socket.end();
       resolve(null);
@@ -124,6 +125,6 @@ export async function queryDoTWithProxy(
   timeout: number = 5000
 ): Promise<DNSResponse | null> {
   // TODO: 实现通过 HTTPS CONNECT 代理的 DoT 查询
-  log.debug('DoTResolver', `DoT with proxy not implemented yet: ${domain}`);
+  log.debug(`DoT with proxy not implemented yet: ${domain}`);
   return null;
 }

--- a/server/src/lib/dns/resolver/plain-resolver.ts
+++ b/server/src/lib/dns/resolver/plain-resolver.ts
@@ -6,8 +6,9 @@ import * as dgram from 'dgram';
 import * as net from 'net';
 import { DNSQueryType, DNSResponse, DNSServerType } from './types';
 import { encodeDNSQuery, decodeDNSResponse } from './doh-resolver';
-import { log } from '../../logger';
+import { createLogger } from '../../logger';
 
+const log = createLogger('DNS').sub('Resolver').sub('Plain');
 /**
  * 使用 UDP 查询 DNS
  */
@@ -33,7 +34,7 @@ export async function queryDNSUDP(
 
     // 设置超时
     timer = setTimeout(() => {
-      log.debug('PlainResolver', `UDP DNS query timeout: ${domain} @ ${serverAddress}`);
+      log.debug(`UDP DNS query timeout: ${domain} @ ${serverAddress}`);
       cleanup();
       resolve(null);
     }, timeout);
@@ -45,7 +46,7 @@ export async function queryDNSUDP(
         cleanup();
         resolve(response);
       } catch (error) {
-        log.error('PlainResolver', `Failed to decode UDP DNS response: ${domain}`, {
+        log.error(`Failed to decode UDP DNS response: ${domain}`, {
           error: error instanceof Error ? error.message : String(error),
         });
         cleanup();
@@ -54,7 +55,7 @@ export async function queryDNSUDP(
     });
 
     socket.on('error', (error) => {
-      log.error('PlainResolver', `UDP DNS socket error: ${domain}`, {
+      log.error(`UDP DNS socket error: ${domain}`, {
         error: error.message,
       });
       cleanup();
@@ -64,7 +65,7 @@ export async function queryDNSUDP(
     // 发送查询
     socket.send(queryBuffer, port, host, (error) => {
       if (error) {
-        log.error('PlainResolver', `Failed to send UDP DNS query: ${domain}`, {
+        log.error(`Failed to send UDP DNS query: ${domain}`, {
           error: error.message,
         });
         cleanup();
@@ -88,7 +89,7 @@ export async function queryDNSTCP(
     const port = parseInt(portStr) || 53;
 
     const queryBuffer = encodeDNSQuery(domain, type);
-    
+
     // TCP DNS 需要在数据前添加 2 字节的长度前缀
     const tcpBuffer = Buffer.alloc(2 + queryBuffer.length);
     tcpBuffer.writeUInt16BE(queryBuffer.length, 0);
@@ -107,7 +108,7 @@ export async function queryDNSTCP(
 
     // 设置超时
     timer = setTimeout(() => {
-      log.debug('PlainResolver', `TCP DNS query timeout: ${domain} @ ${serverAddress}`);
+      log.debug(`TCP DNS query timeout: ${domain} @ ${serverAddress}`);
       cleanup();
       resolve(null);
     }, timeout);
@@ -135,7 +136,7 @@ export async function queryDNSTCP(
           cleanup();
           resolve(response);
         } catch (error) {
-          log.error('PlainResolver', `Failed to decode TCP DNS response: ${domain}`, {
+          log.error(`Failed to decode TCP DNS response: ${domain}`, {
             error: error instanceof Error ? error.message : String(error),
           });
           cleanup();
@@ -145,7 +146,7 @@ export async function queryDNSTCP(
     });
 
     socket.on('error', (error) => {
-      log.error('PlainResolver', `TCP DNS socket error: ${domain}`, {
+      log.error(`TCP DNS socket error: ${domain}`, {
         error: error.message,
       });
       cleanup();
@@ -153,7 +154,7 @@ export async function queryDNSTCP(
     });
 
     socket.on('timeout', () => {
-      log.debug('PlainResolver', `TCP DNS socket timeout: ${domain}`);
+      log.debug(`TCP DNS socket timeout: ${domain}`);
       cleanup();
       resolve(null);
     });

--- a/server/src/lib/dns/resolver/proxy-tunnel.ts
+++ b/server/src/lib/dns/resolver/proxy-tunnel.ts
@@ -8,8 +8,9 @@ import * as tls from 'tls';
 import * as http from 'http';
 import * as https from 'https';
 import { URL } from 'url';
-import { log } from '../../logger';
+import { createLogger } from '../../logger';
 
+const log = createLogger('DNS').sub('Resolver').sub('ProxyTunnel');
 export interface ProxyConfig {
   host: string;
   port: number;
@@ -49,7 +50,7 @@ export async function createProxyTunnel(
     connectHeaders.push('', '');
     const connectRequest = connectHeaders.join('\r\n');
 
-    log.debug('ProxyTunnel', `Creating tunnel to ${targetHost}:${targetPort} via ${proxyHost}:${proxyPort}`);
+    log.debug(`Creating tunnel to ${targetHost}:${targetPort} via ${proxyHost}:${proxyPort}`);
 
     const socket = new net.Socket();
     let buffer = '';
@@ -85,7 +86,7 @@ export async function createProxyTunnel(
           // 隧道建立成功
           clearTimeout(timer);
           cleanup();
-          log.debug('ProxyTunnel', `Tunnel established to ${targetHost}:${targetPort}`);
+          log.debug(`Tunnel established to ${targetHost}:${targetPort}`);
           resolve(socket);
         } else {
           // 隧道建立失败
@@ -157,7 +158,7 @@ export async function createTLSViaProxy(
  */
 export function parseProxyUrl(proxyUrl: string): ProxyConfig {
   const url = new URL(proxyUrl);
-  
+
   const config: ProxyConfig = {
     host: url.hostname,
     port: parseInt(url.port) || (url.protocol === 'https:' ? 443 : 80),

--- a/server/src/lib/dns/resolver/resolver.ts
+++ b/server/src/lib/dns/resolver/resolver.ts
@@ -8,9 +8,10 @@ import { queryDoH } from './doh-resolver';
 import { queryDoT as queryDoTImpl } from './dot-resolver';
 import { queryPlainDNS as queryPlainDNSImpl } from './plain-resolver';
 import { createTLSViaProxy, parseProxyUrl } from './proxy-tunnel';
-import { log } from '../../logger';
+import { createLogger } from '../../logger';
 import { getProxyConfig } from '../../proxy-http';
 
+const log = createLogger('DNS').sub('Resolver').sub('Resolver');
 export class DNSResolver {
   /**
    * 解析域名
@@ -25,7 +26,7 @@ export class DNSResolver {
   ): Promise<DNSResolverResult> {
     const { preferEncrypted = true, timeout = 5000, useProxy = true } = options;
 
-    log.debug('DNSResolver', `Resolving ${domain} (type: ${type})`);
+    log.debug(`Resolving ${domain} (type: ${type})`);
 
     // 1. 尝试加密 DNS 查询（DoH/DoT）
     if (preferEncrypted) {
@@ -33,7 +34,7 @@ export class DNSResolver {
       if (encryptedResult.success) {
         return encryptedResult;
       }
-      log.debug('DNSResolver', `Encrypted DNS failed for ${domain}, falling back to plain DNS`);
+      log.debug(`Encrypted DNS failed for ${domain}, falling back to plain DNS`);
     }
 
     // 2. 尝试明文 DNS 查询（UDP/TCP）
@@ -41,7 +42,7 @@ export class DNSResolver {
     if (plainResult.success) {
       return plainResult;
     }
-    log.debug('DNSResolver', `Plain DNS failed for ${domain}, falling back to system DNS`);
+    log.debug(`Plain DNS failed for ${domain}, falling back to system DNS`);
 
     // 3. 使用系统 DNS
     const systemResult = await this.querySystem(domain, type, timeout);
@@ -50,7 +51,7 @@ export class DNSResolver {
     }
 
     // 全部失败
-    log.error('DNSResolver', `All DNS queries failed for ${domain}`);
+    log.error(`All DNS queries failed for ${domain}`);
     return {
       success: false,
       responseTime: 0,
@@ -111,7 +112,7 @@ export class DNSResolver {
           } as DNSResolverResult;
         }
       } catch (error) {
-        log.debug('DNSResolver', `Encrypted DNS query failed: ${server.name}`, {
+        log.debug(`Encrypted DNS query failed: ${server.name}`, {
           error: error instanceof Error ? error.message : String(error),
         });
       }
@@ -151,13 +152,13 @@ export class DNSResolver {
       }
 
       // 使用代理查询
-      log.debug('DNSResolver', `Using proxy for DoH query: ${domain}`);
+      log.debug(`Using proxy for DoH query: ${domain}`);
 
       // 这里简化处理，实际应该通过代理隧道进行 HTTPS 请求
       // 暂时直接查询
       return await queryDoH(domain, type, dohUrl, timeout);
     } catch (error) {
-      log.error('DNSResolver', `DoH query with proxy failed: ${domain}`, {
+      log.error(`DoH query with proxy failed: ${domain}`, {
         error: error instanceof Error ? error.message : String(error),
       });
       return null;
@@ -191,7 +192,7 @@ export class DNSResolver {
         return await queryDoTImpl(domain, type, address, timeout);
       }
 
-      log.debug('DNSResolver', `Using proxy for DoT query: ${domain}`);
+      log.debug(`Using proxy for DoT query: ${domain}`);
 
       const [host, portStr] = address.split(':');
       const port = parseInt(portStr) || 853;
@@ -202,7 +203,7 @@ export class DNSResolver {
         port: proxyConfig.port || 8080,
         protocol: proxyConfig.type === 'socks5' ? 'http' : (proxyConfig.type as 'http' | 'https') || 'http',
       };
-      
+
       if (proxyConfig.username && proxyConfig.password) {
         proxyCfg.auth = {
           username: proxyConfig.username,
@@ -247,7 +248,7 @@ export class DNSResolver {
               tlsSocket.end();
               resolve(response);
             } catch (error) {
-              log.error('DNSResolver', `Failed to decode DoT+Proxy response: ${domain}`, {
+              log.error(`Failed to decode DoT+Proxy response: ${domain}`, {
                 error: error instanceof Error ? error.message : String(error),
               });
               tlsSocket.end();
@@ -257,20 +258,20 @@ export class DNSResolver {
         });
 
         tlsSocket.on('error', (error) => {
-          log.error('DNSResolver', `DoT+Proxy socket error: ${domain}`, {
+          log.error(`DoT+Proxy socket error: ${domain}`, {
             error: error.message,
           });
           resolve(null);
         });
 
         tlsSocket.on('timeout', () => {
-          log.debug('DNSResolver', `DoT+Proxy timeout: ${domain}`);
+          log.debug(`DoT+Proxy timeout: ${domain}`);
           tlsSocket.end();
           resolve(null);
         });
       });
     } catch (error) {
-      log.error('DNSResolver', `DoT query with proxy failed: ${domain}`, {
+      log.error(`DoT query with proxy failed: ${domain}`, {
         error: error instanceof Error ? error.message : String(error),
       });
       return null;
@@ -312,7 +313,7 @@ export class DNSResolver {
           } as DNSResolverResult;
         }
       } catch (error) {
-        log.debug('DNSResolver', `Plain DNS query failed: ${server.name}`, {
+        log.debug(`Plain DNS query failed: ${server.name}`, {
           error: error instanceof Error ? error.message : String(error),
         });
       }
@@ -399,7 +400,7 @@ export class DNSResolver {
         source: 'system',
       };
     } catch (error) {
-      log.error('DNSResolver', `System DNS query failed: ${domain}`, {
+      log.error(`System DNS query failed: ${domain}`, {
         error: error instanceof Error ? error.message : String(error),
       });
 
@@ -439,7 +440,7 @@ export class DNSResolver {
     if (encryptedResult.success && plainResult.success) {
       // 标准化 NS 记录：移除尾部点号并转为小写
       const normalizeNS = (ns: string) => ns.replace(/\.$/, '').toLowerCase();
-      
+
       const encryptedNS = encryptedResult.records?.map(r => normalizeNS(r.data)).sort() || [];
       const plainNS = plainResult.records?.map(r => normalizeNS(r.data)).sort() || [];
 
@@ -463,7 +464,7 @@ export class DNSResolver {
         : [];
 
     if (isPoisoned) {
-      log.warn('DNSResolver', `DNS poisoning detected for ${domain}`, {
+      log.warn(`DNS poisoning detected for ${domain}`, {
         encrypted: encryptedResult.records?.map(r => r.data),
         plain: plainResult.records?.map(r => r.data),
       });

--- a/server/src/lib/logger.ts
+++ b/server/src/lib/logger.ts
@@ -1,46 +1,26 @@
 /**
  * HiDNS 统一日志系统
- * 
- * 日志格式: 日期 级别 [主模块名] [子模块] [函数名] [L行号] ["自定义标签"] 内容
+ *
+ * 日志格式: 日期 级别 [主模块名] [子模块.三级模块] [函数名] [L行号] ["自定义标签"] 内容
  * 示例:
- *   2026-06-07T12:00:00.000Z  INFO [BAL] [execQuery] [L42] Executing query ...
- *   2026-06-07T12:00:00.000Z  INFO [DSM] [DRY RUN] [reconcile] [L88] Would create table: xxx
- *   2026-06-07T12:00:00.000Z DEBUG [DL] [MySQL] [query] [L55] Creating connection pool ...
- *   2026-06-07T12:00:00.000Z  INFO [WhoisService] [queryApex] [L125] ["SUCCESS"] Query succeeded
- * 
+ *   2026-06-07T12:00:00.000Z  INFO [BAL] [BusinessAdapter] [execQuery] [L42] Executing query ...
+ *   2026-06-07T12:00:00.000Z  INFO [DSM] [Reconciler.Table] [reconcile] [L88] ["DRY_RUN"] Would create table: xxx
+ *   2026-06-07T12:00:00.000Z DEBUG [DL] [MySQL.Pool] [query] [L55] Creating connection pool ...
+ *   2026-06-07T12:00:00.000Z  INFO [DNS] [Provider.Aliyun.Adapter] [getDomainList] [L125] ["SUCCESS"] Query succeeded
+ *
  * 项目理念：详细的日志是调试和监控的基础
  * 所有模块都应该使用此日志系统记录关键操作
- * 
- * 审查要求：
- * - 日志必须包含上下文信息（模块名、函数名、行号等）
- * - 日志必须包含详细错误信息（错误类型、错误消息、错误栈等）
- * - 日志必须包含详细操作信息（操作类型、操作对象、操作结果等）
  */
 
-/**
- * 日志级别
- *
- * - trace: 高频率的底层调试信息（协议帧、原始报文、循环/定时器每次触发等），仅开发环境开启
- * - debug: 低频率的调试信息（请求参数、响应摘要、状态变化等），开发环境默认开启
- * - info:  正常业务流程的关键节点信息（操作成功、任务启停、连接建立等），生产环境默认开启
- * - warn:  预期内的异常或降级处理（重试、限流、熔断、降级、配置回退等），需要关注但无需立即处理
- * - error: 预期外的错误或异常（数据库失败、第三方服务故障、未捕获异常等），需要立即关注和处理
- */
 export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
 
-/** 绑定模块名的子日志器类型 */
 export interface SubLogger {
-  /** 高频率底层调试信息，仅开发环境开启 */
   trace: (message: string, data?: unknown) => void;
-  /** 低频率调试信息，开发环境默认开启 */
   debug: (message: string, data?: unknown) => void;
-  /** 正常业务流程关键节点信息，生产环境默认开启 */
   info: (message: string, data?: unknown) => void;
-  /** 预期内的异常或降级处理，需关注但无需立即处理 */
   warn: (message: string, data?: unknown) => void;
-  /** 预期外的错误或异常，需立即关注和处理 */
   error: (message: string, data?: unknown) => void;
-  /** 创建嵌套子模块日志器，输出为 [父模块] [子模块] */
+  /** 创建嵌套子模块日志器；多个子模块输出为 [主模块] [子模块.三级模块] */
   sub: (name: string) => SubLogger;
   /** 添加自定义标签，输出为 ["标签1"] ["标签2"] */
   tag: (...args: string[]) => SubLogger;
@@ -63,42 +43,47 @@ interface ErrorDetails {
   message: string;
   stack?: string;
   code?: string | number;
+  cause?: unknown;
   [key: string]: unknown;
 }
+
+type Dict = Record<string, unknown>;
+
+const SENSITIVE_KEYS = new Set([
+  'password', 'passwd', 'secret', 'token', 'accesstoken', 'access_token', 'refreshtoken', 'refresh_token',
+  'apikey', 'api_key', 'key', 'authorization', 'cookie', 'set-cookie', 'privatekey', 'private_key',
+  'clientsecret', 'client_secret', 'jwt', 'session', 'signature', 'sign',
+]);
 
 class Logger {
   private static instance: Logger;
   private logLevel: LogLevel;
   private useColors: boolean;
 
-  // ANSI 颜色代码
   private readonly colors = {
     reset: '\x1b[0m',
-    trace: '\x1b[90m',     // 深灰色（比 debug 更淡）
-    debug: '\x1b[36m',      // 青色
-    info: '\x1b[32m',       // 绿色
-    warn: '\x1b[33m',       // 黄色
-    error: '\x1b[31m',      // 红色
-    timestamp: '\x1b[90m',  // 灰色
-    module: '\x1b[35m',     // 紫色
-    context: '\x1b[34m',    // 蓝色
+    trace: '\x1b[90m',
+    debug: '\x1b[36m',
+    info: '\x1b[32m',
+    warn: '\x1b[33m',
+    error: '\x1b[31m',
+    timestamp: '\x1b[90m',
+    module: '\x1b[35m',
+    context: '\x1b[34m',
   };
 
   private constructor() {
-    // 从独立的环境变量 HIDNS_LOG_LEVEL 读取日志级别，默认为 'info'
     const envLevel = (typeof process !== 'undefined' && process.env?.HIDNS_LOG_LEVEL) as LogLevel | undefined;
     const validLevels: LogLevel[] = ['trace', 'debug', 'info', 'warn', 'error'];
     this.logLevel = envLevel && validLevels.includes(envLevel) ? envLevel : 'info';
-    
-    // 检测是否支持彩色输出（默认启用，可通过 HIDNS_NO_COLOR=1 禁用）
+
     const noColor = typeof process !== 'undefined' && (
-      process.env?.NO_COLOR === '1' || 
+      process.env?.NO_COLOR === '1' ||
       process.env?.HIDNS_NO_COLOR === '1'
     );
     const hasTTY = typeof process !== 'undefined' && process.stdout?.isTTY;
-    this.useColors = !noColor && (hasTTY || true); // 默认启用彩色
-    
-    // 初始化时记录日志级别
+    this.useColors = !noColor && (hasTTY || true);
+
     console.info(`[Logger] Log level set to: ${this.logLevel}, Colors: ${this.useColors ? 'enabled' : 'disabled'}`);
   }
 
@@ -118,69 +103,108 @@ class Logger {
     return levels.indexOf(level) >= levels.indexOf(this.logLevel);
   }
 
-  private formatError(error: unknown): ErrorDetails {
+  private isSensitiveKey(key: string): boolean {
+    return SENSITIVE_KEYS.has(key.toLowerCase().replace(/[\s.-]/g, '_')) || SENSITIVE_KEYS.has(key.toLowerCase().replace(/[\s._-]/g, ''));
+  }
+
+  private sanitizeData(data: unknown, depth = 0, seen = new WeakSet<object>()): unknown {
+    if (data === null || data === undefined) return data;
+    if (typeof data === 'string') return data.length > 1000 ? `${data.slice(0, 1000)}...<truncated>` : data;
+    if (typeof data === 'number' || typeof data === 'boolean' || typeof data === 'bigint') return data;
+    if (typeof data === 'function') return `[Function ${(data as Function).name || 'anonymous'}]`;
+    if (Buffer.isBuffer(data)) return `[Buffer length=${data.length}]`;
+    if (data instanceof Date) return data.toISOString();
+    if (data instanceof Error) return this.formatError(data, depth, seen);
+    if (depth >= 5) return '[MaxDepth]';
+
+    if (typeof data === 'object') {
+      if (seen.has(data)) return '[Circular]';
+      seen.add(data);
+
+      if (Array.isArray(data)) {
+        const items = data.slice(0, 50).map((item) => this.sanitizeData(item, depth + 1, seen));
+        if (data.length > 50) items.push(`...${data.length - 50} more items`);
+        return items;
+      }
+
+      const result: Dict = {};
+      for (const [key, value] of Object.entries(data as Dict).slice(0, 80)) {
+        result[key] = this.isSensitiveKey(key) ? '[REDACTED]' : this.sanitizeData(value, depth + 1, seen);
+      }
+      return result;
+    }
+
+    return String(data);
+  }
+
+  private formatError(error: unknown, depth = 0, seen = new WeakSet<object>()): ErrorDetails {
     if (error instanceof Error) {
-      return {
+      const details: ErrorDetails = {
         type: error.constructor.name,
         message: error.message,
         stack: error.stack,
-        ...(error as any).code && { code: (error as any).code },
       };
+      const err = error as Error & Dict;
+      for (const key of ['code', 'errno', 'syscall', 'status', 'statusCode']) {
+        if (err[key] !== undefined) details[key] = err[key];
+      }
+      if (err.cause !== undefined) details.cause = this.sanitizeData(err.cause, depth + 1, seen);
+      if ('errors' in error && Array.isArray((error as Error & { errors?: unknown[] }).errors)) {
+        details.errors = (error as Error & { errors: unknown[] }).errors.map((item: unknown) => this.sanitizeData(item, depth + 1, seen));
+      }
+      return details;
     }
-    // 处理普通对象类型的错误数据
+
     if (error && typeof error === 'object') {
-      const obj = error as Record<string, unknown>;
+      const obj = error as Dict;
       return {
         type: 'Object',
-        message: obj.message ? String(obj.message) : JSON.stringify(error),
-        ...obj,
+        message: obj.message ? String(obj.message) : '[object Object]',
+        ...this.sanitizeData(obj, depth + 1, seen) as Dict,
       };
     }
+
     return {
       type: typeof error,
       message: String(error),
     };
   }
 
+  private formatModules(module: string, subModules?: string[]): string {
+    const primary = `[${module}]`;
+    const subModulePath = (subModules || []).filter(Boolean).join('.');
+    return subModulePath ? `${primary} [${subModulePath}]` : primary;
+  }
+
   private formatMessage(entry: LogEntry): string {
     const time = entry.timestamp;
     const level = entry.level.toUpperCase().padStart(5);
-    // 构建模块路径: [主模块] [子模块1] [子模块2]
-    const modules = [entry.module, ...(entry.subModules || [])].map(m => `[${m}]`).join(' ');
-    // 调用位置: [函数名] [L行号]
+    const modules = this.formatModules(entry.module, entry.subModules);
     const callerStr = entry.callerFunction && entry.callerLine ? ` [${entry.callerFunction}] [L${entry.callerLine}]` : '';
-    // 自定义标签: ["标签1"] ["标签2"]
     const tagStr = (entry.tags || []).map(t => `["${t}"]`).join(' ');
     const middleSection = [modules, callerStr, tagStr ? ` ${tagStr}` : ''].filter(Boolean).join('');
-    
+
     if (!this.useColors) {
       return `${time} ${level} ${middleSection} ${entry.message}`;
     }
-    
-    // 应用颜色
+
     const coloredTime = `${this.colors.timestamp}${time}${this.colors.reset}`;
     const coloredLevel = this.getColorForLevel(entry.level) + level + this.colors.reset;
-    const coloredModules = modules.split(' ').map(m => `${this.colors.module}${m}${this.colors.reset}`).join(' ');
+    const moduleParts = modules.split(' ').map(m => `${this.colors.module}${m}${this.colors.reset}`).join(' ');
     const coloredCaller = callerStr ? callerStr.split(' ').map(m => `${this.colors.context}${m}${this.colors.reset}`).join(' ') : '';
     const coloredTags = tagStr ? ' ' + tagStr.split(' ').map(t => `${this.colors.context}${t}${this.colors.reset}`).join(' ') : '';
-    
-    return `${coloredTime} ${coloredLevel} ${coloredModules}${coloredCaller}${coloredTags} ${entry.message}`;
+
+    return `${coloredTime} ${coloredLevel} ${moduleParts}${coloredCaller}${coloredTags} ${entry.message}`;
   }
 
   private getColorForLevel(level: LogLevel): string {
     return this.colors[level] || this.colors.reset;
   }
 
-  /* 内部日志方法，SubLoggerImpl 通过 logger 实例调用 */
   log(level: LogLevel, module: string, message: string, data?: unknown, subModules?: string[], tags?: string[], callerFunction?: string, callerLine?: number): void {
     if (!this.shouldLog(level)) return;
 
-    // 如果数据是错误类型，格式化为详细错误信息
-    let formattedData = data;
-    if (data instanceof Error || (data && typeof data === 'object' && 'message' in data)) {
-      formattedData = this.formatError(data);
-    }
-
+    const formattedData = data !== undefined ? this.sanitizeData(data) : undefined;
     const entry: LogEntry = {
       timestamp: new Date().toISOString(),
       level,
@@ -194,170 +218,32 @@ class Logger {
     };
 
     const formatted = this.formatMessage(entry);
+    const payload = formattedData !== undefined ? formattedData : '';
 
     switch (level) {
+      case 'trace':
+        console.debug(formatted, payload);
+        break;
       case 'debug':
-        console.debug(formatted, formattedData !== undefined ? formattedData : '');
+        console.debug(formatted, payload);
         break;
       case 'info':
-        console.info(formatted, formattedData !== undefined ? formattedData : '');
+        console.info(formatted, payload);
         break;
       case 'warn':
-        console.warn(formatted, formattedData !== undefined ? formattedData : '');
+        console.warn(formatted, payload);
         break;
       case 'error':
-        console.error(formatted, formattedData !== undefined ? formattedData : '');
+        console.error(formatted, payload);
         break;
     }
   }
 
-  trace(module: string, message: string, data?: unknown): void {
-    this.log('trace', module, message, data);
-  }
-
-  debug(module: string, message: string, data?: unknown): void {
-    this.log('debug', module, message, data);
-  }
-
-  info(module: string, message: string, data?: unknown): void {
-    this.log('info', module, message, data);
-  }
-
-  warn(module: string, message: string, data?: unknown): void {
-    this.log('warn', module, message, data);
-  }
-
-  error(module: string, message: string, data?: unknown): void {
-    this.log('error', module, message, data);
-  }
-
-  // DNS Provider 专用日志方法
-  logProviderRequest(provider: string, method: string, url: string, params?: unknown): void {
-    // DNS 请求日志降级为 debug，避免生产环境日志过多
-    this.debug(`DNS:${provider}`, `Request: ${method} ${url.substring(0, 200)}`, {
-      operationType: 'DNS_REQUEST',
-      provider,
-      method,
-      url: url.substring(0, 200),
-      params,
-    });
-  }
-
-  logProviderResponse(provider: string, status: number, success: boolean, data?: unknown): void {
-    // DNS 响应日志降级为 debug，错误响应使用 warn
-    const logData = {
-      operationType: 'DNS_RESPONSE',
-      provider,
-      status,
-      success,
-      data,
-    };
-    if (!success || status >= 400) {
-      this.warn(`DNS:${provider}`, `Response: status=${status}, success=${success}`, logData);
-    } else {
-      this.debug(`DNS:${provider}`, `Response: status=${status}, success=${success}`, logData);
-    }
-  }
-
-  logProviderError(provider: string, error: unknown): void {
-    this.error(`DNS:${provider}`, 'API Error', {
-      operationType: 'DNS_ERROR',
-      provider,
-      error: this.formatError(error),
-    });
-  }
-
-  // 数据库操作日志
-  logDbQuery(operation: string, sql: string, params?: unknown): void {
-    this.debug('DB', `${operation}: ${sql.substring(0, 100)}`, {
-      operationType: 'DB_QUERY',
-      operation,
-      sql: sql.substring(0, 100),
-      params,
-    });
-  }
-
-  logDbError(operation: string, error: unknown): void {
-    this.error('DB', `Error in ${operation}`, {
-      operationType: 'DB_ERROR',
-      operation,
-      error: this.formatError(error),
-    });
-  }
-
-  // HTTP 请求日志
-  logHttpRequest(method: string, path: string, body?: unknown): void {
-    this.debug('HTTP', `Request: ${method} ${path}`, {
-      operationType: 'HTTP_REQUEST',
-      method,
-      path,
-      body,
-    });
-  }
-
-  logHttpResponse(method: string, path: string, status: number, duration: number): void {
-    // HTTP 响应日志降级为 debug，避免生产环境日志过多
-    // 错误响应（>=400）仍使用 warn 级别
-    const logData = {
-      operationType: 'HTTP_RESPONSE',
-      method,
-      path,
-      status,
-      duration,
-    };
-    if (status >= 400) {
-      this.warn('HTTP', `Response: ${method} ${path} - ${status} (${duration}ms)`, logData);
-    } else {
-      this.debug('HTTP', `Response: ${method} ${path} - ${status} (${duration}ms)`, logData);
-    }
-  }
-
-  // 业务操作日志
-  logBusiness(operation: string, message: string, data?: unknown): void {
-    this.info('Business', `${operation}: ${message}`, {
-      operationType: 'BUSINESS',
-      operation,
-      ...((typeof data === 'object' && data !== null) ? data : { data }),
-    });
-  }
-
-  logBusinessError(operation: string, error: unknown): void {
-    this.error('Business', `Error in ${operation}`, {
-      operationType: 'BUSINESS_ERROR',
-      operation,
-      error: this.formatError(error),
-    });
-  }
-
-  // 用户操作日志
-  logUserAction(userId: number, action: string, target?: string, details?: unknown): void {
-    this.info('User', `User ${userId} performed ${action}`, {
-      operationType: 'USER_ACTION',
-      userId,
-      action,
-      target,
-      details,
-    });
-  }
-
-  // 审计日志
-  logAudit(userId: number, action: string, domain: string, data?: unknown): void {
-    this.info('Audit', `User ${userId} ${action} on ${domain}`, {
-      operationType: 'AUDIT',
-      userId,
-      action,
-      domain,
-      data,
-    });
-  }
-
-  /** 创建嵌套模块日志器 */
   createSubLogger(module: string): SubLogger {
     return new SubLoggerImpl(this, [module], []);
   }
 }
 
-/** 嵌套模块日志器实现，支持 .sub() 和 .tag() 链式调用 */
 class SubLoggerImpl implements SubLogger {
   constructor(
     private logger: Logger,
@@ -379,78 +265,33 @@ class SubLoggerImpl implements SubLogger {
   warn(message: string, data?: unknown) { this.emit('warn', message, data); }
   error(message: string, data?: unknown) { this.emit('error', message, data); }
 
-  /**
-   * 从调用栈中自动捕获调用者函数名和行号
-   * skipFrames = 2: 跳过 emit 自身 + info/debug/warn/error 方法
-   */
-  private getCallerInfo(skipFrames: number): { functionName: string; lineNumber: number } | null {
+  private getCallerInfo(): { functionName: string; lineNumber: number } | null {
     const stack = new Error().stack;
     if (!stack) return null;
-    const lines = stack.split('\n');
-    // 帧分布: 0=Error, 1=getCallerInfo, 2=emit, 3=info/debug/warn/error, 4=实际调用者
-    const idx = skipFrames + 2;
-    if (idx >= lines.length) return null;
-    const frame = lines[idx].trim();
-    // 匹配 V8 栈格式: at functionName (file:line:col) 或 at file:line:col
-    const m = frame.match(/(?:at\s+)?(?:(\S+)\s+\()?(?:\/.+?):(\d+):\d+\)?$/);
-    if (!m) return null;
-    return {
-      functionName: m[1] || '<anonymous>',
-      lineNumber: parseInt(m[2], 10),
-    };
+
+    for (const rawLine of stack.split('\n').slice(1)) {
+      const frame = rawLine.trim();
+      if (!frame || frame.includes('/lib/logger.') || frame.includes('\\lib\\logger.')) continue;
+      const match = frame.match(/(?:at\s+)?(?:(.*?)\s+\()?(.*?):(\d+):(\d+)\)?$/);
+      if (!match) continue;
+      const functionName = (match[1] || '<anonymous>').replace(/^async\s+/, '');
+      return {
+        functionName,
+        lineNumber: parseInt(match[3], 10),
+      };
+    }
+
+    return null;
   }
 
   private emit(level: LogLevel, message: string, data?: unknown) {
-    const callerInfo = this.getCallerInfo(2); // skip emit + info/debug/warn/error
+    const callerInfo = this.getCallerInfo();
     const [primaryModule, ...subModules] = this.modules;
     this.logger.log(level, primaryModule, message, data, subModules, this.tags, callerInfo?.functionName, callerInfo?.lineNumber);
   }
 }
 
 export const logger = Logger.getInstance();
-
-// 便捷导出
-export const log = {
-  trace: (module: string, message: string, data?: unknown) => logger.trace(module, message, data),
-  debug: (module: string, message: string, data?: unknown) => logger.debug(module, message, data),
-  info: (module: string, message: string, data?: unknown) => logger.info(module, message, data),
-  warn: (module: string, message: string, data?: unknown) => logger.warn(module, message, data),
-  error: (module: string, message: string, data?: unknown) => logger.error(module, message, data),
-  
-  // DNS Provider
-  providerRequest: (provider: string, method: string, url: string, params?: unknown) => 
-    logger.logProviderRequest(provider, method, url, params),
-  providerResponse: (provider: string, status: number, success: boolean, data?: unknown) => 
-    logger.logProviderResponse(provider, status, success, data),
-  providerError: (provider: string, error: unknown) => 
-    logger.logProviderError(provider, error),
-  
-  // Database
-  dbQuery: (operation: string, sql: string, params?: unknown) => 
-    logger.logDbQuery(operation, sql, params),
-  dbError: (operation: string, error: unknown) => 
-    logger.logDbError(operation, error),
-  
-  // HTTP
-  httpRequest: (method: string, path: string, body?: unknown) => 
-    logger.logHttpRequest(method, path, body),
-  httpResponse: (method: string, path: string, status: number, duration: number) => 
-    logger.logHttpResponse(method, path, status, duration),
-  
-  // Business
-  business: (operation: string, message: string, data?: unknown) => 
-    logger.logBusiness(operation, message, data),
-  businessError: (operation: string, error: unknown) => 
-    logger.logBusinessError(operation, error),
-  
-  // User
-  userAction: (userId: number, action: string, target?: string, details?: unknown) =>
-    logger.logUserAction(userId, action, target, details),
-  
-  // Audit
-  audit: (userId: number, action: string, domain: string, data?: unknown) =>
-    logger.logAudit(userId, action, domain, data),
-};
 
 export default logger;
 

--- a/server/src/lib/proxy-http.ts
+++ b/server/src/lib/proxy-http.ts
@@ -6,9 +6,10 @@
 import https from 'https';
 import http from 'http';
 import { URL } from 'url';
-import { log } from './logger';
+import { createLogger } from './logger';
 import { SettingsOperations } from '../db/bal/business-adapter';
 
+const log = createLogger('ProxyHttp');
 // Dynamic imports for proxy agents
 let SocksProxyAgent: any;
 let HttpsProxyAgent: any;
@@ -17,14 +18,14 @@ try {
   const socksModule = require('socks-proxy-agent');
   SocksProxyAgent = socksModule.SocksProxyAgent;
 } catch {
-  log.warn('ProxyHTTP', 'socks-proxy-agent not available');
+  log.warn('socks-proxy-agent not available');
 }
 
 try {
   const httpsModule = require('https-proxy-agent');
   HttpsProxyAgent = httpsModule.HttpsProxyAgent;
 } catch {
-  log.warn('ProxyHTTP', 'https-proxy-agent not available');
+  log.warn('https-proxy-agent not available');
 }
 
 /**
@@ -48,7 +49,7 @@ export async function getProxyConfig(): Promise<ProxyConfig | null> {
     if (!configValue) return null;
     return JSON.parse(configValue);
   } catch (error) {
-    log.warn('ProxyHTTP', 'Failed to get proxy config', { error });
+    log.warn('Failed to get proxy config', { error });
     return null;
   }
 }
@@ -73,10 +74,10 @@ export function createProxyAgent(config: ProxyConfig): any | null {
       const proxyUrl = `http://${auth}${config.host}:${config.port}`;
       return new HttpsProxyAgent(proxyUrl);
     }
-    log.warn('ProxyHTTP', 'Proxy agent not available');
+    log.warn('Proxy agent not available');
     return null;
   } catch (error) {
-    log.error('ProxyHTTP', 'Failed to create proxy agent', { error });
+    log.error('Failed to create proxy agent', { error });
     return null;
   }
 }
@@ -195,7 +196,7 @@ export function httpRequest(url: string, options: RequestOptions = {}, agent?: a
  */
 export async function request(url: string, options: RequestOptions = {}): Promise<{ status: number; data: string; headers: Record<string, string> }> {
   const agent = await getProxyAgent();
-  
+
   if (url.startsWith('https://')) {
     return httpsRequest(url, options, agent);
   } else {
@@ -277,7 +278,7 @@ export async function fetchWithFallback(
   // 检查全局代理配置是否启用
   const proxyConfig = await getProxyConfig();
   if (!proxyConfig || !proxyConfig.enabled) {
-    log.info('ProxyHTTP', `[${providerName}] Proxy not configured or disabled, using direct connection`);
+    log.info(`[${providerName}] Proxy not configured or disabled, using direct connection`);
     const res = await fetch(url, options);
     return res;
   }
@@ -285,7 +286,7 @@ export async function fetchWithFallback(
   // 尝试使用代理（设置较短的超时时间）
   const proxyStartTime = Date.now();
   try {
-    log.info('ProxyHTTP', `[${providerName}] Trying proxy request to ${url}`);
+    log.info(`[${providerName}] Trying proxy request to ${url}`);
     const agent = createProxyAgent(proxyConfig);
     if (!agent) {
       throw new Error('Failed to create proxy agent');
@@ -304,7 +305,7 @@ export async function fetchWithFallback(
       : await httpRequest(url, requestOptions, agent);
 
     const proxyDuration = Date.now() - proxyStartTime;
-    log.info('ProxyHTTP', `[${providerName}] Proxy request successful`, { duration: `${proxyDuration}ms` });
+    log.info(`[${providerName}] Proxy request successful`, { duration: `${proxyDuration}ms` });
     return new Response(res.data, {
       status: res.status,
       headers: res.headers,
@@ -312,20 +313,20 @@ export async function fetchWithFallback(
   } catch (proxyError) {
     // 代理请求失败，回退到直连
     const proxyDuration = Date.now() - proxyStartTime;
-    log.warn('ProxyHTTP', `[${providerName}] Proxy request failed after ${proxyDuration}ms, falling back to direct connection`, { 
-      error: proxyError instanceof Error ? proxyError.message : String(proxyError) 
+    log.warn(`[${providerName}] Proxy request failed after ${proxyDuration}ms, falling back to direct connection`, {
+      error: proxyError instanceof Error ? proxyError.message : String(proxyError)
     });
-    
+
     const directStartTime = Date.now();
     try {
       const res = await fetch(url, options);
       const directDuration = Date.now() - directStartTime;
-      log.info('ProxyHTTP', `[${providerName}] Direct connection successful`, { duration: `${directDuration}ms` });
+      log.info(`[${providerName}] Direct connection successful`, { duration: `${directDuration}ms` });
       return res;
     } catch (directError) {
       const directDuration = Date.now() - directStartTime;
-      log.error('ProxyHTTP', `[${providerName}] Direct connection also failed after ${directDuration}ms`, { 
-        error: directError instanceof Error ? directError.message : String(directError) 
+      log.error(`[${providerName}] Direct connection also failed after ${directDuration}ms`, {
+        error: directError instanceof Error ? directError.message : String(directError)
       });
       throw directError;
     }

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -1,14 +1,15 @@
 /**
  * MCP Server 入口文件
- * 
+ *
  * 实现 Model Context Protocol 服务器，提供 DNS 管理工具
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { registerTools } from './tools';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('MCP').sub('Server');
 export class HidnsMcpServer {
   private server: McpServer;
 
@@ -30,7 +31,7 @@ export class HidnsMcpServer {
     // 注册所有工具
     registerTools(this.server);
 
-    log.info('MCP Server', 'HiDNS MCP Server initialized', {
+    log.info('HiDNS MCP Server initialized', {
       capabilities: ['tools'],
       toolCount: 25,
     });
@@ -49,7 +50,7 @@ export class HidnsMcpServer {
   async start(): Promise<void> {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    log.info('MCP Server', 'MCP Server started and connected to stdio transport');
+    log.info('MCP Server started and connected to stdio transport');
   }
 
   /**
@@ -57,7 +58,7 @@ export class HidnsMcpServer {
    */
   async stop(): Promise<void> {
     await this.server.close();
-    log.info('MCP Server', 'MCP Server stopped');
+    log.info('MCP Server stopped');
   }
 }
 

--- a/server/src/mcp/start.ts
+++ b/server/src/mcp/start.ts
@@ -2,37 +2,39 @@
 
 /**
  * MCP Server 独立启动脚本
- * 
+ *
  * 使用方式：
  * npx ts-node src/mcp/start.ts
  */
 
 import { mcpServer } from './server';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('MCP').sub('Start');
 
 async function main() {
   try {
-    log.info('MCP', 'Starting HiDNS MCP Server...');
-    
+    log.info('Starting HiDNS MCP Server...');
+
     // 启动 MCP Server
     await mcpServer.start();
-    
-    log.info('MCP', 'HiDNS MCP Server is running');
-    
+
+    log.info('HiDNS MCP Server is running');
+
     // 保持进程运行
     process.on('SIGINT', async () => {
-      log.info('MCP', 'Received SIGINT, shutting down...');
+      log.info('Received SIGINT, shutting down...');
       await mcpServer.stop();
       process.exit(0);
     });
-    
+
     process.on('SIGTERM', async () => {
-      log.info('MCP', 'Received SIGTERM, shutting down...');
+      log.info('Received SIGTERM, shutting down...');
       await mcpServer.stop();
       process.exit(0);
     });
   } catch (error) {
-    log.error('MCP', 'Failed to start MCP Server', { error });
+    log.error('Failed to start MCP Server', { error });
     process.exit(1);
   }
 }

--- a/server/src/mcp/tools.ts
+++ b/server/src/mcp/tools.ts
@@ -1,6 +1,6 @@
 /**
  * MCP Tools 注册和实现
- * 
+ *
  * 定义所有可用的 MCP 工具及其处理逻辑
  */
 
@@ -13,8 +13,9 @@ import { checkWhoisForDomain } from '../service/whois/checker';
 import { resolveNsRecords, validateNsRecords } from '../lib/dns/ns-lookup';
 import { getFailoverConfig, getFailoverStatus, saveFailoverConfig, deleteFailoverConfig, performHealthCheck } from '../service/failover';
 import { AppError } from '../middleware/errorHandler';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('MCP').sub('Tools');
 /**
  * 认证请求 - 验证 API Key 或 OAuth2 Token
  */
@@ -24,63 +25,63 @@ async function authenticateRequest(apiKey?: string): Promise<AuthResult> {
   if (!apiKey) {
     return null;
   }
-  
+
   try {
     // 先尝试作为 API Key 验证（保持向后兼容）
     const keyInfo = await McpOperations.validateApiKey(apiKey);
-    
+
     if (keyInfo) {
       // 检查是否已撤销
       if (keyInfo.revoked_at) {
-        log.warn('MCP Auth', 'API key has been revoked', { keyId: keyInfo.id });
+        log.warn('API key has been revoked', { keyId: keyInfo.id });
         return null;
       }
-      
+
       // 检查是否过期
       if (keyInfo.expires_at && new Date(keyInfo.expires_at) < new Date()) {
-        log.warn('MCP Auth', 'API key has expired', { keyId: keyInfo.id, expiresAt: keyInfo.expires_at });
+        log.warn('API key has expired', { keyId: keyInfo.id, expiresAt: keyInfo.expires_at });
         return null;
       }
-      
-      log.info('MCP Auth', 'API key validated successfully', { 
-        userId: keyInfo.user_id, 
+
+      log.info('API key validated successfully', {
+        userId: keyInfo.user_id,
         keyId: keyInfo.id,
-        description: keyInfo.description 
+        description: keyInfo.description
       });
-      
+
       return {
         userId: keyInfo.user_id,
         authType: 'api_key',
         keyId: keyInfo.id,
       };
     }
-    
+
     // API Key 验证失败，尝试作为 OAuth2 Access Token 验证
     const tokenInfo = await McpOperations.validateAccessToken(apiKey);
-    
+
     if (tokenInfo) {
       // 检查是否过期
       if (new Date(tokenInfo.expires_at) < new Date()) {
-        log.warn('MCP Auth', 'OAuth token has expired');
+        log.warn('OAuth token has expired');
         return null;
       }
-      
-      log.info('MCP Auth', 'OAuth token validated successfully', {
+
+      log.info('OAuth token validated successfully', {
         userId: tokenInfo.user_id,
         clientId: tokenInfo.client_id,
       });
-      
+
       return {
         userId: tokenInfo.user_id,
         authType: 'oauth2',
         scope: tokenInfo.scope || undefined,
       };
     }
-    
-    log.warn('MCP Auth', 'Invalid API key or OAuth token');
+
+    log.warn('Invalid API key or OAuth token');
     return null;
   } catch (error) {
-    log.error('MCP Auth', 'Failed to validate API key or OAuth token', { error });
+    log.error('Failed to validate API key or OAuth token', { error });
     return null;
   }
 }
@@ -117,7 +118,7 @@ async function requireTokenScope(auth: AuthResult, toolName: string, requiredPer
 
   if (requiredPermission === 'write') {
     if (!scopes.includes(writeScope)) {
-      log.warn('MCP Auth', 'OAuth token scope insufficient for write', {
+      log.warn('OAuth token scope insufficient for write', {
         module, requiredScope, tokenScope: auth.scope
       });
       throw new AppError(403, `Token does not have '${writeScope}' scope`);
@@ -125,7 +126,7 @@ async function requireTokenScope(auth: AuthResult, toolName: string, requiredPer
   } else {
     // read 操作：需要 read 或 write 权限
     if (!scopes.includes(requiredScope) && !scopes.includes(writeScope)) {
-      log.warn('MCP Auth', 'OAuth token scope insufficient for read', {
+      log.warn('OAuth token scope insufficient for read', {
         module, requiredScope, tokenScope: auth.scope
       });
       throw new AppError(403, `Token does not have '${requiredScope}' scope`);
@@ -162,10 +163,10 @@ export function registerTools(server: McpServer): void {
 
         // 获取所有启用的 NS 监控域名
         let nsDomains = await NSMonitorOperations.getAllEnabled();
-        
+
         // 如果有关键词，进行过滤
         if (keyword) {
-          nsDomains = nsDomains.filter((domain: any) => 
+          nsDomains = nsDomains.filter((domain: any) =>
             domain.domain_name?.toLowerCase().includes(keyword.toLowerCase())
           );
         }
@@ -193,7 +194,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'list_ns_records failed', { error });
+        log.error('list_ns_records failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -230,7 +231,7 @@ export function registerTools(server: McpServer): void {
         // 调用实际的域名列表 API
         const pageNum = page || 1;
         const pageSizeNum = pageSize || 50;
-        
+
         // 使用 DomainOperations 获取域名列表
         const domains = await DomainOperations.getAllForSuperAdminWithPagination({
           keyword,
@@ -265,7 +266,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'list_domains failed', { error });
+        log.error('list_domains failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -295,7 +296,7 @@ export function registerTools(server: McpServer): void {
 
         // 调用实际的域名信息查询
         const domain = await DomainOperations.getById(domainId);
-        
+
         if (!domain) {
           return {
             content: [{ type: 'text', text: `Domain with ID ${domainId} not found` }],
@@ -325,7 +326,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'get_domain_info failed', { error });
+        log.error('get_domain_info failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -359,21 +360,21 @@ export function registerTools(server: McpServer): void {
 
         // 获取所有启用的续期域名
         const renewableDomains = await RenewableDomainOperations.getAllEnabled();
-        
+
         const daysThreshold = daysBeforeExpiry || 30;
         const now = new Date();
         const thresholdDate = new Date(now.getTime() + daysThreshold * 24 * 60 * 60 * 1000);
-        
+
         // 过滤出即将到期的域名
         const expiringDomains = renewableDomains.filter((domain: any) => {
           if (domain.never_expires) {
             return false; // 永不过期的域名不显示
           }
-          
+
           if (!domain.expires_at) {
             return false; // 没有到期日期的不显示
           }
-          
+
           const expiryDate = new Date(domain.expires_at);
           return expiryDate <= thresholdDate && expiryDate > now;
         });
@@ -402,7 +403,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'get_renewable_domains failed', { error });
+        log.error('get_renewable_domains failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -499,7 +500,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'query_audit_logs failed', { error });
+        log.error('query_audit_logs failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -581,7 +582,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'get_audit_stats failed', { error });
+        log.error('get_audit_stats failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -638,7 +639,7 @@ export function registerTools(server: McpServer): void {
         }
 
         const whereClause = conditions.join(' AND ');
-        
+
         // 获取所有匹配的日志（不分页）
         const logs = await AuditExportOperations.getLogs(whereClause, params, 10000, 0);
 
@@ -697,7 +698,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'export_audit_logs failed', { error });
+        log.error('export_audit_logs failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -753,7 +754,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'list_failover_rules failed', { error });
+        log.error('list_failover_rules failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -817,7 +818,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'get_failover_config failed', { error });
+        log.error('get_failover_config failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -889,7 +890,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'create_failover_config failed', { error });
+        log.error('create_failover_config failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -943,7 +944,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'delete_failover_config failed', { error });
+        log.error('delete_failover_config failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -973,7 +974,7 @@ export function registerTools(server: McpServer): void {
 
         // 获取容灾配置
         const config = await getFailoverConfig(domainId);
-        
+
         if (!config) {
           return {
             content: [{ type: 'text', text: `No failover configuration found for domain ${domainId}` }],
@@ -983,7 +984,7 @@ export function registerTools(server: McpServer): void {
 
         // 获取当前状态
         const status = await getFailoverStatus(config.id);
-        
+
         if (!status) {
           return {
             content: [{ type: 'text', text: `No failover status found for config ${config.id}` }],
@@ -1024,7 +1025,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'perform_health_check failed', { error });
+        log.error('perform_health_check failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1078,7 +1079,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: `Domain ${domainId} ${enabled ? 'enabled' : 'disabled'} successfully` }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'update_domain_status failed', { error });
+        log.error('update_domain_status failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1138,7 +1139,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify({ total: result.total, records: result.list }, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'list_domain_records failed', { error });
+        log.error('list_domain_records failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1187,7 +1188,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify({ lines }, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'get_dns_lines failed', { error });
+        log.error('get_dns_lines failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1252,7 +1253,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: `DNS record created successfully with ID: ${recordId}${line ? ` (Line: ${line})` : ''}` }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'create_dns_record failed', { error });
+        log.error('create_dns_record failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1334,7 +1335,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: `DNS record ${recordId} updated successfully${line ? ` (Line: ${line})` : ''}` }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'update_dns_record failed', { error });
+        log.error('update_dns_record failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1388,7 +1389,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: `DNS record ${recordId} deleted successfully` }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'delete_dns_record failed', { error });
+        log.error('delete_dns_record failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1422,7 +1423,7 @@ export function registerTools(server: McpServer): void {
 
         // 获取域名信息
         const domain = await DomainOperations.getById(domainId);
-        
+
         if (!domain) {
           return {
             content: [{ type: 'text', text: `Domain with ID ${domainId} not found` }],
@@ -1454,7 +1455,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'get_domain_remark failed', { error });
+        log.error('get_domain_remark failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1484,7 +1485,7 @@ export function registerTools(server: McpServer): void {
 
         // 获取用户的置顶域名列表
         const pinnedDomains = await UserPreferencesOperations.getPinnedDomains(auth.userId);
-        
+
         const isPinned = pinnedDomains.includes(domainId);
 
         const result = {
@@ -1511,7 +1512,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'get_domain_pinned_status failed', { error });
+        log.error('get_domain_pinned_status failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1544,7 +1545,7 @@ export function registerTools(server: McpServer): void {
 
         const pageNum = page || 1;
         const pageSizeNum = pageSize || 50;
-        
+
         // 使用 DomainOperations 获取域名列表（自动过滤禁用的账号）
         const domains = await DomainOperations.getAllForSuperAdminWithPagination({
           keyword,
@@ -1588,7 +1589,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'list_domains_filtered failed', { error });
+        log.error('list_domains_filtered failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1642,7 +1643,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: `Domain ${renewableDomainId} renewed successfully. New expiry: ${newExpiresAt}` }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'manual_renew_domain failed', { error });
+        log.error('manual_renew_domain failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1691,7 +1692,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: `Renewal disabled for domain ${renewableDomainId}` }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'disable_domain_renewal failed', { error });
+        log.error('disable_domain_renewal failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1741,7 +1742,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(whoisResult, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'get_domain_whois failed', { error });
+        log.error('get_domain_whois failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1775,7 +1776,7 @@ export function registerTools(server: McpServer): void {
 
         // 获取 NS 监控配置
         const monitorConfig = await NSMonitorOperations.getById(nsMonitorId) as any;
-        
+
         if (!monitorConfig) {
           return {
             content: [{ type: 'text', text: `NS monitor ${nsMonitorId} not found` }],
@@ -1783,9 +1784,9 @@ export function registerTools(server: McpServer): void {
           };
         }
 
-        log.info('MCP Tool', 'Starting manual NS check', { 
-          domain: monitorConfig.domain_name, 
-          monitorId: nsMonitorId 
+        log.info('Starting manual NS check', {
+          domain: monitorConfig.domain_name,
+          monitorId: nsMonitorId
         });
 
         // 查询当前 NS 记录（带DNS污染检测）
@@ -1836,14 +1837,14 @@ export function registerTools(server: McpServer): void {
           plain_ns: plainNs,
           expected_ns: expectedList,
           last_check_at: nowStr,
-          message: status === 'ok' 
-            ? 'NS records are normal' 
+          message: status === 'ok'
+            ? 'NS records are normal'
             : `NS anomaly detected: ${status}`,
         };
 
         // 如果状态异常，记录到审计日志
         if (status !== 'ok') {
-          log.warn('MCP Tool', 'NS record anomaly detected during manual refresh', {
+          log.warn('NS record anomaly detected during manual refresh', {
             domain: monitorConfig.domain_name,
             status,
             isPoisoned: nsResult.isPoisoned,
@@ -1871,7 +1872,7 @@ export function registerTools(server: McpServer): void {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
-        log.error('MCP Tool', 'refresh_ns_monitor failed', { error });
+        log.error('refresh_ns_monitor failed', { error });
         return {
           content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
           isError: true,
@@ -1880,5 +1881,5 @@ export function registerTools(server: McpServer): void {
     }
   );
 
-  log.info('MCP Tools', `Registered ${Object.keys(server['_registeredTools'] || {}).length} tools`);
+  log.info(`Registered ${Object.keys(server['_registeredTools'] || {}).length} tools`);
 }

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -6,26 +6,27 @@ import { isAdmin, normalizeRole } from '../utils/roles';
 import { SecretOperations } from '../db/bal/business-adapter';
 import { verifyToken, hasServicePermission, hasDomainPermission } from '../service/token';
 import { TokenPayload } from '../types/token';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('HTTP').sub('Middleware').sub('Auth');
 // JWT密钥配置 - 如果没有设置则随机生成
 const BASE_JWT_SECRET = (() => {
   const secret = process.env.JWT_SECRET;
-  
+
   // 如果设置了环境变量，使用环境变量
   if (secret) {
     // 生产环境检查密钥强度
     if (process.env.NODE_ENV === 'production' && secret.length < 32) {
-      log.error('Auth', 'JWT_SECRET must be at least 32 characters long in production!');
+      log.error('JWT_SECRET must be at least 32 characters long in production!');
       process.exit(1);
     }
     return secret;
   }
-  
+
   // 如果没有设置，生成随机密钥（每次重启服务会变化，仅适合开发环境）
     const generatedSecret = crypto.randomBytes(32).toString('hex');
-    log.warn('Auth', 'JWT_SECRET not set, using randomly generated secret.');
-    log.warn('Auth', 'For production, please set JWT_SECRET environment variable to ensure token persistence across restarts.');
+    log.warn('JWT_SECRET not set, using randomly generated secret.');
+    log.warn('For production, please set JWT_SECRET environment variable to ensure token persistence across restarts.');
     return generatedSecret;
 })();
 
@@ -34,7 +35,7 @@ let runtimeSecretCache: string | null = null;
 
 async function getRuntimeSecret(): Promise<string> {
   if (runtimeSecretCache) return runtimeSecretCache;
-  
+
   try {
     // 使用业务适配器获取运行时密钥
     const value = await SecretOperations.getRuntimeSecret(RUNTIME_SECRET_KEY);
@@ -45,18 +46,18 @@ async function getRuntimeSecret(): Promise<string> {
   } catch {
     // Table might not exist, will create below
   }
-  
+
   // Fallback in case initSchema has not rotated secrets yet.
   const generated = crypto.randomBytes(32).toString('hex');
-  
+
   try {
     // 使用业务适配器创建表和插入密钥
     await SecretOperations.ensureRuntimeSecretsTable();
     await SecretOperations.setRuntimeSecret(RUNTIME_SECRET_KEY, generated);
   } catch (e) {
-    log.error('Auth', 'Error creating runtime_secrets table', { error: e });
+    log.error('Error creating runtime_secrets table', { error: e });
   }
-  
+
   runtimeSecretCache = generated;
   return generated;
 }
@@ -69,19 +70,19 @@ async function getJwtSecret(): Promise<string> {
 export async function authMiddleware(req: Request, res: Response, next: NextFunction): Promise<void> {
   // Try to get token from httpOnly cookie first, then fallback to Authorization header
   let token = req.cookies?.token;
-  
+
   if (!token) {
     const header = req.headers.authorization;
     if (header?.startsWith('Bearer ')) {
       token = header.slice(7);
     }
   }
-  
+
   if (!token) {
     res.status(401).json({ code: -1, msg: 'Unauthorized' });
     return;
   }
-  
+
   // First try to verify as JWT
   try {
     const jwtSecret = await getJwtSecret();
@@ -92,7 +93,7 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
   } catch {
     // Not a valid JWT, try user token
   }
-  
+
   // Try to verify as user token
   const tokenPayload = await verifyToken(token);
   if (tokenPayload) {
@@ -107,7 +108,7 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
     next();
     return;
   }
-  
+
   res.status(401).json({ code: -1, msg: 'Invalid or expired token' });
 }
 
@@ -115,18 +116,18 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
 export function requireServicePermission(service: string) {
   return (req: Request, res: Response, next: NextFunction): void => {
     const tokenPayload = (req as any).tokenPayload as TokenPayload | undefined;
-    
+
     // If not using token auth, allow (JWT auth has its own checks)
     if (!tokenPayload) {
       next();
       return;
     }
-    
+
     if (!hasServicePermission(tokenPayload, service)) {
       res.status(403).json({ code: -1, msg: `Token does not have permission for ${service}` });
       return;
     }
-    
+
     next();
   };
 }
@@ -176,9 +177,9 @@ function isTokenAuth(req: Request): boolean {
 export function noTokenAuth(routeName: string = 'this resource') {
   return (req: Request, res: Response, next: NextFunction): void => {
     if (isTokenAuth(req)) {
-      res.status(403).json({ 
-        code: -1, 
-        msg: `API token is not allowed to access ${routeName}. Please use JWT authentication.` 
+      res.status(403).json({
+        code: -1,
+        msg: `API token is not allowed to access ${routeName}. Please use JWT authentication.`
       });
       return;
     }
@@ -219,13 +220,13 @@ export function requireTokenDomainPermission(paramName: string = 'id') {
       next();
       return;
     }
-    
+
     // 空数组表示允许所有域名（向后兼容 ddns-go 等外部工具）
     // 如果需要限制权限，请显式配置 allowedDomains
     if (tokenPayload.allowedDomains.length === 0) {
-      log.debug('Auth', 'Token has no domain restrictions, allowing all domains', { 
+      log.debug('Token has no domain restrictions, allowing all domains', {
         tokenId: tokenPayload.tokenId,
-        userId: tokenPayload.userId 
+        userId: tokenPayload.userId
       });
       next();
       return;

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,7 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { getRequestIP } from './clientIP';
 
+const log = createLogger('HTTP').sub('Middleware').sub('ErrorHandler');
 /**
  * Standard API error response format
  */
@@ -36,7 +37,7 @@ export function errorHandler(
   res: Response,
   next: NextFunction
 ): void {
-  log.error('Error', `Request error: ${err.message}`, {
+  log.error(`Request error: ${err.message}`, {
     name: err.name,
     message: err.message,
     stack: err.stack,

--- a/server/src/middleware/requestLogger.ts
+++ b/server/src/middleware/requestLogger.ts
@@ -1,7 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { getRequestIP } from './clientIP';
 
+const log = createLogger('HTTP').sub('Middleware').sub('RequestLogger');
 /**
  * Request logging middleware
  * Logs all incoming requests with method, path, status, and duration
@@ -18,26 +19,26 @@ export function requestLogger(req: Request, res: Response, next: NextFunction): 
 
     // 扁平化日志：只保留关键信息
     const logLevel = statusCode >= 500 ? 'error' : statusCode >= 400 ? 'warn' : 'debug';
-    
+
     // 基础日志数据（精简）
     const baseLog = `${req.method} ${req.path} ${statusCode} ${duration}ms`;
-    
+
     // 错误和警告才记录详细信息
     if (logLevel === 'error') {
-      log.error('HTTP', baseLog, { 
+      log.error(baseLog, {
         ip: getRequestIP(req),
         error: 'Server error'
       });
     } else if (logLevel === 'warn') {
       // 404 等警告只记录基础信息
       if (statusCode === 404) {
-        log.debug('HTTP', baseLog);
+        log.debug(baseLog);
       } else {
-        log.warn('HTTP', baseLog, { ip: getRequestIP(req) });
+        log.warn(baseLog, { ip: getRequestIP(req) });
       }
     } else {
       // 正常请求使用 debug 级别
-      log.debug('HTTP', baseLog);
+      log.debug(baseLog);
     }
   };
 

--- a/server/src/routes/accounts.ts
+++ b/server/src/routes/accounts.ts
@@ -9,8 +9,9 @@ import { isAdmin, isSuper, normalizeRole, ROLE_ADMIN } from '../utils/roles';
 import { parseInteger, sendError, sendSuccess, sendServerError } from '../utils/http';
 import { wsService } from '../service/websocket';
 import { logAuditOperation } from '../service/audit';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('HTTP').sub('Route').sub('Accounts');
 const router = Router();
 
 async function canReadAccount(account: DnsAccount, userId: number, role: number): Promise<boolean> {
@@ -65,7 +66,7 @@ router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response)
     const teamIds = teams.map(r => r.id as number);
     accounts = await DnsAccountOperations.getAccessibleByUserId(userId, teamIds) as unknown as DnsAccount[];
   }
-  
+
   // Check if showDnsProviderSecrets is enabled
   let showSecrets = false;
   try {
@@ -77,7 +78,7 @@ router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response)
   } catch {
     // Ignore errors, default to false
   }
-  
+
   // Mask config secrets unless showDnsProviderSecrets is enabled
   const safe = accounts.map(a => {
     // MySQL JSON type returns object directly, SQLite/PostgreSQL returns string
@@ -146,7 +147,7 @@ router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response
     sendError(res, 'Provider is a stub and cannot be added');
     return;
   }
-  
+
   // Check for duplicate account name under the same provider type
   const existingAccounts = await DnsAccountOperations.getAll() as any[];
   const duplicate = existingAccounts.find(
@@ -156,7 +157,7 @@ router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response
     sendError(res, `Account name "${name}" already exists for provider ${normalizedType}`);
     return;
   }
-  
+
   try {
     const dnsAdapter = createAdapter(normalizedType, config);
     const ok = await dnsAdapter.check();
@@ -176,10 +177,10 @@ router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response
     created_by: req.user!.userId,
     team_id: team_id ?? null
   });
-  
+
   // 获取完整的账户数据用于 WebSocket 推送
   const newAccount = await DnsAccountOperations.getById(id);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -190,9 +191,9 @@ router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response
       },
     });
   } catch (error) {
-    log.error('Accounts', 'Failed to broadcast account_created event', { error });
+    log.error('Failed to broadcast account_created event', { error });
   }
-  
+
   sendSuccess(res, { id });
 }));
 
@@ -222,7 +223,7 @@ router.get('/:id', authMiddleware, asyncHandler(async (req: Request, res: Respon
     sendError(res, 'Account not found');
     return;
   }
-  
+
   // Check if showDnsProviderSecrets is enabled
   let showSecrets = false;
   try {
@@ -234,7 +235,7 @@ router.get('/:id', authMiddleware, asyncHandler(async (req: Request, res: Respon
   } catch {
     // Ignore errors, default to false
   }
-  
+
   // MySQL JSON type returns object directly, SQLite/PostgreSQL returns string
   const cfg = typeof account.config === 'string' ? JSON.parse(account.config) as Record<string, string> : account.config as Record<string, string>;
   const masked: Record<string, string> = {};
@@ -315,16 +316,16 @@ router.put('/:id', authMiddleware, asyncHandler(async (req: Request, res: Respon
       return;
     }
   }
-  
+
   // Check for duplicate account name when updating name or type
   if (name !== undefined || normalizedType !== undefined) {
     const newName = name ?? account.name;
     const newType = normalizedType ?? account.type;
     const existingAccounts = await DnsAccountOperations.getAll() as any[];
     const duplicate = existingAccounts.find(
-      (acc) => 
-        acc.id !== id && 
-        acc.type === newType && 
+      (acc) =>
+        acc.id !== id &&
+        acc.type === newType &&
         acc.name.toLowerCase() === newName.toLowerCase()
     );
     if (duplicate) {
@@ -332,24 +333,24 @@ router.put('/:id', authMiddleware, asyncHandler(async (req: Request, res: Respon
       return;
     }
   }
-  
+
   const updates: Record<string, unknown> = {};
   if (normalizedType !== undefined) updates.type = normalizedType;
   if (name !== undefined) updates.name = name;
   if (config !== undefined) updates.config = JSON.stringify(config);
   if (remark !== undefined) updates.remark = remark;
   if (team_id !== undefined) updates.team_id = team_id;
-  
+
   if (Object.keys(updates).length === 0) {
     sendSuccess(res);
     return;
   }
-  
+
   await DnsAccountOperations.update(id, updates);
-  
+
   // 获取更新后的完整账户数据用于 WebSocket 推送
   const updatedAccount = await DnsAccountOperations.getById(id);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -360,9 +361,9 @@ router.put('/:id', authMiddleware, asyncHandler(async (req: Request, res: Respon
       },
     });
   } catch (error) {
-    log.error('Accounts', 'Failed to broadcast account_updated event', { error });
+    log.error('Failed to broadcast account_updated event', { error });
   }
-  
+
   sendSuccess(res);
 }));
 
@@ -392,7 +393,7 @@ router.delete('/:id', authMiddleware, asyncHandler(async (req: Request, res: Res
     return;
   }
   await DnsAccountOperations.delete(id);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -403,9 +404,9 @@ router.delete('/:id', authMiddleware, asyncHandler(async (req: Request, res: Res
       },
     });
   } catch (error) {
-    log.error('Accounts', 'Failed to broadcast account_deleted event', { error });
+    log.error('Failed to broadcast account_deleted event', { error });
   }
-  
+
   sendSuccess(res);
 }));
 
@@ -419,22 +420,22 @@ router.patch('/:id/toggle-enabled', authMiddleware, asyncHandler(async (req: Req
     sendError(res, 'Account not found');
     return;
   }
-  
+
   const { enabled } = req.body;
   if (typeof enabled !== 'boolean') {
     sendError(res, 'Enabled field is required and must be boolean');
     return;
   }
-  
-  log.info('Accounts', 'Toggle account enabled status', { 
-    id, 
+
+  log.info('Toggle account enabled status', {
+    id,
     enabled,
-    userId: req.user?.userId 
+    userId: req.user?.userId
   });
-  
+
   try {
     await DnsAccountOperations.updateEnabled(id, enabled);
-    
+
     // Log audit operation
     await logAuditOperation(
       req.user!.userId,
@@ -443,13 +444,13 @@ router.patch('/:id/toggle-enabled', authMiddleware, asyncHandler(async (req: Req
       { enabled, accountId: id },
       req
     );
-    
-    log.info('Accounts', 'Successfully toggled account enabled status', { 
-      id, 
+
+    log.info('Successfully toggled account enabled status', {
+      id,
       enabled,
-      userId: req.user?.userId 
+      userId: req.user?.userId
     });
-    
+
     // Broadcast WebSocket event with full account data
     try {
       const updatedAccount = await DnsAccountOperations.getById(id);
@@ -461,12 +462,12 @@ router.patch('/:id/toggle-enabled', authMiddleware, asyncHandler(async (req: Req
         },
       });
     } catch (error) {
-      log.error('Accounts', 'Failed to broadcast account_updated event', { error });
+      log.error('Failed to broadcast account_updated event', { error });
     }
-    
+
     sendSuccess(res, { enabled });
   } catch (error) {
-    log.error('Accounts', 'Failed to toggle account enabled status', { 
+    log.error('Failed to toggle account enabled status', {
       id,
       error: error instanceof Error ? error.message : String(error),
     });

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -10,7 +10,7 @@ import { getSmtpConfig, sendSmtpEmail } from '../service/smtp';
 import { getUserPreferences, updateUserPreferences, UserPreferences } from '../service/userPreferences';
 import { loginLimiter, emailLimiter } from '../middleware/rateLimit';
 import { getTOTPStatus, verifyTOTPToken, verifyBackupCode } from '../service/totp';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { UserOperations, OAuthOperations, TwoFAOperations, SettingsOperations, UserPreferencesOperations, DomainOperations } from '../db/bal/business-adapter';
 import { requires2FA, has2FAEnabled, validatePassword, getSecurityPolicy, SecurityPolicy } from '../service/securityPolicy';
 import { verifyTrustedDevice, addTrustedDevice, DeviceInfo } from '../service/deviceTrust';
@@ -18,6 +18,7 @@ import { getRequestIP } from '../middleware/clientIP';
 import db from '../db/bal/business-adapter';
 import { sendError } from '../utils/http';
 
+const log = createLogger('HTTP').sub('Route').sub('Auth');
 /**
  * RSA Key Pair for password encryption
  * Generated once and cached for the lifetime of the server
@@ -33,11 +34,11 @@ let keyGeneratedAt = 0;
 
 function getOrGenerateRSAKeyPair(): RSAKeyPair {
   const now = Date.now();
-  
+
   // Regenerate keys if expired or not generated
   if (!rsaKeyPair || (now - keyGeneratedAt) > KEY_CACHE_TTL) {
-    log.info('Auth', 'Generating new RSA key pair for password encryption');
-    
+    log.info('Generating new RSA key pair for password encryption');
+
     const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
       modulusLength: 2048,
       publicKeyEncoding: {
@@ -49,21 +50,21 @@ function getOrGenerateRSAKeyPair(): RSAKeyPair {
         format: 'pem'
       }
     });
-    
+
     rsaKeyPair = { publicKey, privateKey };
     keyGeneratedAt = now;
   }
-  
+
   return rsaKeyPair;
 }
 
 function decryptPassword(encryptedPassword: string): string {
   try {
     const keyPair = getOrGenerateRSAKeyPair();
-    
+
     // Decode from base64
     const buffer = Buffer.from(encryptedPassword, 'base64');
-    
+
     // Decrypt using private key
     const decrypted = crypto.privateDecrypt(
       {
@@ -73,10 +74,10 @@ function decryptPassword(encryptedPassword: string): string {
       },
       buffer
     );
-    
+
     return decrypted.toString('utf-8');
   } catch (error) {
-    log.error('Auth', 'Failed to decrypt password', { error: error instanceof Error ? error.message : String(error) });
+    log.error('Failed to decrypt password', { error: error instanceof Error ? error.message : String(error) });
     throw new Error('Invalid encrypted password');
   }
 }
@@ -195,14 +196,14 @@ function randomHex(size: number): string {
 
 function addProcessedCode(code: string): void {
   const now = Date.now();
-  
+
   // 先清理过期条目
   for (const [key, timestamp] of processedCodes.entries()) {
     if (now - timestamp > PROCESSED_CODES_TTL) {
       processedCodes.delete(key);
     }
   }
-  
+
   // 如果仍然超过限制，删除最旧的条目
   if (processedCodes.size >= MAX_PROCESSED_CODES) {
     let oldestKey: string | undefined;
@@ -217,7 +218,7 @@ function addProcessedCode(code: string): void {
       processedCodes.delete(oldestKey);
     }
   }
-  
+
   processedCodes.set(code, now);
 }
 
@@ -280,16 +281,16 @@ async function exchangeOauthCode(config: OAuthConfig, code: string): Promise<{ a
     client_secret: config.clientSecret,
     redirect_uri: config.redirectUri,
   });
-  log.debug('OAuth', 'Token request', { endpoint: config.tokenEndpoint, body: body.toString() });
+  log.debug('Token request', { endpoint: config.tokenEndpoint, body: body.toString() });
   try {
     const response = await fetch(config.tokenEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: body.toString(),
     });
-    log.debug('OAuth', 'Token response', { status: response.status });
+    log.debug('Token response', { status: response.status });
     const tokenPayload = await response.json() as { access_token?: string; id_token?: string; error?: string; error_description?: string };
-    log.debug('OAuth', 'Token response payload', { payload: tokenPayload });
+    log.debug('Token response payload', { payload: tokenPayload });
     if (!response.ok) {
       throw new Error(`OAuth token exchange failed: HTTP ${response.status}${tokenPayload.error_description ? ' - ' + tokenPayload.error_description : ''}`);
     }
@@ -298,7 +299,7 @@ async function exchangeOauthCode(config: OAuthConfig, code: string): Promise<{ a
     }
     return { accessToken: tokenPayload.access_token, idToken: tokenPayload.id_token || '' };
   } catch (error) {
-    log.error('OAuth', 'Token request failed', { error: error instanceof Error ? error.message : String(error), endpoint: config.tokenEndpoint });
+    log.error('Token request failed', { error: error instanceof Error ? error.message : String(error), endpoint: config.tokenEndpoint });
     throw error;
   }
 }
@@ -385,23 +386,23 @@ async function verifyIdToken(idToken: string, config: OAuthConfig): Promise<OAut
   const header = JSON.parse(decodeBase64Url(parts[0]).toString('utf8')) as { alg?: string; kid?: string };
   const payload = JSON.parse(decodeBase64Url(parts[1]).toString('utf8')) as Record<string, unknown>;
 
-  log.debug('OAuth', 'id_token header', { header });
-  log.debug('OAuth', 'id_token payload', { payload });
-  log.debug('OAuth', 'Expected issuer', { issuer: config.issuer });
-  log.debug('OAuth', 'Expected clientId', { clientId: config.clientId });
-  log.debug('OAuth', 'JWKS URI', { jwksUri: config.jwksUri });
+  log.debug('id_token header', { header });
+  log.debug('id_token payload', { payload });
+  log.debug('Expected issuer', { issuer: config.issuer });
+  log.debug('Expected clientId', { clientId: config.clientId });
+  log.debug('JWKS URI', { jwksUri: config.jwksUri });
 
   if (!header.alg || !header.kid) throw new Error('id_token missing alg or kid');
 
   const jwksResp = await fetch(config.jwksUri);
-  log.debug('OAuth', 'JWKS fetch status', { status: jwksResp.status });
+  log.debug('JWKS fetch status', { status: jwksResp.status });
   if (!jwksResp.ok) throw new Error(`JWKS fetch failed: HTTP ${jwksResp.status}`);
   const jwks = await jwksResp.json() as { keys?: Array<Record<string, unknown>> };
-  log.debug('OAuth', 'JWKS keys count', { count: jwks.keys?.length });
-  log.debug('OAuth', 'JWKS keys', { keys: jwks.keys?.map(k => ({ kid: k.kid, alg: k.alg, kty: k.kty })) });
+  log.debug('JWKS keys count', { count: jwks.keys?.length });
+  log.debug('JWKS keys', { keys: jwks.keys?.map(k => ({ kid: k.kid, alg: k.alg, kty: k.kty })) });
 
   const jwk = (jwks.keys || []).find((key) => String(key.kid || '') === header.kid);
-  log.debug('OAuth', 'Matched JWK', { jwk: jwk ? { kid: jwk.kid, alg: jwk.alg, kty: jwk.kty } : 'NOT FOUND' });
+  log.debug('Matched JWK', { jwk: jwk ? { kid: jwk.kid, alg: jwk.alg, kty: jwk.kty } : 'NOT FOUND' });
   if (!jwk) throw new Error('Unable to find matching JWKS key for id_token');
 
   const verifyAlgMap: Record<string, string> = {
@@ -413,12 +414,12 @@ async function verifyIdToken(idToken: string, config: OAuthConfig): Promise<OAut
     ES512: 'sha512',
   };
   const verifyAlg = verifyAlgMap[header.alg];
-  log.debug('OAuth', 'Using verify algorithm', { verifyAlg });
+  log.debug('Using verify algorithm', { verifyAlg });
   if (!verifyAlg) throw new Error(`Unsupported id_token algorithm: ${header.alg}`);
   const publicKey = crypto.createPublicKey({ key: jwk as crypto.JsonWebKey, format: 'jwk' });
   const signingInput = `${parts[0]}.${parts[1]}`;
   let signature = decodeBase64Url(parts[2]);
-  log.debug('OAuth', 'Original signature length', { length: signature.length });
+  log.debug('Original signature length', { length: signature.length });
 
   if (header.alg.startsWith('ES') && jwk.kty === 'EC') {
     const keySize = header.alg === 'ES256' ? 32 : header.alg === 'ES384' ? 48 : 66;
@@ -426,12 +427,12 @@ async function verifyIdToken(idToken: string, config: OAuthConfig): Promise<OAut
       const r = signature.slice(0, keySize);
       const s = signature.slice(keySize);
       signature = ellipticSigToDer(r, s);
-      log.debug('OAuth', 'Converted ECDSA signature to DER format', { newLength: signature.length });
+      log.debug('Converted ECDSA signature to DER format', { newLength: signature.length });
     }
   }
 
   const ok = crypto.verify(verifyAlg, Buffer.from(signingInput), publicKey, signature);
-  log.debug('OAuth', 'Signature verification result', { ok });
+  log.debug('Signature verification result', { ok });
   if (!ok) throw new Error('id_token signature verification failed');
 
   const now = Math.floor(Date.now() / 1000);
@@ -465,7 +466,7 @@ router.get('/public-key', (req: Request, res: Response) => {
       msg: 'success'
     });
   } catch (error) {
-    log.error('Auth', 'Failed to generate public key', { error: error instanceof Error ? error.message : String(error) });
+    log.error('Failed to generate public key', { error: error instanceof Error ? error.message : String(error) });
     res.status(500).json({ code: 500, msg: 'Failed to generate public key' });
   }
 });
@@ -498,11 +499,11 @@ router.get('/public-key', (req: Request, res: Response) => {
  *         description: JWT token returned
  */
 router.post('/login', loginLimiter, async (req: Request, res: Response) => {
-  const { username, password, totpCode, backupCode, webauthnResponse, trustDevice, encrypted } = req.body as { 
-    username: string; 
-    password: string; 
-    totpCode?: string; 
-    backupCode?: string; 
+  const { username, password, totpCode, backupCode, webauthnResponse, trustDevice, encrypted } = req.body as {
+    username: string;
+    password: string;
+    totpCode?: string;
+    backupCode?: string;
     webauthnResponse?: any;
     trustDevice?: boolean;
     encrypted?: boolean;
@@ -518,19 +519,19 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
     if (encrypted) {
       try {
         actualPassword = decryptPassword(password);
-        log.debug('Auth', 'Password decrypted successfully');
+        log.debug('Password decrypted successfully');
       } catch (decryptError) {
-        log.warn('Auth', 'Failed to decrypt password, using as-is', { error: decryptError instanceof Error ? decryptError.message : String(decryptError) });
+        log.warn('Failed to decrypt password, using as-is', { error: decryptError instanceof Error ? decryptError.message : String(decryptError) });
         // If decryption fails, continue with the original password (backward compatibility)
       }
     }
 
     // Check if input is an email (contains @)
     const isEmail = username.includes('@');
-    
+
     // Get the identifier for login limit check (use username if found, otherwise use the input)
     let loginIdentifier = username.toLowerCase();
-    
+
     // Check login limit
     const ipAddress = getRequestIP(req);
     const limitCheck = await checkLoginAllowed(loginIdentifier, ipAddress);
@@ -538,7 +539,7 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
       sendError(res, limitCheck.message || 'Account is temporarily locked', 429);
       return;
     }
-    
+
     let user: User | undefined;
     if (isEmail) {
       // Login with email
@@ -550,7 +551,7 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
 
     // Timing attack prevention: always execute bcrypt to maintain constant response time
     const fakeHash = '$2b$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'; // Fixed dummy hash
-    const passwordMatch = user 
+    const passwordMatch = user
       ? bcrypt.compareSync(actualPassword, user.password_hash)
       : bcrypt.compareSync(actualPassword, fakeHash);
 
@@ -564,7 +565,7 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
       }
       return;
     }
-    
+
     // At this point, user is guaranteed to exist and password matches
     // Use non-null assertion to satisfy TypeScript
     const authenticatedUser = user!;
@@ -581,17 +582,17 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
     const isWebauthnEnabled = await TwoFAOperations.isWebAuthnEnabled(authenticatedUser.id);
     const isTotpEnabled = totpStatus.enabled;
     const has2FA = isTotpEnabled || isWebauthnEnabled;
-    
+
     // 检查是否需要强制 2FA
     const force2FA = twoFAValidationEnabled && (await requires2FA(authenticatedUser.id));
     const userHas2FA = await has2FAEnabled(authenticatedUser.id);
-    
+
     // 如果强制 2FA 但用户未设置，要求先设置 2FA
     if (force2FA && !userHas2FA) {
-      res.json({ 
-        code: -3, 
-        msg: '2FA setup required', 
-        data: { require2FASetup: true } 
+      res.json({
+        code: -3,
+        msg: '2FA setup required',
+        data: { require2FASetup: true }
       });
       return;
     }
@@ -616,7 +617,7 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
           sendError(res, 'WebAuthn challenge expired or missing', 400);
           return;
         }
-        
+
         const { verifyAuthenticationResponse } = require('@simplewebauthn/server');
         const { getUserWebAuthnCredentials, updateWebAuthnCredentialCounter } = require('../service/webauthn');
         const userCreds = await getUserWebAuthnCredentials(authenticatedUser.id);
@@ -625,7 +626,7 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
           sendError(res, 'Credential not found', 404);
           return;
         }
-        
+
         try {
           const verification = await verifyAuthenticationResponse({
             response: webauthnResponse,
@@ -639,7 +640,7 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
               transports: cred.transports,
             },
           });
-          
+
           if (!verification.verified) {
             sendError(res, 'WebAuthn verification failed', 401);
             return;
@@ -662,7 +663,7 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
 
     // Clear login attempts on successful login
     await clearLoginAttempts(loginIdentifier);
-    
+
     // 如果用户选择信任设备，添加设备信任
     let deviceId: string | undefined;
     if (trustDevice && twoFAValidationEnabled && has2FA) {
@@ -672,15 +673,15 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
       };
       deviceId = await addTrustedDevice(authenticatedUser.id, deviceInfo);
     }
-    
+
     const token = await signToken({ userId: authenticatedUser.id, username: authenticatedUser.username, nickname: authenticatedUser.nickname, role: authenticatedUser.role });
-    
+
     // Set httpOnly cookie (secure, XSS-proof)
     setAuthCookie(res, token);
-    
+
     res.json({
       code: 0,
-      data: { 
+      data: {
         user: { id: authenticatedUser.id, username: authenticatedUser.username, nickname: authenticatedUser.nickname, email: authenticatedUser.email, role: authenticatedUser.role },
         deviceId,
         require2FASetup: force2FA && !userHas2FA,
@@ -791,7 +792,7 @@ router.post('/oauth/start', async (req: Request, res: Response) => {
     const state = randomHex(24);
     const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
     await OAuthOperations.createState(state, 'login', desired, null, expiresAt);
-    log.debug('OAuth', 'State created for login', { state: state.substring(0, 10) + '...', provider: desired, expiresAt: expiresAt.toISOString() });
+    log.debug('State created for login', { state: state.substring(0, 10) + '...', provider: desired, expiresAt: expiresAt.toISOString() });
     res.json({ code: 0, data: { authUrl: buildOauthAuthUrl(config, state) }, msg: 'success' });
   } catch (error) {
     res.status(400).json({ code: 400, msg: error instanceof Error ? error.message : 'Failed to start oauth flow' });
@@ -826,10 +827,10 @@ router.post('/oauth/start', async (req: Request, res: Response) => {
  */
 router.post('/oauth/start-bind', authMiddleware, async (req: Request, res: Response) => {
   // 最早期日志，确认请求到达
-  log.debug('OAuth', '>>> /oauth/start-bind ENTRY', { userId: req.user?.userId, body: req.body });
+  log.debug('>>> /oauth/start-bind ENTRY', { userId: req.user?.userId, body: req.body });
   try {
     const desired = (req.body?.provider as 'custom' | 'logto' | undefined) || 'custom';
-    log.debug('OAuth', 'Start bind request received', { provider: desired, userId: req.user!.userId });
+    log.debug('Start bind request received', { provider: desired, userId: req.user!.userId });
 
     const config = await getOAuthConfigByProvider(desired);
     assertOAuthEnabled(config);
@@ -843,7 +844,7 @@ router.post('/oauth/start-bind', authMiddleware, async (req: Request, res: Respo
     const state = randomHex(24);
     const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
     await OAuthOperations.createState(state, 'bind', desired, req.user!.userId, expiresAt);
-    log.debug('OAuth', 'State created for bind', {
+    log.debug('State created for bind', {
       state: state.substring(0, 16) + '...',
       provider: desired,
       userId: req.user!.userId,
@@ -851,7 +852,7 @@ router.post('/oauth/start-bind', authMiddleware, async (req: Request, res: Respo
     });
     res.json({ code: 0, data: { authUrl: buildOauthAuthUrl(config, state) }, msg: 'success' });
   } catch (error) {
-    log.error('OAuth', 'Failed to start bind', { error: error instanceof Error ? error.message : String(error) });
+    log.error('Failed to start bind', { error: error instanceof Error ? error.message : String(error) });
     res.status(400).json({ code: 400, msg: error instanceof Error ? error.message : 'Failed to start oauth bind flow' });
   }
 });
@@ -907,18 +908,18 @@ router.post('/oauth/start-bind', authMiddleware, async (req: Request, res: Respo
  */
 router.post('/oauth/callback', async (req: Request, res: Response) => {
   const { code, state } = req.body as { code?: string; state?: string };
-  log.debug('OAuth', 'Callback received', { code: code?.substring(0, 16) + '...', state: state?.substring(0, 16) + '...' });
-  
+  log.debug('Callback received', { code: code?.substring(0, 16) + '...', state: state?.substring(0, 16) + '...' });
+
   if (!code || !state) {
-    log.warn('OAuth', 'Missing code or state', { hasCode: !!code, hasState: !!state });
+    log.warn('Missing code or state', { hasCode: !!code, hasState: !!state });
     res.status(400).json({ code: 400, msg: 'code and state are required' });
     return;
   }
-  
+
   // 检查是否正在处理相同的回调（防止重复请求）
   const callbackKey = `${code}:${state}`;
   if (processingCallbacks.has(callbackKey)) {
-    log.warn('OAuth', 'Duplicate callback detected, ignoring', { state: state.substring(0, 16) + '...' });
+    log.warn('Duplicate callback detected, ignoring', { state: state.substring(0, 16) + '...' });
     res.status(429).json({ code: 429, msg: 'Callback is being processed, please wait' });
     return;
   }
@@ -926,18 +927,18 @@ router.post('/oauth/callback', async (req: Request, res: Response) => {
   processingCallbacks.add(callbackKey);
 
   try {
-    log.debug('OAuth', 'State store lookup', { lookingFor: state.substring(0, 16) + '...' });
+    log.debug('State store lookup', { lookingFor: state.substring(0, 16) + '...' });
 
     // 从数据库获取并删除 state（一次性使用）
     const stateEntry = await OAuthOperations.getAndDeleteState(state);
 
     if (!stateEntry) {
-      log.warn('OAuth', 'State not found in store', { state: state.substring(0, 16) + '...', code: code?.substring(0, 16) + '...' });
-      
+      log.warn('State not found in store', { state: state.substring(0, 16) + '...', code: code?.substring(0, 16) + '...' });
+
       // 检查这个code是否已经被处理过
       const processedTimestamp = processedCodes.get(code);
       if (processedTimestamp && Date.now() - processedTimestamp <= PROCESSED_CODES_TTL) {
-        log.info('OAuth', 'Code already processed, returning success', { code: code?.substring(0, 16) + '...' });
+        log.info('Code already processed, returning success', { code: code?.substring(0, 16) + '...' });
         // 如果已经处理过，返回成功（幂等性）
         // 对于绑定模式，返回成功
         // 对于登录模式，需要检查用户是否已经登录，但这里简单返回成功
@@ -945,35 +946,35 @@ router.post('/oauth/callback', async (req: Request, res: Response) => {
         res.json({ code: 0, data: { mode: 'login' }, msg: 'OAuth flow already completed' });
         return;
       }
-      
+
       // 可能正在处理中，等待一小段时间后重试
-      log.info('OAuth', 'State not found but may be processing, waiting...', { state: state.substring(0, 16) + '...' });
-      
+      log.info('State not found but may be processing, waiting...', { state: state.substring(0, 16) + '...' });
+
       // 等待1秒，让第一个请求有机会完成
       await new Promise(resolve => setTimeout(resolve, 1000));
-      
+
       // 再次检查是否已经被处理
       const processedTimestamp2 = processedCodes.get(code);
       if (processedTimestamp2 && Date.now() - processedTimestamp2 <= PROCESSED_CODES_TTL) {
-        log.info('OAuth', 'Code processed after waiting, returning success', { code: code?.substring(0, 16) + '...' });
+        log.info('Code processed after waiting, returning success', { code: code?.substring(0, 16) + '...' });
         addProcessedCode(code);
         res.json({ code: 0, data: { mode: 'login' }, msg: 'OAuth flow completed after retry' });
         return;
       }
-      
+
       res.status(400).json({ code: 400, msg: 'Invalid oauth state - state not found. Server may have restarted or callback was already processed.' });
       return;
     }
 
-    log.debug('OAuth', 'State found and removed', { state: state.substring(0, 16) + '...' });
+    log.debug('State found and removed', { state: state.substring(0, 16) + '...' });
 
     if (new Date() > stateEntry.expiresAt) {
-      log.warn('OAuth', 'State expired', { state: state.substring(0, 16) + '...', expiredAt: stateEntry.expiresAt.toISOString() });
+      log.warn('State expired', { state: state.substring(0, 16) + '...', expiredAt: stateEntry.expiresAt.toISOString() });
       res.status(400).json({ code: 400, msg: 'Expired oauth state' });
       return;
     }
 
-    log.debug('OAuth', 'State validated', { mode: stateEntry.mode, provider: stateEntry.provider, userId: stateEntry.userId });
+    log.debug('State validated', { mode: stateEntry.mode, provider: stateEntry.provider, userId: stateEntry.userId });
 
     // 处理成功后立即清理标记（后续代码可能耗时较长）
     processingCallbacks.delete(callbackKey);
@@ -981,13 +982,13 @@ router.post('/oauth/callback', async (req: Request, res: Response) => {
     const config = await getOAuthConfigByProvider(stateEntry.provider);
     assertOAuthEnabled(config);
     const provider = stateEntry.provider;
-    
+
     // Force redirectUri to use the fixed callback endpoint
     const protocol = req.headers['x-forwarded-proto'] || req.protocol;
     const host = req.headers['x-forwarded-host'] || req.get('host');
     const baseUrl = `${protocol}://${host}`;
     config.redirectUri = `${baseUrl}/oauth/callback`;
-    
+
     const tokenResult = await exchangeOauthCode(config, code);
     const profile = await fetchOAuthProfile(config, tokenResult.accessToken);
     // ID Token 验证（可选，失败不阻断流程）
@@ -996,16 +997,16 @@ router.post('/oauth/callback', async (req: Request, res: Response) => {
       try {
         idTokenClaims = await verifyIdToken(tokenResult.idToken, config);
       } catch (idTokenError) {
-        log.warn('OAuth', 'ID Token verification failed, continuing with profile only', { error: idTokenError instanceof Error ? idTokenError.message : String(idTokenError) });
+        log.warn('ID Token verification failed, continuing with profile only', { error: idTokenError instanceof Error ? idTokenError.message : String(idTokenError) });
       }
     }
     const mergedProfile = { ...idTokenClaims, ...profile };
     const subject = resolveOAuthSubject(config, mergedProfile);
     const normalizedEmail = resolveOAuthEmail(config, mergedProfile);
-    
+
     // Get provider key for database lookup
     const providerKey = getProviderKey(config);
-    
+
     const existingLink = await OAuthOperations.getUserByProviderSubject(providerKey, subject);
 
     if (stateEntry.mode === 'bind') {
@@ -1042,10 +1043,10 @@ router.post('/oauth/callback', async (req: Request, res: Response) => {
     }
 
     const token = await signToken({ userId: user.id, username: user.username, nickname: user.nickname, role: user.role });
-    
+
     // Set httpOnly cookie (secure, XSS-proof)
     setAuthCookie(res, token);
-    
+
     await logAuditOperation(user.id, 'oauth_login', 'system', { provider: providerKey });
     addProcessedCode(code);
     res.json({
@@ -1054,7 +1055,7 @@ router.post('/oauth/callback', async (req: Request, res: Response) => {
       msg: 'success',
     });
   } catch (error) {
-    log.error('OAuth', 'Callback processing failed', { error: error instanceof Error ? error.message : String(error) });
+    log.error('Callback processing failed', { error: error instanceof Error ? error.message : String(error) });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'OAuth callback failed' });
   } finally {
     // 清理处理标记
@@ -1137,8 +1138,8 @@ router.get('/me', authMiddleware, async (req: Request, res: Response) => {
  *         description: Password changed
  */
 router.put('/password', authMiddleware, async (req: Request, res: Response) => {
-  const { oldPassword, newPassword, encrypted } = req.body as { 
-    oldPassword: string; 
+  const { oldPassword, newPassword, encrypted } = req.body as {
+    oldPassword: string;
     newPassword: string;
     encrypted?: boolean;
   };
@@ -1151,37 +1152,37 @@ router.put('/password', authMiddleware, async (req: Request, res: Response) => {
     // Decrypt passwords if encrypted
     let actualOldPassword = oldPassword;
     let actualNewPassword = newPassword;
-    
+
     if (encrypted) {
       try {
         actualOldPassword = decryptPassword(oldPassword);
         actualNewPassword = decryptPassword(newPassword);
-        log.debug('Auth', 'Passwords decrypted successfully for password change');
+        log.debug('Passwords decrypted successfully for password change');
       } catch (decryptError) {
-        log.warn('Auth', 'Failed to decrypt passwords, using as-is', { 
-          error: decryptError instanceof Error ? decryptError.message : String(decryptError) 
+        log.warn('Failed to decrypt passwords, using as-is', {
+          error: decryptError instanceof Error ? decryptError.message : String(decryptError)
         });
       }
     }
-    
+
     const user = await UserOperations.getById(req.user!.userId);
 
     if (!user || !bcrypt.compareSync(actualOldPassword, user.password_hash as string)) {
       sendError(res, 'Old password is incorrect', 401);
       return;
     }
-    
+
     // 验证新密码强度
     const passwordCheck = await validatePassword(actualNewPassword);
     if (!passwordCheck.valid) {
       sendError(res, passwordCheck.message!, 400);
       return;
     }
-    
+
     const hash = bcrypt.hashSync(actualNewPassword, 10);
 
     await UserOperations.updatePassword(user.id as number, hash);
-    
+
     // 修改密码后清除所有受信任设备
     const { removeAllUserTrustedDevices } = require('../service/deviceTrust');
     await removeAllUserTrustedDevices(user.id as number);
@@ -1305,9 +1306,9 @@ router.post('/password-reset/request', async (req: Request, res: Response) => {
 });
 
 router.post('/password-reset/confirm', async (req: Request, res: Response) => {
-  const { email, code, newPassword, encrypted } = req.body as { 
-    email?: string; 
-    code?: string; 
+  const { email, code, newPassword, encrypted } = req.body as {
+    email?: string;
+    code?: string;
     newPassword?: string;
     encrypted?: boolean;
   };
@@ -1316,20 +1317,20 @@ router.post('/password-reset/confirm', async (req: Request, res: Response) => {
     res.status(400).json({ code: 400, msg: 'Email, code and newPassword are required' });
     return;
   }
-  
+
   // Decrypt password if encrypted
   let actualNewPassword = newPassword;
   if (encrypted) {
     try {
       actualNewPassword = decryptPassword(newPassword);
-      log.debug('Auth', 'Password decrypted successfully for reset');
+      log.debug('Password decrypted successfully for reset');
     } catch (decryptError) {
-      log.warn('Auth', 'Failed to decrypt password, using as-is', { 
-        error: decryptError instanceof Error ? decryptError.message : String(decryptError) 
+      log.warn('Failed to decrypt password, using as-is', {
+        error: decryptError instanceof Error ? decryptError.message : String(decryptError)
       });
     }
   }
-  
+
   if (actualNewPassword.length < 6) {
     res.status(400).json({ code: 400, msg: 'Password must be at least 6 characters' });
     return;
@@ -1459,27 +1460,27 @@ router.get('/preferences/pinned-domains', authMiddleware, async (req: Request, r
  */
 router.put('/preferences/pinned-domains', authMiddleware, async (req: Request, res: Response) => {
   const { domainIds } = req.body as { domainIds?: number[] };
-  
+
   if (!Array.isArray(domainIds)) {
     res.status(400).json({ code: 400, msg: 'domainIds must be an array' });
     return;
   }
-  
+
   try {
     // ← 新增：检查是否有同名域名已经置顶
     if (domainIds.length > 0) {
       // 获取所有要置顶的域名信息
       const domainsToPin = await DomainOperations.getByIds(domainIds);
-      
+
       // 构建域名名称到 ID 的映射
       const nameToIdMap = new Map<string, number>();
       const duplicateNames: string[] = [];
-      
+
       for (const domain of domainsToPin) {
         const domainName = (domain as any).name || (domain as any).full_domain;
         const domainId = Number((domain as any).id);
         if (!domainName || !domainId) continue;
-        
+
         if (nameToIdMap.has(domainName)) {
           // 发现同名域名
           duplicateNames.push(domainName);
@@ -1487,19 +1488,19 @@ router.put('/preferences/pinned-domains', authMiddleware, async (req: Request, r
           nameToIdMap.set(domainName, domainId);
         }
       }
-      
+
       // 如果有重复的域名名称，返回错误
       if (duplicateNames.length > 0) {
-        res.status(400).json({ 
-          code: 400, 
-          msg: `Duplicate domain names found: ${duplicateNames.join(', ')}. Cannot pin multiple domains with the same name.` 
+        res.status(400).json({
+          code: 400,
+          msg: `Duplicate domain names found: ${duplicateNames.join(', ')}. Cannot pin multiple domains with the same name.`
         });
         return;
       }
     }
-    
+
     await UserPreferencesOperations.updatePinnedDomains(req.user!.userId, domainIds);
-    
+
     // ← 发送 WebSocket 通知，刷新前端域名列表
     const wsService = require('../service/websocket').wsService;
     wsService.sendToUser(req.user!.userId, {
@@ -1507,7 +1508,7 @@ router.put('/preferences/pinned-domains', authMiddleware, async (req: Request, r
       data: { domainIds },
       timestamp: new Date().toISOString()
     });
-    
+
     res.json({ code: 0, msg: 'success' });
   } catch (error) {
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to update pinned domains' });

--- a/server/src/routes/domains.ts
+++ b/server/src/routes/domains.ts
@@ -9,13 +9,14 @@ import { DnsAccount, Domain } from '../types';
 import { ROLE_ADMIN, isSuper, normalizeRole } from '../utils/roles';
 import { logAuditOperation } from '../service/audit';
 import { parseInteger, sendError, sendSuccess, sendServerError } from '../utils/http';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { DomainOperations, DnsAccountOperations, DomainPermissionOperations, TeamOperations, RenewableDomainOperations, UserPreferencesOperations, NSMonitorOperations } from '../db/bal/business-adapter';
 import { syncDomainWhois } from '../service/whois';
 import { getRootDomain, queryWhois } from '../service/whois';
 import { wsService } from '../service/websocket';
 import { normalizeDomain, isValidDomain, getDisplayDomain } from '../utils/dns';
 
+const log = createLogger('HTTP').sub('Route').sub('Domains');
 const router = Router();
 
 async function getAccountForUser(accountId: number, userId: number, role: number): Promise<DnsAccount | null> {
@@ -76,7 +77,7 @@ async function resolveDomainAccess(domain: Domain, userId: number, role: number)
     // 账号不存在或已禁用，拒绝所有操作（除了 WHOIS）
     return { domain, canRead: false, canWrite: false, writeSubs: [], hasRules: false };
   }
-  
+
   const hasRules = await DomainPermissionOperations.hasRules(domain.id);
   if (isSuper(role)) {
     return { domain, canRead: true, canWrite: true, writeSubs: null, hasRules };
@@ -159,11 +160,11 @@ export async function getDomainAccess(domainId: number, userId: number, role: nu
  *         description: List of domains
  */
 router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
-  const { account_id, keyword, domain_type, page, pageSize, format, include_disabled, domain_status, pinned_domains } = req.query as { 
-    account_id?: string; 
-    keyword?: string; 
-    domain_type?: string; 
-    page?: string; 
+  const { account_id, keyword, domain_type, page, pageSize, format, include_disabled, domain_status, pinned_domains } = req.query as {
+    account_id?: string;
+    keyword?: string;
+    domain_type?: string;
+    page?: string;
     pageSize?: string;
     format?: string; // 'array' for direct array response (for external adapters)
     include_disabled?: string; // 'true' to include disabled domains (legacy)
@@ -176,11 +177,11 @@ router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response)
   // Pagination params
   const currentPage = Math.max(1, parseInteger(page) || 1);
   const size = Math.min(100, Math.max(1, parseInteger(pageSize) || 20));
-  
+
   // Parse domain_type with type safety
-  const parsedDomainType: 'apex' | 'subdomain' | undefined = 
+  const parsedDomainType: 'apex' | 'subdomain' | undefined =
     (domain_type === 'apex' || domain_type === 'subdomain') ? domain_type : undefined;
-  
+
   // Parse domain_status with fallback to legacy include_disabled parameter
   let parsedDomainStatus: 'enabled' | 'disabled' | 'all' = 'all';
   if (domain_status === 'enabled' || domain_status === 'disabled' || domain_status === 'all') {
@@ -192,7 +193,7 @@ router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response)
   // If include_disabled=true or not specified, default to 'all'
 
   // Parse pinned_domains (comma-separated string to number array)
-  const pinnedDomainIds: number[] = pinned_domains 
+  const pinnedDomainIds: number[] = pinned_domains
     ? pinned_domains.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id))
     : [];
 
@@ -212,7 +213,7 @@ router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response)
 
   let domains: Domain[];
   let total = 0; // 初始化 total
-  
+
   // Token 认证优化：根据 allowedDomains 是否为空选择不同策略
   if (tokenPayload) {
     const queryStartTime = Date.now();
@@ -255,8 +256,8 @@ router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response)
         total = result.total;
       }
     }
-    log.debug('Domains', 'Token auth domain query completed', { 
-      duration: `${Date.now() - queryStartTime}ms`, 
+    log.debug('Token auth domain query completed', {
+      duration: `${Date.now() - queryStartTime}ms`,
       count: domains.length,
       total
     });
@@ -365,7 +366,7 @@ router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response)
  * ⚠️ IMPORTANT: Static routes MUST be defined BEFORE dynamic routes (/:id)
  * Express matches routes in definition order. If /:id is defined first,
  * it will match '/renewable-domains' as an ID parameter, causing 404 errors.
- * 
+ *
  * Route priority order:
  * 1. Exact static routes (e.g., /renewable-domains)
  * 2. Prefixed static routes (e.g., /renewable-domains/sync)
@@ -379,28 +380,28 @@ router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response)
 router.get('/renewable-domains', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
   // Only allow admins and super admins
   const role = normalizeRole(req.user?.role);
-  log.info('Domains', 'Renewable domains request', { userId: req.user?.userId, role });
-  
+  log.info('Renewable domains request', { userId: req.user?.userId, role });
+
   if (role < 2) {
-    log.warn('Domains', 'Unauthorized attempt to fetch renewable domains', { userId: req.user?.userId, role });
+    log.warn('Unauthorized attempt to fetch renewable domains', { userId: req.user?.userId, role });
     sendError(res, 'Permission denied');
     return;
   }
-  
-  log.info('Domains', 'Fetching renewable domains', { userId: req.user?.userId });
-  
+
+  log.info('Fetching renewable domains', { userId: req.user?.userId });
+
   try {
     // Query from renewable_domains table (include both enabled and disabled)
     const startTime = Date.now();
-    log.debug('Domains', 'Calling RenewableDomainOperations.getAll()');
+    log.debug('Calling RenewableDomainOperations.getAll()');
     const renewableDomains = await RenewableDomainOperations.getAll();
     const queryDuration = Date.now() - startTime;
-    
-    log.info('Domains', 'Fetched renewable domains from database', { 
+
+    log.info('Fetched renewable domains from database', {
       count: renewableDomains.length,
       duration: `${queryDuration}ms`
     });
-    
+
     // Enrich with account information
     const enrichStartTime = Date.now();
     const tokenPayload = (req as any).tokenPayload;
@@ -424,20 +425,20 @@ router.get('/renewable-domains', authMiddleware, asyncHandler(async (req: Reques
       })
     );
     const enrichDuration = Date.now() - enrichStartTime;
-    
-    log.debug('Domains', 'Enriched domains with account info', { 
+
+    log.debug('Enriched domains with account info', {
       count: enrichedDomains.length,
       duration: `${enrichDuration}ms`
     });
-    
-    log.info('Domains', 'Successfully fetched renewable domains', { 
+
+    log.info('Successfully fetched renewable domains', {
       total: enrichedDomains.length,
       totalDuration: `${Date.now() - startTime}ms`
     });
-    
+
     sendSuccess(res, enrichedDomains);
   } catch (error) {
-    log.error('Domains', 'Failed to fetch renewable domains', { 
+    log.error('Failed to fetch renewable domains', {
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined
     });
@@ -474,9 +475,9 @@ router.get('/:id', authMiddleware, asyncHandler(async (req: Request, res: Respon
       sendError(res, 'Domain not found or no permission');
       return;
     }
-    
+
     const domain = access.domain;
-    
+
     // For Session auth, convert Punycode to Unicode for display
     // For Token auth, return raw Punycode
     const tokenPayload = (req as any).tokenPayload;
@@ -490,7 +491,7 @@ router.get('/:id', authMiddleware, asyncHandler(async (req: Request, res: Respon
       sendSuccess(res, domain);
     }
   } catch (error) {
-    log.error('Domains', 'Failed to get domain', { error });
+    log.error('Failed to get domain', { error });
     sendError(res, error instanceof Error ? error.message : 'Failed to get domain');
   }
 }));
@@ -562,10 +563,10 @@ router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response
       if (firstId === null) firstId = id;
       added++;
       addedDomains.push(item.name);
-      
+
       // 异步获取 WHOIS 信息（不阻塞响应），强制刷新以获取最新的多状态
       syncDomainWhois(id, true).catch(err => {
-        log.warn('Domains', `Failed to sync WHOIS for ${item.name}:`, { error: err });
+        log.warn(`Failed to sync WHOIS for ${item.name}:`, { error: err });
       });
     } catch (error) {
       if (error instanceof Error && error.message.toLowerCase().includes('unique')) {
@@ -584,7 +585,7 @@ router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response
   for (const domainName of addedDomains) {
     await logAuditOperation(req.user!.userId, 'add_domain', domainName, { accountId: account_id }, req);
   }
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -596,9 +597,9 @@ router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response
       },
     });
   } catch (error) {
-    log.error('Domains', 'Failed to broadcast domain_created event', { error });
+    log.error('Failed to broadcast domain_created event', { error });
   }
-  
+
   sendSuccess(res, { id: firstId, added, skipped: duplicates.length, duplicates });
 }));
 
@@ -658,30 +659,30 @@ router.post('/sync', authMiddleware, asyncHandler(async (req: Request, res: Resp
 
         // 安全限制：最多获取10万个域名或2000页防止无限循环
         if (allDomains.length >= 100000 || page > maxPages) {
-          log.warn('Domains', `Sync domain limit reached (${allDomains.length} domains, ${page} pages), stopping pagination`);
+          log.warn(`Sync domain limit reached (${allDomains.length} domains, ${page} pages), stopping pagination`);
           break;
         }
       } catch (error) {
-        log.error('Domains', `Failed to fetch page ${page}:`, { error });
+        log.error(`Failed to fetch page ${page}:`, { error });
         break;
       }
     }
 
-    log.info('Domains', `Sync fetched ${allDomains.length} domains from provider`, { accountId: account_id, provider: account.type });
+    log.info(`Sync fetched ${allDomains.length} domains from provider`, { accountId: account_id, provider: account.type });
 
     let added = 0;
     for (const d of allDomains) {
       const normalizedName = normalizeDomain(d.Domain);
-      
+
       // 记录 IDN 域名转换信息
       if (normalizedName !== d.Domain.toLowerCase()) {
-        log.debug('Domains', 'IDN domain normalized during sync', {
+        log.debug('IDN domain normalized during sync', {
           original: d.Domain,
           normalized: normalizedName,
           accountId: account_id,
         });
       }
-      
+
       const existing = await DomainOperations.getByAccountIdAndName(account_id, normalizedName);
       if (!existing) {
         const id = await DomainOperations.create({
@@ -691,7 +692,7 @@ router.post('/sync', authMiddleware, asyncHandler(async (req: Request, res: Resp
           record_count: d.RecordCount ?? 0,
         });
         added++;
-        log.info('Domains', `Domain added during sync: ${normalizedName}`, {
+        log.info(`Domain added during sync: ${normalizedName}`, {
           originalName: d.Domain,
           accountId: account_id,
           isIdn: normalizedName !== d.Domain.toLowerCase(),
@@ -700,7 +701,7 @@ router.post('/sync', authMiddleware, asyncHandler(async (req: Request, res: Resp
 
         // 异步获取 WHOIS 信息（不阻塞响应）
         syncDomainWhois(id).catch(err => {
-          log.warn('Domains', `Failed to sync WHOIS for ${normalizedName}:`, { error: err });
+          log.warn(`Failed to sync WHOIS for ${normalizedName}:`, { error: err });
         });
       } else {
         await DomainOperations.updateThirdIdAndRecordCount(existing.id as number, d.ThirdId || '', d.RecordCount ?? 0);
@@ -741,7 +742,7 @@ router.get('/provider-list/:accountId', authMiddleware, asyncHandler(async (req:
   try {
     // MySQL JSON type returns object directly, SQLite/PostgreSQL returns string
     const cfg = typeof account.config === 'string' ? JSON.parse(account.config) as Record<string, string> : account.config as Record<string, string>;
-    log.info('ProviderList', 'Fetching domains', { accountType: account.type, configKeys: Object.keys(cfg) });
+    log.info('Fetching domains', { accountType: account.type, configKeys: Object.keys(cfg) });
     const dnsAdapter = createAdapter(account.type, cfg);
 
     // 分页获取所有域名
@@ -759,16 +760,16 @@ router.get('/provider-list/:accountId', authMiddleware, asyncHandler(async (req:
         page++;
 
         if (allProviderDomains.length >= 100000 || page > maxPages) {
-          log.warn('ProviderList', `Domain limit reached (${allProviderDomains.length} domains, ${page} pages), stopping pagination`);
+          log.warn(`Domain limit reached (${allProviderDomains.length} domains, ${page} pages), stopping pagination`);
           break;
         }
       } catch (error) {
-        log.error('ProviderList', `Failed to fetch page ${page}:`, { error });
+        log.error(`Failed to fetch page ${page}:`, { error });
         break;
       }
     }
 
-    log.info('ProviderList', 'Domains fetched', { total: allProviderDomains.length });
+    log.info('Domains fetched', { total: allProviderDomains.length });
 
     // 获取当前账号下已添加的域名列表
     const existingDomains = await DomainOperations.getByAccountId(accountId) as Array<{ name: string }>;
@@ -794,10 +795,10 @@ router.get('/provider-list/:accountId', authMiddleware, asyncHandler(async (req:
         };
       });
 
-    log.info('ProviderList', 'Filtered domains', { total: allProviderDomains.length, filtered: domains.length, existing: existingDomainNames.size });
+    log.info('Filtered domains', { total: allProviderDomains.length, filtered: domains.length, existing: existingDomainNames.size });
     sendSuccess(res, domains);
   } catch (e) {
-    log.error('ProviderList', 'Error fetching domains', e);
+    log.error('Error fetching domains', e);
     sendError(res, e instanceof Error ? e.message : String(e));
   }
 }));
@@ -875,17 +876,17 @@ router.put('/:id', authMiddleware, requireTokenDomainPermission(), asyncHandler(
   }
   const { remark, is_hidden, enabled } = req.body as { remark?: string; is_hidden?: number; enabled?: number };
   await DomainOperations.updateRemarkAndHidden(id, remark, is_hidden);
-  
+
   // Update enabled status if provided
   if (enabled !== undefined) {
     await DomainOperations.setEnabled(id, enabled);
   }
-  
+
   await logAuditOperation(req.user!.userId, 'update_domain', access.domain.name, { remark, is_hidden, enabled }, req);
-  
+
   // 获取更新后的域名信息（包含到期时间）
   const updatedDomain = await DomainOperations.getById(id);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -900,9 +901,9 @@ router.put('/:id', authMiddleware, requireTokenDomainPermission(), asyncHandler(
       },
     });
   } catch (error) {
-    log.error('Domains', 'Failed to broadcast domain_updated event', { error });
+    log.error('Failed to broadcast domain_updated event', { error });
   }
-  
+
   sendSuccess(res);
 }));
 
@@ -936,15 +937,15 @@ router.delete('/:id', authMiddleware, requireTokenDomainPermission(), asyncHandl
     return;
   }
   await DomainOperations.delete(id);
-  
+
   // Check if there are any other domains with the same name
   const domainName = access.domain.name as string;
   const remainingDomains = await DomainOperations.getAll();
   const hasSameNameDomain = remainingDomains.some((d: any) => d.name === domainName);
-  
+
   // If no other domains with this name exist, delete NS monitor configs
   if (!hasSameNameDomain) {
-    log.info('Domains', 'No remaining domains with this name, deleting NS monitors', { domainName });
+    log.info('No remaining domains with this name, deleting NS monitors', { domainName });
     // Find and delete NS monitor configs for this domain name
     const userId = req.user!.userId;
     try {
@@ -952,19 +953,19 @@ router.delete('/:id', authMiddleware, requireTokenDomainPermission(), asyncHandl
       for (const monitor of monitors) {
         if ((monitor as any).domain_name === domainName) {
           await NSMonitorOperations.delete(monitor.id as number, userId);
-          log.info('Domains', 'Deleted NS monitor for removed domain', {
+          log.info('Deleted NS monitor for removed domain', {
             monitorId: monitor.id,
             domainName,
           });
         }
       }
     } catch (error) {
-      log.error('Domains', 'Failed to cleanup NS monitors', { error });
+      log.error('Failed to cleanup NS monitors', { error });
     }
   }
-  
+
   await logAuditOperation(req.user!.userId, 'delete_domain', access.domain.name, { domainId: id, accountId: access.domain.account_id }, req);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -975,9 +976,9 @@ router.delete('/:id', authMiddleware, requireTokenDomainPermission(), asyncHandl
       },
     });
   } catch (error) {
-    log.error('Domains', 'Failed to broadcast domain_deleted event', { error });
+    log.error('Failed to broadcast domain_deleted event', { error });
   }
-  
+
   sendSuccess(res);
 }));
 
@@ -1080,7 +1081,7 @@ router.post('/:id/failover', authMiddleware, requireTokenDomainPermission(), asy
   };
   if (existing) {
     await updateFailoverConfig(existing.id, configData);
-    
+
     // 推送 WebSocket 消息
     try {
       wsService.broadcast({
@@ -1091,13 +1092,13 @@ router.post('/:id/failover', authMiddleware, requireTokenDomainPermission(), asy
         },
       });
     } catch (error) {
-      log.error('Domains', 'Failed to broadcast failover_config_updated event', { error });
+      log.error('Failed to broadcast failover_config_updated event', { error });
     }
-    
+
     sendSuccess(res, { id: existing.id });
   } else {
     const configId = await createFailoverConfig(domainId, configData);
-    
+
     // 推送 WebSocket 消息
     try {
       wsService.broadcast({
@@ -1108,9 +1109,9 @@ router.post('/:id/failover', authMiddleware, requireTokenDomainPermission(), asy
         },
       });
     } catch (error) {
-      log.error('Domains', 'Failed to broadcast failover_config_created event', { error });
+      log.error('Failed to broadcast failover_config_created event', { error });
     }
-    
+
     sendSuccess(res, { id: configId });
   }
 }));
@@ -1128,7 +1129,7 @@ router.put('/:id/failover', authMiddleware, requireTokenDomainPermission(), asyn
     return;
   }
   await updateFailoverConfig(existing.id, req.body);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -1139,9 +1140,9 @@ router.put('/:id/failover', authMiddleware, requireTokenDomainPermission(), asyn
       },
     });
   } catch (error) {
-    log.error('Domains', 'Failed to broadcast failover_config_updated event', { error });
+    log.error('Failed to broadcast failover_config_updated event', { error });
   }
-  
+
   sendSuccess(res);
 }));
 
@@ -1158,7 +1159,7 @@ router.delete('/:id/failover', authMiddleware, requireTokenDomainPermission(), a
     return;
   }
   await deleteFailoverConfig(existing.id);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -1169,9 +1170,9 @@ router.delete('/:id/failover', authMiddleware, requireTokenDomainPermission(), a
       },
     });
   } catch (error) {
-    log.error('Domains', 'Failed to broadcast failover_config_deleted event', { error });
+    log.error('Failed to broadcast failover_config_deleted event', { error });
   }
-  
+
   sendSuccess(res);
 }));
 
@@ -1200,11 +1201,11 @@ router.post('/:id/whois', authMiddleware, requireTokenDomainPermission(), asyncH
     sendError(res, 'Domain not found');
     return;
   }
-  
+
   const result = await syncDomainWhois(id);
-  
+
   if (result.success) {
-    sendSuccess(res, { 
+    sendSuccess(res, {
       expires_at: result.expiresAt?.toISOString(),
       apex_expires_at: result.apexExpiresAt?.toISOString(),
     }, 'WHOIS info refreshed successfully');
@@ -1219,38 +1220,38 @@ router.post('/:id/whois', authMiddleware, requireTokenDomainPermission(), asyncH
 router.post('/:id/renew', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
   const renewableDomainId = parseInteger(req.params.id);
   const { subdomain_id } = req.body;
-  
-  log.info('Domains', 'Renewal request received', { 
-    renewableDomainId, 
-    subdomainId: subdomain_id, 
-    userId: req.user?.userId 
+
+  log.info('Renewal request received', {
+    renewableDomainId,
+    subdomainId: subdomain_id,
+    userId: req.user?.userId
   });
-  
+
   if (!renewableDomainId || !subdomain_id) {
-    log.error('Domains', 'Missing required parameters', { renewableDomainId, subdomain_id });
+    log.error('Missing required parameters', { renewableDomainId, subdomain_id });
     sendError(res, 'Missing domain ID or subdomain ID');
     return;
   }
-  
+
   // Only allow admins and super admins
   const role = normalizeRole(req.user?.role);
   if (role < 2) {
-    log.warn('Domains', 'Unauthorized renewal attempt', { userId: req.user?.userId, role });
+    log.warn('Unauthorized renewal attempt', { userId: req.user?.userId, role });
     sendError(res, 'Permission denied');
     return;
   }
-  
+
   // Get the renewable domain from renewable_domains table
   const renewableDomain = await RenewableDomainOperations.getById(renewableDomainId);
   if (!renewableDomain) {
-    log.error('Domains', 'Renewable domain not found', { renewableDomainId });
+    log.error('Renewable domain not found', { renewableDomainId });
     sendError(res, 'Renewable domain not found');
     return;
   }
-  
+
   // Check if domain is enabled
   if (!renewableDomain.enabled) {
-    log.warn('Domains', 'Cannot renew disabled domain', { 
+    log.warn('Cannot renew disabled domain', {
       renewableDomainId,
       full_domain: renewableDomain.full_domain,
       enabled: renewableDomain.enabled
@@ -1258,45 +1259,45 @@ router.post('/:id/renew', authMiddleware, asyncHandler(async (req: Request, res:
     sendError(res, 'Cannot renew disabled domain. Please enable it first.');
     return;
   }
-  
-  log.info('Domains', 'Renewable domain retrieved', { 
+
+  log.info('Renewable domain retrieved', {
     id: renewableDomain.id,
     full_domain: renewableDomain.full_domain,
     account_id: renewableDomain.account_id,
     provider_type: renewableDomain.provider_type,
     third_id: renewableDomain.third_id
   });
-  
+
   // Get the account
   const account = await DnsAccountOperations.getById(renewableDomain.account_id) as DnsAccount | undefined;
   if (!account) {
-    log.error('Domains', 'Account not found', { accountId: renewableDomain.account_id });
+    log.error('Account not found', { accountId: renewableDomain.account_id });
     sendError(res, 'Account not found');
     return;
   }
-  
-  log.info('Domains', 'Account retrieved for renewal', { 
-    accountId: account.id, 
-    accountName: account.name, 
-    type: account.type 
+
+  log.info('Account retrieved for renewal', {
+    accountId: account.id,
+    accountName: account.name,
+    type: account.type
   });
-  
+
   // Only support DNSHE provider
   if (account.type !== 'dnshe') {
-    log.warn('Domains', 'Unsupported provider for renewal', { type: account.type });
+    log.warn('Unsupported provider for renewal', { type: account.type });
     sendError(res, 'Renewal only supported for DNSHE provider');
     return;
   }
-  
+
   try {
     const config = typeof account.config === 'string' ? JSON.parse(account.config) : account.config;
-    
-    log.info('Domains', 'Calling DNSHE renewal API', { 
-      subdomainId: Number(subdomain_id), 
+
+    log.info('Calling DNSHE renewal API', {
+      subdomainId: Number(subdomain_id),
       useProxy: !!config.useProxy,
       apiKeyPrefix: config.apiKey?.substring(0, 8) + '...'
     });
-    
+
     const result = await dnsheRenewSubdomain(
       {
         apiKey: config.apiKey,
@@ -1305,24 +1306,24 @@ router.post('/:id/renew', authMiddleware, asyncHandler(async (req: Request, res:
       },
       Number(subdomain_id)
     );
-    
-    log.info('Domains', 'DNSHE renewal API response', { success: !!result, result });
-    
+
+    log.info('DNSHE renewal API response', { success: !!result, result });
+
     if (!result) {
-      log.error('Domains', 'DNSHE renewal returned null result');
+      log.error('DNSHE renewal returned null result');
       sendError(res, 'Renewal failed');
       return;
     }
-    
+
     // Update expires_at in renewable_domains table
     if (result.new_expires_at) {
       await RenewableDomainOperations.updateExpiresAt(renewableDomainId, result.new_expires_at);
-      log.info('Domains', 'Updated expires_at in renewable_domains', { 
+      log.info('Updated expires_at in renewable_domains', {
         renewableDomainId,
         newExpiresAt: result.new_expires_at
       });
     }
-    
+
     // Log audit operation
     await logAuditOperation(
       req.user!.userId,
@@ -1337,16 +1338,16 @@ router.post('/:id/renew', authMiddleware, asyncHandler(async (req: Request, res:
       },
       req
     );
-    
-    log.info('Domains', 'Domain renewed successfully', { 
-      renewableDomainId, 
+
+    log.info('Domain renewed successfully', {
+      renewableDomainId,
       subdomainId: result.subdomain_id,
       fullDomain: renewableDomain.full_domain,
       previousExpiresAt: result.previous_expires_at,
       newExpiresAt: result.new_expires_at,
       remainingDays: result.remaining_days
     });
-    
+
     // 推送 WebSocket 消息
     try {
       wsService.broadcast({
@@ -1359,12 +1360,12 @@ router.post('/:id/renew', authMiddleware, asyncHandler(async (req: Request, res:
         },
       });
     } catch (error) {
-      log.error('Domains', 'Failed to broadcast domain_renewed event', { error });
+      log.error('Failed to broadcast domain_renewed event', { error });
     }
-    
+
     sendSuccess(res, result, 'Domain renewed successfully');
   } catch (error) {
-    log.error('Domains', 'Renewal failed with exception', { 
+    log.error('Renewal failed with exception', {
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined
     });
@@ -1377,24 +1378,24 @@ router.post('/:id/renew', authMiddleware, asyncHandler(async (req: Request, res:
  */
 router.get('/whois', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
   const { domain, accountId } = req.query;
-  
+
   if (!domain || typeof domain !== 'string') {
     sendError(res, 'Domain parameter is required');
     return;
   }
-  
+
   // Normalize domain name to Punycode for database query
   const normalizedDomain = normalizeDomain(domain);
-  
+
   let dbDomain: Domain | undefined;
-  
+
   if (accountId) {
     // 如果指定了 accountId，精确查询
     dbDomain = await DomainOperations.getByAccountIdAndName(
       Number(accountId),
       normalizedDomain
     ) as Domain | undefined;
-    
+
     if (!dbDomain) {
       sendError(res, 'Domain not found in specified account');
       return;
@@ -1402,20 +1403,20 @@ router.get('/whois', authMiddleware, asyncHandler(async (req: Request, res: Resp
   } else {
     // 未指定 accountId，查询第一条记录
     dbDomain = await DomainOperations.getByName(normalizedDomain) as Domain | undefined;
-    
+
     if (!dbDomain) {
       sendError(res, 'Domain not found');
       return;
     }
-    
+
     // 检查用户是否有权限访问这个域名
     const access = await resolveDomainAccessById(dbDomain.id, req.user!.userId, normalizeRole(req.user?.role));
-    
+
     if (!access.domain || !access.canRead) {
       // 如果第一条记录无权限，尝试查找用户有权限的其他同名域名
       const userDomains = await DomainOperations.getAll() as unknown as Domain[];
       const accessibleDomains = userDomains.filter((d: Domain) => d.name === normalizedDomain);
-      
+
       let foundAccessible = false;
       for (const candidateDomain of accessibleDomains) {
         const candidateAccess = await resolveDomainAccessById(
@@ -1423,38 +1424,38 @@ router.get('/whois', authMiddleware, asyncHandler(async (req: Request, res: Resp
           req.user!.userId,
           normalizeRole(req.user?.role)
         );
-        
+
         if (candidateAccess.domain && candidateAccess.canRead) {
           dbDomain = candidateDomain;
           foundAccessible = true;
           break;
         }
       }
-      
+
       if (!foundAccessible) {
         sendError(res, 'No permission to access this domain');
         return;
       }
     }
   }
-  
+
   // Get the account
   const account = await DnsAccountOperations.getById(dbDomain.account_id) as DnsAccount | undefined;
   if (!account) {
     sendError(res, 'Account not found');
     return;
   }
-  
+
   try {
     // 使用通用 WHOIS 查询服务（支持所有域名）
-    log.info('Domains', `Querying WHOIS for ${domain}`);
+    log.info(`Querying WHOIS for ${domain}`);
     const whoisResult = await queryWhois(domain);
-    
+
     if (!whoisResult) {
       sendError(res, 'WHOIS query failed or no data available');
       return;
     }
-    
+
     // 转换为前端期望的格式
     const response = {
       domain: whoisResult.domain || domain,
@@ -1466,10 +1467,10 @@ router.get('/whois', authMiddleware, asyncHandler(async (req: Request, res: Resp
       name_servers: whoisResult.nameServers || [],
       raw_data: whoisResult.raw || '',
     };
-    
+
     sendSuccess(res, response);
   } catch (error) {
-    log.error('Domains', 'WHOIS query failed', { error });
+    log.error('WHOIS query failed', { error });
     sendError(res, error instanceof Error ? error.message : 'WHOIS query failed');
   }
 }));
@@ -1492,11 +1493,11 @@ router.post('/renewable-domains', authMiddleware, asyncHandler(async (req: Reque
   // Only allow admins and super admins
   const role = normalizeRole(req.user?.role);
   if (role < 2) {
-    log.warn('Domains', 'Unauthorized attempt to add renewable domain', { userId: req.user?.userId, role });
+    log.warn('Unauthorized attempt to add renewable domain', { userId: req.user?.userId, role });
     sendError(res, 'Permission denied');
     return;
   }
-  
+
   const { account_id, provider_type, domain_name, third_id, full_domain, expires_at, remark } = req.body as {
     account_id: number;
     provider_type: string;
@@ -1506,32 +1507,32 @@ router.post('/renewable-domains', authMiddleware, asyncHandler(async (req: Reque
     expires_at?: string;
     remark?: string;
   };
-  
-  log.info('Domains', 'Add renewable domain request', { 
-    account_id, 
-    provider_type, 
-    domain_name, 
+
+  log.info('Add renewable domain request', {
+    account_id,
+    provider_type,
+    domain_name,
     third_id,
     full_domain,
     expires_at,
     userId: req.user?.userId
   });
-  
+
   if (!account_id || !provider_type || !domain_name || !third_id || !full_domain) {
-    log.error('Domains', 'Missing required fields for adding renewable domain', { 
-      account_id, 
-      provider_type, 
-      domain_name, 
+    log.error('Missing required fields for adding renewable domain', {
+      account_id,
+      provider_type,
+      domain_name,
       third_id,
       full_domain
     });
     sendError(res, 'Missing required fields');
     return;
   }
-  
+
   try {
-    log.debug('Domains', 'Adding renewable domain to database', { account_id, provider_type, domain_name, third_id });
-    
+    log.debug('Adding renewable domain to database', { account_id, provider_type, domain_name, third_id });
+
     const id = await RenewableDomainOperations.add({
       account_id,
       provider_type,
@@ -1541,11 +1542,11 @@ router.post('/renewable-domains', authMiddleware, asyncHandler(async (req: Reque
       expires_at,
       remark,
     });
-    
-    log.info('Domains', 'Successfully added renewable domain', { id, full_domain, userId: req.user?.userId });
+
+    log.info('Successfully added renewable domain', { id, full_domain, userId: req.user?.userId });
     sendSuccess(res, { id });
   } catch (error) {
-    log.error('Domains', 'Failed to add renewable domain', { 
+    log.error('Failed to add renewable domain', {
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined
     });
@@ -1560,26 +1561,26 @@ router.delete('/renewable-domains/:id', authMiddleware, asyncHandler(async (req:
   // Only allow admins and super admins
   const role = normalizeRole(req.user?.role);
   if (role < 2) {
-    log.warn('Domains', 'Unauthorized attempt to delete renewable domain', { userId: req.user?.userId, role });
+    log.warn('Unauthorized attempt to delete renewable domain', { userId: req.user?.userId, role });
     sendError(res, 'Permission denied');
     return;
   }
-  
+
   const id = parseInt(req.params.id);
   if (isNaN(id)) {
-    log.error('Domains', 'Invalid renewable domain ID', { id: req.params.id });
+    log.error('Invalid renewable domain ID', { id: req.params.id });
     sendError(res, 'Invalid ID');
     return;
   }
-  
-  log.info('Domains', 'Delete renewable domain request', { id, userId: req.user?.userId });
-  
+
+  log.info('Delete renewable domain request', { id, userId: req.user?.userId });
+
   try {
     await RenewableDomainOperations.delete(id);
-    log.info('Domains', 'Successfully deleted renewable domain', { id, userId: req.user?.userId });
+    log.info('Successfully deleted renewable domain', { id, userId: req.user?.userId });
     sendSuccess(res, null);
   } catch (error) {
-    log.error('Domains', 'Failed to delete renewable domain', { 
+    log.error('Failed to delete renewable domain', {
       id,
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined
@@ -1595,42 +1596,42 @@ router.patch('/renewable-domains/:id/toggle-enabled', authMiddleware, asyncHandl
   // Only allow admins and super admins
   const role = normalizeRole(req.user?.role);
   if (role < 2) {
-    log.warn('Domains', 'Unauthorized attempt to toggle renewable domain', { userId: req.user?.userId, role });
+    log.warn('Unauthorized attempt to toggle renewable domain', { userId: req.user?.userId, role });
     sendError(res, 'Permission denied');
     return;
   }
-  
+
   const id = parseInt(req.params.id);
   if (isNaN(id)) {
-    log.error('Domains', 'Invalid renewable domain ID', { id: req.params.id });
+    log.error('Invalid renewable domain ID', { id: req.params.id });
     sendError(res, 'Invalid ID');
     return;
   }
-  
+
   const { enabled } = req.body;
   if (typeof enabled !== 'boolean') {
-    log.error('Domains', 'Missing or invalid enabled field', { enabled });
+    log.error('Missing or invalid enabled field', { enabled });
     sendError(res, 'Enabled field is required and must be boolean');
     return;
   }
-  
-  log.info('Domains', 'Toggle renewable domain enabled status', { 
-    id, 
+
+  log.info('Toggle renewable domain enabled status', {
+    id,
     enabled,
-    userId: req.user?.userId 
+    userId: req.user?.userId
   });
-  
+
   try {
     // Get current domain info for audit log
     const domain = await RenewableDomainOperations.getById(id);
     if (!domain) {
-      log.error('Domains', 'Renewable domain not found', { id });
+      log.error('Renewable domain not found', { id });
       sendError(res, 'Renewable domain not found');
       return;
     }
-    
+
     await RenewableDomainOperations.toggleEnabled(id, enabled);
-    
+
     // Log audit operation
     await logAuditOperation(
       req.user!.userId,
@@ -1639,16 +1640,16 @@ router.patch('/renewable-domains/:id/toggle-enabled', authMiddleware, asyncHandl
       { enabled },
       req
     );
-    
-    log.info('Domains', 'Successfully toggled renewable domain enabled status', { 
-      id, 
+
+    log.info('Successfully toggled renewable domain enabled status', {
+      id,
       enabled,
-      userId: req.user?.userId 
+      userId: req.user?.userId
     });
-    
+
     sendSuccess(res, { enabled });
   } catch (error) {
-    log.error('Domains', 'Failed to toggle renewable domain enabled status', { 
+    log.error('Failed to toggle renewable domain enabled status', {
       id,
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined
@@ -1667,7 +1668,7 @@ router.post('/renewable-domains/sync', authMiddleware, asyncHandler(async (req: 
     sendError(res, 'Permission denied');
     return;
   }
-  
+
   const { account_id, domain_ids } = req.body as {
     account_id: number;
     domain_ids: Array<{
@@ -1677,12 +1678,12 @@ router.post('/renewable-domains/sync', authMiddleware, asyncHandler(async (req: 
       expires_at?: string;
     }>;
   };
-  
+
   if (!account_id || !Array.isArray(domain_ids) || domain_ids.length === 0) {
     sendError(res, 'Missing required fields');
     return;
   }
-  
+
   try {
     // Get account info
     const account = await DnsAccountOperations.getById(account_id);
@@ -1690,7 +1691,7 @@ router.post('/renewable-domains/sync', authMiddleware, asyncHandler(async (req: 
       sendError(res, 'Account not found');
       return;
     }
-    
+
     // Filter out disabled domains
     const enabledDomainIds: Set<string> = new Set();
     for (const d of domain_ids) {
@@ -1698,10 +1699,10 @@ router.post('/renewable-domains/sync', authMiddleware, asyncHandler(async (req: 
       if (dbDomain && dbDomain.enabled !== 0) {
         enabledDomainIds.add(String(d.id));
       } else if (dbDomain) {
-        log.info('Domains', `Skipping disabled domain for renewal sync: ${d.name || d.full_domain}`);
+        log.info(`Skipping disabled domain for renewal sync: ${d.name || d.full_domain}`);
       }
     }
-    
+
     // Add only enabled domains to renewable list
     const domainsToAdd = domain_ids
       .filter(d => enabledDomainIds.has(String(d.id)))
@@ -1714,18 +1715,18 @@ router.post('/renewable-domains/sync', authMiddleware, asyncHandler(async (req: 
         expires_at: d.expires_at,
         remark: `Synced from ${account.name}`,
       }));
-    
+
     const addedCount = await RenewableDomainOperations.addBatch(domainsToAdd);
-    
-    log.info('Domains', 'Synced renewable domains', { 
-      accountId: account_id, 
+
+    log.info('Synced renewable domains', {
+      accountId: account_id,
       addedCount,
-      totalCount: domain_ids.length 
+      totalCount: domain_ids.length
     });
-    
+
     sendSuccess(res, { addedCount, total: domain_ids.length });
   } catch (error) {
-    log.error('Domains', 'Failed to sync renewable domains', { error });
+    log.error('Failed to sync renewable domains', { error });
     sendError(res, 'Failed to sync domains');
   }
 }));

--- a/server/src/routes/init.ts
+++ b/server/src/routes/init.ts
@@ -7,8 +7,9 @@ import { createConnection, isDbInitialized, hasUsers } from '../db/connection';
 import { connect } from '../db/dal/connection';
 import type { DatabaseConfig } from '../db/dal/config';
 import { UserOperations, SystemOperations, SecretOperations } from '../db/bal/business-adapter';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('HTTP').sub('Route').sub('Init');
 // ============================================================================
 // 初始化专用数据库连接函数（隔离、防污染）
 // ============================================================================
@@ -102,7 +103,7 @@ function saveDatabaseConfig(
   }
 
   saveEnvConfig(envConfig);
-  log.info('Init', 'Database configuration saved', { type });
+  log.info('Database configuration saved', { type });
 }
 
 const router = Router();
@@ -144,7 +145,7 @@ router.get('/db-config', async (_req: Request, res: Response) => {
       msg: 'success',
     });
   } catch (error) {
-    log.error('Init', 'Failed to read database configuration', { error });
+    log.error('Failed to read database configuration', { error });
     res.status(500).json({
       code: 500,
       msg: error instanceof Error ? error.message : 'Failed to read database configuration',
@@ -155,11 +156,11 @@ router.get('/db-config', async (_req: Request, res: Response) => {
 // Check system initialization status
 router.get('/status', async (req: Request, res: Response) => {
   try {
-    log.debug('Init', 'Checking system status...');
+    log.debug('Checking system status...');
     const dbInitialized = await isDbInitialized();
     const hasAnyUsers = await hasUsers();
 
-    log.debug('Init', 'Status check result', { dbInitialized, hasAnyUsers });
+    log.debug('Status check result', { dbInitialized, hasAnyUsers });
     res.json({
       code: 0,
       data: {
@@ -170,7 +171,7 @@ router.get('/status', async (req: Request, res: Response) => {
       msg: 'success',
     });
   } catch (error) {
-    log.warn('Init', 'Status check failed, returning uninitialized state', { error });
+    log.warn('Status check failed, returning uninitialized state', { error });
     // If database is not connected yet
     res.json({
       code: 0,
@@ -188,7 +189,7 @@ router.get('/status', async (req: Request, res: Response) => {
 router.post('/test-db', async (req: Request, res: Response) => {
   const { type, sqlite, mysql: mysqlConfig, postgresql: pgConfig } = req.body;
 
-  log.info('Init', 'Received test-db request', { type, sqlitePath: sqlite?.path });
+  log.info('Received test-db request', { type, sqlitePath: sqlite?.path });
 
   if (!type || !['sqlite', 'mysql', 'postgresql'].includes(type)) {
     return res.status(400).json({ code: 400, msg: 'Invalid database type' });
@@ -197,10 +198,10 @@ router.post('/test-db', async (req: Request, res: Response) => {
   try {
     if (type === 'sqlite') {
       const sqlitePath = sqlite?.path || './data/dnsmgr.db';
-      log.info('Init', 'Testing SQLite connection', { path: sqlitePath });
+      log.info('Testing SQLite connection', { path: sqlitePath });
 
       const result = await SystemOperations.testSqliteConnection(sqlitePath);
-      log.info('Init', 'SQLite test result', { result });
+      log.info('SQLite test result', { result });
       return res.json({
         code: 0,
         data: result,
@@ -213,7 +214,7 @@ router.post('/test-db', async (req: Request, res: Response) => {
         return res.status(400).json({ code: 400, msg: 'MySQL configuration required' });
       }
 
-      log.info('Init', 'Testing MySQL connection', { host: mysqlConfig.host, database: mysqlConfig.database });
+      log.info('Testing MySQL connection', { host: mysqlConfig.host, database: mysqlConfig.database });
       const result = await SystemOperations.testMysqlConnection(mysqlConfig);
       return res.json({
         code: 0,
@@ -227,7 +228,7 @@ router.post('/test-db', async (req: Request, res: Response) => {
         return res.status(400).json({ code: 400, msg: 'PostgreSQL configuration required' });
       }
 
-      log.info('Init', 'Testing PostgreSQL connection', { host: pgConfig.host, database: pgConfig.database });
+      log.info('Testing PostgreSQL connection', { host: pgConfig.host, database: pgConfig.database });
       const result = await SystemOperations.testPostgresqlConnection(pgConfig);
       return res.json({
         code: 0,
@@ -236,7 +237,7 @@ router.post('/test-db', async (req: Request, res: Response) => {
       });
     }
   } catch (error) {
-    log.error('Init', 'Test database connection failed', { error, type, sqlitePath: sqlite?.path });
+    log.error('Test database connection failed', { error, type, sqlitePath: sqlite?.path });
     return res.status(400).json({
       code: 400,
       data: { success: false, message: error instanceof Error ? error.message : 'Connection failed' },
@@ -259,7 +260,7 @@ router.post('/database', async (req: Request, res: Response) => {
   let hasExistingUsers = false;
 
   try {
-    log.info('Init', 'Testing database connection', { type, sqlitePath: sqlite?.path });
+    log.info('Testing database connection', { type, sqlitePath: sqlite?.path });
     const testResult = await SystemOperations.testConnection({
       type,
       sqlite: sqlite || { path: './data/dnsmgr.db' },
@@ -268,113 +269,113 @@ router.post('/database', async (req: Request, res: Response) => {
     });
     hasExistingData = testResult.hasExistingData;
     hasExistingUsers = testResult.hasUsers || false;
-    log.info('Init', 'Test connection result', { hasExistingData, hasExistingUsers, type });
+    log.info('Test connection result', { hasExistingData, hasExistingUsers, type });
   } catch (error) {
-    log.warn('Init', 'Database connection test failed', { error, type, sqlitePath: sqlite?.path });
+    log.warn('Database connection test failed', { error, type, sqlitePath: sqlite?.path });
     // 继续执行，因为这是新数据库的正常情况
   }
 
   // Step 2: Handle different scenarios based on existing data
-  
+
   // Scenario A: Has existing users and keeping data -> Skip to complete
   if (hasExistingData && hasExistingUsers && !reset) {
     try {
       // Save config first
       saveDatabaseConfig(type, sqlite, mysqlConfig, pgConfig);
-      
+
       // Disconnect any existing connection
       try {
         const { disconnect } = await import('../db/dal/connection');
         await disconnect();
       } catch { /* Ignore */ }
-      
+
       // Establish new connection with explicit config
       await connect(testConfig);
-      log.info('Init', 'Connected to existing database with users, skipping to complete');
-      
+      log.info('Connected to existing database with users, skipping to complete');
+
       return res.json({
         code: 0,
-        data: { 
-          success: true, 
+        data: {
+          success: true,
           skipToComplete: true,
           message: 'Database already initialized with users. Setup complete.'
         },
         msg: 'Database already initialized with users. Setup complete.',
       });
     } catch (error) {
-      log.error('Init', 'Failed to connect to existing database', { error });
+      log.error('Failed to connect to existing database', { error });
       return res.status(500).json({
         code: 500,
         msg: 'Failed to connect to existing database. Please check your configuration.',
       });
     }
   }
-  
+
   // Scenario B: Has existing data but no users, keeping data -> Skip to user creation
   if (hasExistingData && !hasExistingUsers && !reset) {
     try {
       // Save config first
       saveDatabaseConfig(type, sqlite, mysqlConfig, pgConfig);
-      
+
       // Disconnect any existing connection
       try {
         const { disconnect } = await import('../db/dal/connection');
         await disconnect();
       } catch { /* Ignore */ }
-      
+
       // Establish new connection with explicit config
       await connect(testConfig);
-      log.info('Init', 'Connected to existing database without users, skipping to user creation');
-      
+      log.info('Connected to existing database without users, skipping to user creation');
+
       return res.json({
         code: 0,
-        data: { 
-          success: true, 
+        data: {
+          success: true,
           skipToUserCreation: true,
           message: 'Database already initialized. Proceed to create admin user.'
         },
         msg: 'Database already initialized. Please create admin user.',
       });
     } catch (error) {
-      log.error('Init', 'Failed to connect to existing database', { error });
+      log.error('Failed to connect to existing database', { error });
       return res.status(500).json({
         code: 500,
         msg: 'Failed to connect to existing database. Please check your configuration.',
       });
     }
   }
-  
+
   // Scenario C: Fresh initialization or reset
   try {
     // Save configuration
     saveDatabaseConfig(type, sqlite, mysqlConfig, pgConfig);
-    
+
     // Generate JWT secret if needed
     const currentJwtSecret = process.env.JWT_SECRET || '';
     if (!currentJwtSecret || currentJwtSecret === 'dnsmgr-secret-key') {
       saveEnvConfig({ JWT_SECRET: crypto.randomBytes(32).toString('hex') });
     }
-    
+
     // Create database connection with explicit config
-    log.info('Init', 'Creating new database connection', { type, reset });
+    log.info('Creating new database connection', { type, reset });
     const conn = await connect(testConfig);
-    
+
     // Initialize schema using DSM
     if (reset) {
       await initializeDSM();
-      log.info('Init', 'Database schema reset successfully via DSM');
+      log.info('Database schema reset successfully via DSM');
     } else {
       await initializeDSM();
-      log.info('Init', 'Database schema initialized successfully via DSM');
+      log.info('Database schema initialized successfully via DSM');
     }
-    
+
     return res.json({
       code: 0,
       data: { success: true, reset },
       msg: reset ? 'Database reset successfully' : 'Database initialized successfully',
     });
   } catch (error) {
-    log.error('Init', 'Database initialization error', { error, type, reset });
+    log.error('Database initialization error', { error, type, reset });
     return res.status(500).json({
       code: 500,
       msg: error instanceof Error ? error.message : 'Failed to initialize database',
@@ -434,7 +435,7 @@ router.post('/admin', async (req: Request, res: Response) => {
     // 使用业务适配器轮换运行时密钥
     await SecretOperations.rotateRuntimeSecrets();
 
-    log.info('Init', 'Admin user created successfully', { username, email });
+    log.info('Admin user created successfully', { username, email });
 
     res.json({
       code: 0,
@@ -442,7 +443,7 @@ router.post('/admin', async (req: Request, res: Response) => {
       msg: 'Admin user created successfully',
     });
   } catch (error) {
-    log.error('Init', 'Failed to create admin user', { error });
+    log.error('Failed to create admin user', { error });
     res.status(500).json({
       code: 500,
       msg: error instanceof Error ? error.message : 'Failed to create admin user',

--- a/server/src/routes/mcp-apikeys.ts
+++ b/server/src/routes/mcp-apikeys.ts
@@ -2,9 +2,10 @@ import { Router, Request, Response } from 'express';
 import { authMiddleware } from '../middleware/auth';
 import { McpOperations } from '../db/bal/business-adapter';
 import { sendSuccess } from '../utils/http';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import crypto from 'crypto';
 
+const log = createLogger('MCP').sub('Route').sub('Apikeys');
 const router = Router();
 
 /**
@@ -31,16 +32,16 @@ function generateApiKey(): string {
 router.get('/', authMiddleware, async (req: Request, res: Response) => {
   try {
     const keys = await McpOperations.getUserApiKeys(req.user!.userId);
-    
+
     // Mask API keys for security
     const maskedKeys = keys.map(key => ({
       ...key,
       api_key: key.api_key.substring(0, 15) + '...',
     }));
-    
+
     sendSuccess(res, maskedKeys);
   } catch (error) {
-    log.error('MCP', 'Failed to get API keys', { error });
+    log.error('Failed to get API keys', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to get API keys' });
   }
 });
@@ -81,7 +82,7 @@ router.post('/', authMiddleware, async (req: Request, res: Response) => {
     }
 
     const apiKey = generateApiKey();
-    
+
     // Calculate expiration date - support both camelCase and snake_case
     let expiresAtStr: string | undefined;
     if (expiresAt) {
@@ -93,9 +94,9 @@ router.post('/', authMiddleware, async (req: Request, res: Response) => {
     }
 
     await McpOperations.createApiKey(req.user!.userId, apiKey, description, expiresAtStr);
-    
-    log.info('MCP', `API key created for user ${req.user!.userId}`, { description });
-    
+
+    log.info(`API key created for user ${req.user!.userId}`, { description });
+
     // Return the full API key (only shown once) with both formats for compatibility
     sendSuccess(res, {
       api_key: apiKey,
@@ -103,7 +104,7 @@ router.post('/', authMiddleware, async (req: Request, res: Response) => {
       message: 'API key generated successfully. Please save it securely, it will not be shown again.',
     });
   } catch (error) {
-    log.error('MCP', 'Failed to create API key', { error });
+    log.error('Failed to create API key', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to create API key' });
   }
 });
@@ -131,18 +132,18 @@ router.post('/', authMiddleware, async (req: Request, res: Response) => {
 router.post('/:id/revoke', authMiddleware, async (req: Request, res: Response) => {
   try {
     const keyId = parseInt(req.params.id);
-    
+
     if (isNaN(keyId)) {
       return res.status(400).json({ code: 400, msg: 'Invalid key ID' });
     }
 
     await McpOperations.revokeApiKey(keyId, req.user!.userId);
-    
-    log.info('MCP', `API key revoked by user ${req.user!.userId}`, { keyId });
-    
+
+    log.info(`API key revoked by user ${req.user!.userId}`, { keyId });
+
     sendSuccess(res, { success: true, message: 'API key revoked' });
   } catch (error) {
-    log.error('MCP', 'Failed to revoke API key', { error });
+    log.error('Failed to revoke API key', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to revoke API key' });
   }
 });
@@ -170,18 +171,18 @@ router.post('/:id/revoke', authMiddleware, async (req: Request, res: Response) =
 router.delete('/:id', authMiddleware, async (req: Request, res: Response) => {
   try {
     const keyId = parseInt(req.params.id);
-    
+
     if (isNaN(keyId)) {
       return res.status(400).json({ code: 400, msg: 'Invalid key ID' });
     }
 
     await McpOperations.deleteApiKey(keyId, req.user!.userId);
-    
-    log.info('MCP', `API key deleted by user ${req.user!.userId}`, { keyId });
-    
+
+    log.info(`API key deleted by user ${req.user!.userId}`, { keyId });
+
     sendSuccess(res, { success: true, message: 'API key deleted' });
   } catch (error) {
-    log.error('MCP', 'Failed to delete API key', { error });
+    log.error('Failed to delete API key', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to delete API key' });
   }
 });

--- a/server/src/routes/mcp-audit.ts
+++ b/server/src/routes/mcp-audit.ts
@@ -2,8 +2,9 @@ import { Router, Request, Response } from 'express';
 import { authMiddleware, adminOnly } from '../middleware/auth';
 import { McpOperations } from '../db/bal/business-adapter';
 import { sendSuccess } from '../utils/http';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('MCP').sub('Route').sub('Audit');
 const router = Router();
 
 /**
@@ -81,7 +82,7 @@ router.get('/', authMiddleware, async (req: Request, res: Response) => {
       total: filtered.length,
     });
   } catch (error) {
-    log.error('MCP', 'Failed to get audit logs', { error });
+    log.error('Failed to get audit logs', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to get audit logs' });
   }
 });
@@ -143,7 +144,7 @@ router.get('/export', authMiddleware, async (req: Request, res: Response) => {
       });
     }
   } catch (error) {
-    log.error('MCP', 'Failed to export audit logs', { error });
+    log.error('Failed to export audit logs', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to export audit logs' });
   }
 });

--- a/server/src/routes/mcp-config.ts
+++ b/server/src/routes/mcp-config.ts
@@ -3,8 +3,9 @@ import { Router, Request, Response } from 'express';
 import { authMiddleware, adminOnly } from '../middleware/auth';
 import { McpOperations } from '../db/bal/business-adapter';
 import { sendSuccess } from '../utils/http';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('MCP').sub('Route').sub('Config');
 const router = Router();
 
 // ─── MCP OAuth JWKS Key Pair ──────────────────────────────────────
@@ -21,7 +22,7 @@ function getOrGenerateMcpJwksKey(): McpJwksKey {
   const now = Date.now();
 
   if (!jwksKeyCache || (now - jwksKeyGeneratedAt) > JWKS_KEY_TTL) {
-    log.info('MCP', 'Generating new EC P-256 key pair for MCP OAuth JWKS');
+    log.info('Generating new EC P-256 key pair for MCP OAuth JWKS');
 
     const { publicKey } = crypto.generateKeyPairSync('ec', {
       namedCurve: 'P-256',
@@ -65,7 +66,7 @@ router.get('/.well-known/jwks.json', async (req: Request, res: Response) => {
     const { jwk } = getOrGenerateMcpJwksKey();
     res.status(200).json({ keys: [jwk] });
   } catch (error) {
-    log.error('MCP', 'Failed to serve JWKS', { error });
+    log.error('Failed to serve JWKS', { error });
     res.status(500).json({ error: 'server_error', error_description: 'Internal server error' });
   }
 });
@@ -99,7 +100,7 @@ router.get('/status', async (req: Request, res: Response) => {
     const config = await McpOperations.getGlobalConfig();
     sendSuccess(res, { enabled: config?.enabled || false });
   } catch (error) {
-    log.error('MCP', 'Failed to get MCP status', { error });
+    log.error('Failed to get MCP status', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to get MCP status' });
   }
 });
@@ -123,7 +124,7 @@ router.get('/config', authMiddleware, adminOnly, async (req: Request, res: Respo
     const config = await McpOperations.getGlobalConfig();
     sendSuccess(res, config || { id: 0, enabled: false });
   } catch (error) {
-    log.error('MCP', 'Failed to get MCP config', { error });
+    log.error('Failed to get MCP config', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to get MCP config' });
   }
 });
@@ -163,12 +164,12 @@ router.post('/config', authMiddleware, adminOnly, async (req: Request, res: Resp
     }
 
     await McpOperations.updateGlobalConfig(enabled, req.user!.userId);
-    
-    log.info('MCP', `MCP global config updated by user ${req.user!.userId}`, { enabled });
-    
+
+    log.info(`MCP global config updated by user ${req.user!.userId}`, { enabled });
+
     sendSuccess(res, { success: true });
   } catch (error) {
-    log.error('MCP', 'Failed to update MCP config', { error });
+    log.error('Failed to update MCP config', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to update MCP config' });
   }
 });
@@ -183,12 +184,12 @@ router.put('/config', authMiddleware, adminOnly, async (req: Request, res: Respo
     }
 
     await McpOperations.updateGlobalConfig(enabled, req.user!.userId);
-    
-    log.info('MCP', `MCP global config updated by user ${req.user!.userId}`, { enabled });
-    
+
+    log.info(`MCP global config updated by user ${req.user!.userId}`, { enabled });
+
     sendSuccess(res, { success: true });
   } catch (error) {
-    log.error('MCP', 'Failed to update MCP config', { error });
+    log.error('Failed to update MCP config', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to update MCP config' });
   }
 });
@@ -267,7 +268,7 @@ router.get('/.well-known/oauth-protected-resource', async (req: Request, res: Re
 
     res.status(200).json(metadata);
   } catch (error) {
-    log.error('MCP', 'Failed to serve OAuth protected resource metadata', { error });
+    log.error('Failed to serve OAuth protected resource metadata', { error });
     res.status(500).json({ error: 'server_error', error_description: 'Internal server error' });
   }
 });
@@ -372,7 +373,7 @@ router.get('/.well-known/oauth-authorization-server', async (req: Request, res: 
 
     res.status(200).json(metadata);
   } catch (error) {
-    log.error('MCP', 'Failed to serve authorization server metadata', { error });
+    log.error('Failed to serve authorization server metadata', { error });
     res.status(500).json({ error: 'server_error', error_description: 'Internal server error' });
   }
 });
@@ -491,7 +492,7 @@ router.get('/.well-known/mcp.json', async (req: Request, res: Response) => {
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.status(200).json(metadata);
   } catch (error) {
-    log.error('MCP', 'Failed to serve MCP capability discovery metadata', { error });
+    log.error('Failed to serve MCP capability discovery metadata', { error });
     res.status(500).json({ error: 'server_error', error_description: 'Internal server error' });
   }
 });

--- a/server/src/routes/mcp-oauth.ts
+++ b/server/src/routes/mcp-oauth.ts
@@ -3,8 +3,9 @@ import { Router, Request, Response } from 'express';
 import { authMiddleware } from '../middleware/auth';
 import { McpOperations } from '../db/bal/business-adapter';
 import { sendSuccess } from '../utils/http';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('MCP').sub('Route').sub('Oauth');
 const router = Router();
 
 /**
@@ -33,7 +34,7 @@ router.get('/clients', authMiddleware, async (req: Request, res: Response) => {
     const clients = await McpOperations.getUserOAuthClients(req.user!.userId);
     sendSuccess(res, clients);
   } catch (error) {
-    log.error('MCP', 'Failed to get OAuth clients', { error });
+    log.error('Failed to get OAuth clients', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to get OAuth clients' });
   }
 });
@@ -94,7 +95,7 @@ router.post('/clients', authMiddleware, async (req: Request, res: Response) => {
       scope: scope ? JSON.stringify(scope) : undefined,
     });
 
-    log.info('MCP', `OAuth client created for user ${req.user!.userId}`, { app_name });
+    log.info(`OAuth client created for user ${req.user!.userId}`, { app_name });
 
     // Return credentials (only shown once)
     sendSuccess(res, {
@@ -103,7 +104,7 @@ router.post('/clients', authMiddleware, async (req: Request, res: Response) => {
       message: 'OAuth client created successfully. Please save the client_secret securely, it will not be shown again.',
     });
   } catch (error) {
-    log.error('MCP', 'Failed to create OAuth client', { error });
+    log.error('Failed to create OAuth client', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to create OAuth client' });
   }
 });
@@ -145,10 +146,10 @@ router.put('/clients/:id/scope', authMiddleware, async (req: Request, res: Respo
     }
 
     await McpOperations.updateOAuthClientScope(req.params.id, req.user!.userId, scope);
-    log.info('MCP', `OAuth client scope updated by user ${req.user!.userId}`, { clientId: req.params.id, scope });
+    log.info(`OAuth client scope updated by user ${req.user!.userId}`, { clientId: req.params.id, scope });
     sendSuccess(res, { success: true });
   } catch (error) {
-    log.error('MCP', 'Failed to update OAuth client scope', { error });
+    log.error('Failed to update OAuth client scope', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to update scope' });
   }
 });
@@ -188,10 +189,10 @@ router.put('/clients/:id/expiry', authMiddleware, async (req: Request, res: Resp
     const expiryValue = expires_at ? expires_at : null;
 
     await McpOperations.updateOAuthClientExpiry(req.params.id, req.user!.userId, expiryValue);
-    log.info('MCP', `OAuth client expiry updated by user ${req.user!.userId}`, { clientId: req.params.id, expires_at: expiryValue });
+    log.info(`OAuth client expiry updated by user ${req.user!.userId}`, { clientId: req.params.id, expires_at: expiryValue });
     sendSuccess(res, { success: true });
   } catch (error) {
-    log.error('MCP', 'Failed to update OAuth client expiry', { error });
+    log.error('Failed to update OAuth client expiry', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to update expiry' });
   }
 });
@@ -223,11 +224,11 @@ router.delete('/clients/:id', authMiddleware, async (req: Request, res: Response
 
     await McpOperations.deleteOAuthClient(clientId, req.user!.userId);
 
-    log.info('MCP', `OAuth client deleted by user ${req.user!.userId}`, { clientId });
+    log.info(`OAuth client deleted by user ${req.user!.userId}`, { clientId });
 
     sendSuccess(res, { success: true, message: 'OAuth client deleted' });
   } catch (error) {
-    log.error('MCP', 'Failed to delete OAuth client', { error });
+    log.error('Failed to delete OAuth client', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to delete OAuth client' });
   }
 });
@@ -333,7 +334,7 @@ router.get('/authorize', authMiddleware, async (req: Request, res: Response) => 
       expires_at: expiresAt,
     });
 
-    log.info('MCP OAuth', 'Authorization code issued', {
+    log.info('Authorization code issued', {
       client_id,
       user_id: req.user!.userId,
       redirect_uri,
@@ -343,7 +344,7 @@ router.get('/authorize', authMiddleware, async (req: Request, res: Response) => 
     const redirectUrl = `${redirect_uri}?code=${encodeURIComponent(code)}${state ? `&state=${encodeURIComponent(state)}` : ''}`;
     res.redirect(redirectUrl);
   } catch (error) {
-    log.error('MCP OAuth', 'Authorization failed', { error });
+    log.error('Authorization failed', { error });
     res.status(500).json({ error: 'server_error', error_description: 'Internal server error' });
   }
 });
@@ -438,7 +439,7 @@ router.post('/register', async (req: Request, res: Response) => {
 
     const now = Math.floor(Date.now() / 1000);
 
-    log.info('MCP OAuth', 'Dynamic client registered (expires in 10m)', {
+    log.info('Dynamic client registered (expires in 10m)', {
       client_id: clientId,
       client_name,
     });
@@ -453,7 +454,7 @@ router.post('/register', async (req: Request, res: Response) => {
       token_endpoint_auth_method: token_endpoint_auth_method || 'client_secret_post',
     });
   } catch (error) {
-    log.error('MCP OAuth', 'Dynamic client registration failed', { error });
+    log.error('Dynamic client registration failed', { error });
     res.status(500).json({
       error: 'server_error',
       error_description: 'Internal server error',
@@ -538,7 +539,7 @@ router.post('/token', async (req: Request, res: Response) => {
         });
     }
   } catch (error) {
-    log.error('MCP OAuth', 'Token endpoint error', { error });
+    log.error('Token endpoint error', { error });
     res.status(500).json({ error: 'server_error', error_description: 'Internal server error' });
   }
 });
@@ -577,7 +578,7 @@ async function handleClientCredentials(req: Request, res: Response) {
     expires_at: expiresAt,
   });
 
-  log.info('MCP OAuth', 'Token issued (client_credentials)', { client_id, user_id: client.user_id ?? 0 });
+  log.info('Token issued (client_credentials)', { client_id, user_id: client.user_id ?? 0 });
 
   res.status(200).json({
     access_token: accessToken,
@@ -648,7 +649,7 @@ async function handleAuthorizationCode(req: Request, res: Response) {
 
   await Promise.all(operations);
 
-  log.info('MCP OAuth', 'Token issued (authorization_code)', {
+  log.info('Token issued (authorization_code)', {
     client_id: authData.client_id,
     user_id: authData.user_id,
   });
@@ -716,7 +717,7 @@ async function handleRefreshToken(req: Request, res: Response) {
     expires_at: new Date(Date.now() + 30 * 24 * 3600 * 1000).toISOString(), // 30 days
   });
 
-  log.info('MCP OAuth', 'Token refreshed', {
+  log.info('Token refreshed', {
     client_id: tokenData.client_id,
     user_id: tokenData.user_id,
   });
@@ -747,7 +748,7 @@ router.get('/tokens', authMiddleware, async (req: Request, res: Response) => {
     const tokens = await McpOperations.getOAuthAccessTokens(req.user!.userId);
     sendSuccess(res, tokens);
   } catch (error) {
-    log.error('MCP OAuth', 'Failed to get tokens', { error });
+    log.error('Failed to get tokens', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to get tokens' });
   }
 });
@@ -779,11 +780,11 @@ router.post('/tokens/:id/revoke', authMiddleware, async (req: Request, res: Resp
 
     await McpOperations.revokeOAuthTokenById(tokenId, req.user!.userId);
 
-    log.info('MCP OAuth', `Token revoked by user ${req.user!.userId}`, { tokenId });
+    log.info(`Token revoked by user ${req.user!.userId}`, { tokenId });
 
     sendSuccess(res, { success: true, message: 'Token revoked' });
   } catch (error) {
-    log.error('MCP OAuth', 'Failed to revoke token', { error });
+    log.error('Failed to revoke token', { error });
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to revoke token' });
   }
 });
@@ -876,7 +877,7 @@ router.post('/introspect', async (req: Request, res: Response) => {
 
     res.status(200).json(response);
   } catch (error) {
-    log.error('MCP OAuth', 'Token introspection failed', { error });
+    log.error('Token introspection failed', { error });
     res.status(500).json({ error: 'server_error', error_description: 'Internal server error' });
   }
 });
@@ -922,7 +923,7 @@ router.post('/revoke', async (req: Request, res: Response) => {
     // Per RFC 7009: always return 200, even if the token was already invalid
     res.status(200).json({});
   } catch (error) {
-    log.error('MCP OAuth', 'Token revocation failed', { error });
+    log.error('Token revocation failed', { error });
     res.status(500).json({ error: 'server_error', error_description: 'Internal server error' });
   }
 });

--- a/server/src/routes/mcp-protocol.ts
+++ b/server/src/routes/mcp-protocol.ts
@@ -14,8 +14,9 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { mcpServer, HidnsMcpServer } from '../mcp/server';
 import { McpOperations } from '../db/bal/business-adapter';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('MCP').sub('Route').sub('Protocol');
 const router = Router();
 
 // ── 传统 SSE 传输层 ──
@@ -38,7 +39,7 @@ async function mcpEnabledCheck(req: Request, res: Response, next: NextFunction):
     }
     next();
   } catch (error) {
-    log.error('MCP Protocol', 'Failed to check MCP enabled status', { error });
+    log.error('Failed to check MCP enabled status', { error });
     res.status(500).json({ code: 500, msg: 'Failed to check MCP status', data: null });
   }
 }
@@ -101,7 +102,7 @@ async function handleMcpRequest(req: Request, res: Response): Promise<void> {
 
   try {
     // ── 日志：收到请求 ──
-    log.info('MCP Protocol', `Incoming ${req.method} /api/mcp`, {
+    log.info(`Incoming ${req.method} /api/mcp`, {
       method: req.method,
       clientIp,
       contentType: req.headers['content-type'],
@@ -124,7 +125,7 @@ async function handleMcpRequest(req: Request, res: Response): Promise<void> {
     if (!authValue) {
       const oauthUri = buildOAuthMetadataUrl(req);
 
-      log.info('MCP Protocol', 'Auth required (no API-Key/Bearer token), returning 401 with OAuth discovery', {
+      log.info('Auth required (no API-Key/Bearer token), returning 401 with OAuth discovery', {
         clientIp,
         oauthUri,
       });
@@ -141,7 +142,7 @@ async function handleMcpRequest(req: Request, res: Response): Promise<void> {
 
     // ── 日志：认证通过 ──
     const methods = extractMethods(req.body);
-    log.info('MCP Protocol', 'POST /api/mcp authenticated', {
+    log.info('POST /api/mcp authenticated', {
       clientIp,
       authType: req.headers['api-key'] ? 'api-key' : 'bearer',
       authValue: maskAuthValue(authValue),
@@ -154,7 +155,7 @@ async function handleMcpRequest(req: Request, res: Response): Promise<void> {
       const injectApiKey = (msg: any) => {
         if (msg?.method === 'tools/call' && msg?.params && !msg.params.apiKey) {
           msg.params.apiKey = authValue;
-          log.debug('MCP Protocol', 'API key injected into tools/call params', {
+          log.debug('API key injected into tools/call params', {
             toolName: msg.params?.name,
             params: Object.keys(msg.params).filter(k => k !== 'apiKey'),
           });
@@ -181,7 +182,7 @@ async function handleMcpRequest(req: Request, res: Response): Promise<void> {
       await server.close().catch(() => { /* 忽略未连接时的关闭错误 */ });
     }
     await server.connect(transport);
-    log.debug('MCP Protocol', 'Streamable HTTP transport connected for request', {
+    log.debug('Streamable HTTP transport connected for request', {
       clientIp,
       methods,
     });
@@ -192,7 +193,7 @@ async function handleMcpRequest(req: Request, res: Response): Promise<void> {
 
       // ── 日志：请求完成 ──
       const duration = Date.now() - startTime;
-      log.info('MCP Protocol', `Completed POST /api/mcp`, {
+      log.info(`Completed POST /api/mcp`, {
         statusCode: res.statusCode,
         durationMs: duration,
         clientIp,
@@ -200,12 +201,12 @@ async function handleMcpRequest(req: Request, res: Response): Promise<void> {
     } finally {
       // 断开 Transport 连接，释放服务器以供下一个请求连接
       await server.close().catch((err) => {
-        log.debug('MCP Protocol', 'Error closing per-request transport', { error: err });
+        log.debug('Error closing per-request transport', { error: err });
       });
     }
   } catch (error) {
     const duration = Date.now() - startTime;
-    log.error('MCP Protocol', 'Failed to handle MCP protocol request', {
+    log.error('Failed to handle MCP protocol request', {
       error: error instanceof Error ? { message: error.message, name: error.name, stack: error.stack } : error,
       method: req.method,
       path: req.path,
@@ -235,14 +236,14 @@ async function handleSseGet(req: Request, res: Response): Promise<void> {
     const authValue = extractAuthValue(req);
 
     // ── 日志：收到 SSE 连接请求 ──
-    log.info('MCP Protocol', 'Incoming SSE GET /api/mcp/sse', {
+    log.info('Incoming SSE GET /api/mcp/sse', {
       clientIp,
       contentType: req.headers['content-type'],
       accept: req.headers['accept'],
     });
 
     if (!authValue) {
-      log.info('MCP Protocol', 'SSE auth required (no API-Key/Bearer token), returning 401', { clientIp });
+      log.info('SSE auth required (no API-Key/Bearer token), returning 401', { clientIp });
 
       const oauthUri = buildOAuthMetadataUrl(req);
 
@@ -257,7 +258,7 @@ async function handleSseGet(req: Request, res: Response): Promise<void> {
     }
 
     // ── 日志：SSE 认证通过 ──
-    log.info('MCP Protocol', 'SSE GET /api/mcp/sse authenticated', {
+    log.info('SSE GET /api/mcp/sse authenticated', {
       clientIp,
       authType: req.headers['api-key'] ? 'api-key' : 'bearer',
       authValue: maskAuthValue(authValue),
@@ -273,7 +274,7 @@ async function handleSseGet(req: Request, res: Response): Promise<void> {
     // 连接到 MCP 服务器（connect 会调用 transport.start() 自动发送 endpoint 事件）
     await sseMcpServer.getServer().connect(transport);
 
-    log.info('MCP Protocol', `SSE session established: ${sessionId}`, {
+    log.info(`SSE session established: ${sessionId}`, {
       sessionId,
       clientIp,
       authType: req.headers['api-key'] ? 'api-key' : 'bearer',
@@ -283,13 +284,13 @@ async function handleSseGet(req: Request, res: Response): Promise<void> {
     // 连接关闭时清理
     res.on('close', () => {
       sseTransports.delete(sessionId);
-      log.info('MCP Protocol', `SSE session closed: ${sessionId}`, {
+      log.info(`SSE session closed: ${sessionId}`, {
         sessionId,
         clientIp,
       });
     });
   } catch (error) {
-    log.error('MCP Protocol', 'Failed to establish SSE connection', {
+    log.error('Failed to establish SSE connection', {
       error: error instanceof Error ? { message: error.message, name: error.name, stack: error.stack } : error,
       clientIp,
     });
@@ -315,7 +316,7 @@ async function handleSsePost(req: Request, res: Response): Promise<void> {
   try {
     // ── 日志：收到 SSE POST 消息 ──
     const methods = extractMethods(req.body);
-    log.info('MCP Protocol', `Incoming SSE POST /api/mcp/sse`, {
+    log.info(`Incoming SSE POST /api/mcp/sse`, {
       sessionId: sessionId || '(missing)',
       clientIp,
       contentType: req.headers['content-type'],
@@ -330,7 +331,7 @@ async function handleSsePost(req: Request, res: Response): Promise<void> {
 
     const transport = sseTransports.get(sessionId);
     if (!transport) {
-      log.warn('MCP Protocol', 'SSE session not found for POST message', {
+      log.warn('SSE session not found for POST message', {
         sessionId,
         clientIp,
         durationMs: Date.now() - startTime,
@@ -344,7 +345,7 @@ async function handleSsePost(req: Request, res: Response): Promise<void> {
 
     // ── 日志：SSE POST 完成 ──
     const duration = Date.now() - startTime;
-    log.info('MCP Protocol', `Completed SSE POST /api/mcp/sse`, {
+    log.info(`Completed SSE POST /api/mcp/sse`, {
       sessionId,
       clientIp,
       statusCode: res.statusCode,
@@ -352,7 +353,7 @@ async function handleSsePost(req: Request, res: Response): Promise<void> {
     });
   } catch (error) {
     const duration = Date.now() - startTime;
-    log.error('MCP Protocol', 'Failed to handle SSE POST message', {
+    log.error('Failed to handle SSE POST message', {
       error: error instanceof Error ? { message: error.message, name: error.name, stack: error.stack } : error,
       sessionId: sessionId || '(unknown)',
       clientIp,

--- a/server/src/routes/network.ts
+++ b/server/src/routes/network.ts
@@ -6,12 +6,13 @@
 import { Router, Request, Response } from 'express';
 import { authMiddleware } from '../middleware/auth';
 import { asyncHandler } from '../middleware/errorHandler';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { SettingsOperations } from '../db/bal/business-adapter';
 import { getProxyConfig, createProxyAgent } from '../lib/proxy-http';
 import https from 'https';
 import http from 'http';
 
+const log = createLogger('HTTP').sub('Route').sub('Network');
 const router = Router();
 
 /**
@@ -42,15 +43,15 @@ interface ConnectivityResult {
  */
 async function getProxyConfigFromDB(): Promise<ProxyConfig | null> {
   try {
-    log.debug('Network', 'Getting proxy config from database');
+    log.debug('Getting proxy config from database');
     const configValue = await SettingsOperations.get('proxy_config');
-    log.debug('Network', 'Proxy config raw value', { configValue: configValue || 'null' });
+    log.debug('Proxy config raw value', { configValue: configValue || 'null' });
     if (!configValue) return null;
     const parsed = JSON.parse(configValue);
-    log.debug('Network', 'Proxy config parsed', { enabled: parsed.enabled, type: parsed.type, host: parsed.host });
+    log.debug('Proxy config parsed', { enabled: parsed.enabled, type: parsed.type, host: parsed.host });
     return parsed;
   } catch (error) {
-    log.warn('Network', 'Failed to get proxy config', { error: (error as Error).message });
+    log.warn('Failed to get proxy config', { error: (error as Error).message });
     return null;
   }
 }
@@ -90,14 +91,14 @@ router.post('/proxy', authMiddleware, asyncHandler(async (req: Request, res: Res
   };
 
   const configJson = JSON.stringify(config);
-  log.debug('Network', 'Saving proxy config to database', { configJson });
+  log.debug('Saving proxy config to database', { configJson });
   await SettingsOperations.set('proxy_config', configJson);
 
   // 验证保存是否成功
   const verifyValue = await SettingsOperations.get('proxy_config');
-  log.debug('Network', 'Verify proxy config saved', { verifyValue: verifyValue || 'null' });
+  log.debug('Verify proxy config saved', { verifyValue: verifyValue || 'null' });
 
-  log.info('Network', 'Proxy configuration updated', { enabled, type, host, port });
+  log.info('Proxy configuration updated', { enabled, type, host, port });
 
   res.json({
     code: 0,
@@ -114,7 +115,7 @@ function testConnectivity(url: string, agent?: any, timeout: number = 10000): Pr
     const startTime = Date.now();
     const parsedUrl = new URL(url);
     const isHttps = parsedUrl.protocol === 'https:';
-    
+
     const requestOptions = {
       hostname: parsedUrl.hostname,
       port: parsedUrl.port || (isHttps ? 443 : 80),
@@ -128,7 +129,7 @@ function testConnectivity(url: string, agent?: any, timeout: number = 10000): Pr
     }
 
     const client = isHttps ? https : http;
-    
+
     const req = client.request(requestOptions, (res) => {
       const latency = Date.now() - startTime;
       resolve({
@@ -174,26 +175,26 @@ const CONNECTIVITY_TARGETS = [
  * GET /api/network/connectivity
  */
 router.get('/connectivity', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
-  log.debug('Network', 'Testing network connectivity');
-  
+  log.debug('Testing network connectivity');
+
   // 获取代理配置
   const proxyConfig = await getProxyConfig();
   const agent = proxyConfig?.enabled ? createProxyAgent(proxyConfig) : undefined;
-  
+
   const results: ConnectivityResult[] = [];
-  
+
   // 并行测试所有目标
   const tests = CONNECTIVITY_TARGETS.map(async (target) => {
     try {
       const result = await testConnectivity(target.url, agent, 10000);
-      
+
       let status: 'ok' | 'error' | 'timeout' = 'error';
       if (result.error === 'Request timeout') {
         status = 'timeout';
       } else if (result.status >= 200 && result.status < 400) {
         status = 'ok';
       }
-      
+
       return {
         name: target.name,
         url: target.url,
@@ -211,12 +212,12 @@ router.get('/connectivity', authMiddleware, asyncHandler(async (req: Request, re
       } as ConnectivityResult;
     }
   });
-  
+
   const settledResults = await Promise.all(tests);
   results.push(...settledResults);
-  
-  log.debug('Network', 'Connectivity test completed', { results });
-  
+
+  log.debug('Connectivity test completed', { results });
+
   res.json({
     code: 0,
     msg: 'success',

--- a/server/src/routes/ns-monitor.ts
+++ b/server/src/routes/ns-monitor.ts
@@ -7,13 +7,14 @@ import { Router, Request, Response } from 'express';
 import { NSMonitorOperations, DomainOperations, getDbType, formatDateForDB } from '../db/bal/business-adapter';
 import { authMiddleware } from '../middleware/auth';
 import { asyncHandler } from '../middleware/errorHandler';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { normalizeRole, isSuper, isAdmin } from '../utils/roles';
 import { resolveNsRecords, NSLookupResult, validateNsRecords } from '../lib/dns/ns-lookup';
 import { getDomainAccess } from './domains';
 import { wsService } from '../service/websocket';
 import { normalizeDomain, isValidDomain, toUnicode, getDisplayDomain } from '../utils/dns';
 
+const log = createLogger('HTTP').sub('Route').sub('NsMonitor');
 const router = Router();
 
 /** 将布尔值转换为数据库特定的布尔类型 */
@@ -116,7 +117,7 @@ router.post('/resolve-ns', authMiddleware, asyncHandler(async (req: Request, res
       },
     });
   } catch (error) {
-    log.error('NSMonitor', 'Failed to resolve NS records', {
+    log.error('Failed to resolve NS records', {
       domain,
       error: error instanceof Error ? error.message : String(error),
     });
@@ -160,7 +161,7 @@ router.put('/user/prefs', authMiddleware, asyncHandler(async (req: Request, res:
       updates.notify_channels = toDbBoolean(notify_channels, dbType);
     }
   } else if (notify_channels !== undefined) {
-    log.warn('NSMonitor', 'Non-admin user attempted to modify notification channels', {
+    log.warn('Non-admin user attempted to modify notification channels', {
       userId,
       role,
     });
@@ -184,8 +185,8 @@ router.put('/user/prefs', authMiddleware, asyncHandler(async (req: Request, res:
     });
   }
 
-  log.info('NSMonitor', 'User preferences updated', { userId, updates });
-  
+  log.info('User preferences updated', { userId, updates });
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -195,9 +196,9 @@ router.put('/user/prefs', authMiddleware, asyncHandler(async (req: Request, res:
       },
     });
   } catch (error) {
-    log.error('NSMonitor', 'Failed to broadcast ns_monitor_prefs_updated event', { error });
+    log.error('Failed to broadcast ns_monitor_prefs_updated event', { error });
   }
-  
+
   res.json({ success: true, msg: 'Preferences updated successfully' });
 }));
 
@@ -246,7 +247,7 @@ router.get('/available-domains', authMiddleware, asyncHandler(async (req: Reques
   // Level 1: Reuse DomainOperations.getAll() for super admin
   // For regular users, use dedicated function that filters by user's accounts
   let allDomains: any[];
-  
+
   if (isSuper(role)) {
     // Super admin: reuse existing getAll() function
     allDomains = await DomainOperations.getAll() as any[];
@@ -259,8 +260,8 @@ router.get('/available-domains', authMiddleware, asyncHandler(async (req: Reques
   const monitoredDomainNames = new Set(
     (await NSMonitorOperations.getUserMonitors(userId)).map((m: any) => m.domain_name)
   );
-  
-  const availableDomains = allDomains.filter((domain: any) => 
+
+  const availableDomains = allDomains.filter((domain: any) =>
     !monitoredDomainNames.has(domain.name)
   );
 
@@ -346,7 +347,7 @@ router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response
   const existing = await NSMonitorOperations.getByDomainName(userId, domainName);
   if (existing) {
     // Delete old monitor config first
-    log.info('NSMonitor', 'Deleting old monitor config for same domain name', {
+    log.info('Deleting old monitor config for same domain name', {
       oldMonitorId: existing.id,
       domainName,
     });
@@ -360,13 +361,13 @@ router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response
       const nsResult = await resolveNsRecords(domainName);
       if (nsResult.nsRecords.length > 0) {
         finalExpectedNs = nsResult.nsRecords.join(', ');
-        log.info('NSMonitor', 'Auto-filled expected NS', {
+        log.info('Auto-filled expected NS', {
           domainName,
           nsRecords: nsResult.nsRecords,
         });
       }
     } catch (error) {
-      log.warn('NSMonitor', 'Failed to auto-fetch NS records', { domainName, error });
+      log.warn('Failed to auto-fetch NS records', { domainName, error });
     }
   }
 
@@ -376,7 +377,7 @@ router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response
     expected_ns: finalExpectedNs,
   });
 
-  log.info('NSMonitor', 'Monitor created', { domainName, userId, monitorId: id });
+  log.info('Monitor created', { domainName, userId, monitorId: id });
 
   // 获取完整的监测配置数据用于 WebSocket 推送
   const newMonitor = await NSMonitorOperations.getById(id, userId);
@@ -393,7 +394,7 @@ router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response
       },
     });
   } catch (error) {
-    log.error('NSMonitor', 'Failed to broadcast ns_monitor_created event', { error });
+    log.error('Failed to broadcast ns_monitor_created event', { error });
   }
 
   res.json({
@@ -434,11 +435,11 @@ router.put('/:id', authMiddleware, asyncHandler(async (req: Request, res: Respon
 
   await NSMonitorOperations.update(parseInt(id), userId, updates);
 
-  log.info('NSMonitor', 'Monitor updated', { monitorId: id, userId, updates });
-  
+  log.info('Monitor updated', { monitorId: id, userId, updates });
+
   // 获取更新后的完整监测配置数据用于 WebSocket 推送
   const updatedMonitor = await NSMonitorOperations.getById(parseInt(id), userId);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -450,9 +451,9 @@ router.put('/:id', authMiddleware, asyncHandler(async (req: Request, res: Respon
       },
     });
   } catch (error) {
-    log.error('NSMonitor', 'Failed to broadcast ns_monitor_updated event', { error });
+    log.error('Failed to broadcast ns_monitor_updated event', { error });
   }
-  
+
   res.json({ success: true });
 }));
 
@@ -477,8 +478,8 @@ router.delete('/:id', authMiddleware, asyncHandler(async (req: Request, res: Res
 
   await NSMonitorOperations.delete(parseInt(id), userId);
 
-  log.info('NSMonitor', 'Monitor deleted', { monitorId: id, userId });
-  
+  log.info('Monitor deleted', { monitorId: id, userId });
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -489,9 +490,9 @@ router.delete('/:id', authMiddleware, asyncHandler(async (req: Request, res: Res
       },
     });
   } catch (error) {
-    log.error('NSMonitor', 'Failed to broadcast ns_monitor_deleted event', { error });
+    log.error('Failed to broadcast ns_monitor_deleted event', { error });
   }
-  
+
   res.json({ success: true });
 }));
 
@@ -540,7 +541,7 @@ async function performNsCheck(monitorId: number, monitor: any, userId: number): 
     last_check_at: formatDateForDB(new Date()),
   });
 
-  log.info('NSMonitor', 'Manual check completed', {
+  log.info('Manual check completed', {
     monitorId,
     domainName: monitor.domain_name,
     status,

--- a/server/src/routes/providers.ts
+++ b/server/src/routes/providers.ts
@@ -4,7 +4,7 @@ import { asyncHandler } from '../middleware/errorHandler';
 import { normalizeRole } from '../utils/roles';
 import { sendError, sendSuccess } from '../utils/http';
 import { createLogger } from '../lib/logger';
-const log = createLogger('Route:Providers');
+const log = createLogger('HTTP').sub('Route').sub('Providers');
 import { DnsAccountOperations, RenewableDomainOperations } from '../db/bal/business-adapter';
 import { listSubdomains as dnsheListSubdomains } from '../lib/dns/providers/dnshe/renewal';
 import * as fs from 'fs';
@@ -18,22 +18,22 @@ const router = Router();
  */
 router.get('/:type/icon', asyncHandler(async (req: Request, res: Response) => {
   const { type } = req.params;
-  
+
   try {
     // Icon file paths to check in priority order (SVG > PNG > ICO > JPG)
     // SVG is preferred for scalability and small file size
     const iconExtensions = ['.svg', '.png', '.ico', '.jpg', '.jpeg'];
-    
+
     // Support both development (src) and production (dist) environments
     // In dev: __dirname = server/dist/routes, need to go up to server/src/lib/dns/providers
     // In prod: __dirname = server/dist/routes, need to go up to server/dist/lib/dns/providers
     const providersDir = path.join(__dirname, '..', 'lib', 'dns', 'providers');
-    
+
     log.info(`Looking for icon in: ${providersDir}`);
-    
+
     let iconPath = '';
     let iconExt = '';
-    
+
     // Try to find icon file with highest priority extension first
     for (const ext of iconExtensions) {
       const candidatePath = path.join(providersDir, type, `icon${ext}`);
@@ -45,7 +45,7 @@ router.get('/:type/icon', asyncHandler(async (req: Request, res: Response) => {
         break;
       }
     }
-    
+
     // If not found in dist, try src directory (for development without copying files)
     if (!iconPath) {
       const srcProvidersDir = path.join(__dirname, '..', '..', 'src', 'lib', 'dns', 'providers');
@@ -56,19 +56,19 @@ router.get('/:type/icon', asyncHandler(async (req: Request, res: Response) => {
         if (fs.existsSync(candidatePath)) {
           iconPath = candidatePath;
           iconExt = ext;
-          log.info('Providers', `Serving icon from src for ${type}: icon${ext}`);
+          log.info(`Serving icon from src for ${type}: icon${ext}`);
           break;
         }
       }
     }
-    
+
     if (!iconPath || !fs.existsSync(iconPath)) {
       // Return 404 if icon not found
       log.warn(`Icon not found for provider: ${type}`);
       res.status(404).json({ error: 'Icon not found' });
       return;
     }
-    
+
     // Set appropriate content type based on file extension
     const contentTypes: Record<string, string> = {
       '.svg': 'image/svg+xml',
@@ -77,9 +77,9 @@ router.get('/:type/icon', asyncHandler(async (req: Request, res: Response) => {
       '.jpg': 'image/jpeg',
       '.jpeg': 'image/jpeg',
     };
-    
+
     const contentType = contentTypes[iconExt] || 'application/octet-stream';
-    
+
     // Read and send the icon file
     const iconData = fs.readFileSync(iconPath);
     res.set('Content-Type', contentType);
@@ -104,12 +104,12 @@ router.get('/:type/renewable-domains', authMiddleware, asyncHandler(async (req: 
   }
 
   const { type } = req.params;
-  
+
   try {
     // Get all accounts of the specified provider type
     const accounts = await DnsAccountOperations.getAll() as any[];
     const providerAccounts = accounts.filter((acc: any) => acc.type === type);
-    
+
     if (providerAccounts.length === 0) {
       sendSuccess(res, []);
       return;
@@ -132,13 +132,13 @@ router.get('/:type/renewable-domains', authMiddleware, asyncHandler(async (req: 
         for (const account of providerAccounts) {
           try {
             const config = typeof account.config === 'string' ? JSON.parse(account.config) : account.config;
-            
+
             const result = await dnsheListSubdomains({
               apiKey: config.apiKey,
               apiSecret: config.apiSecret,
               useProxy: !!config.useProxy,
             });
-            
+
             if (result && result.success && result.subdomains) {
               // Filter out already added domains and add account info
               const domainsWithAccount = result.subdomains
@@ -151,7 +151,7 @@ router.get('/:type/renewable-domains', authMiddleware, asyncHandler(async (req: 
                   id: sub.id,
                   third_id: String(sub.id),
                 }));
-              
+
               allDomains.push(...domainsWithAccount);
             }
           } catch (error) {
@@ -164,13 +164,13 @@ router.get('/:type/renewable-domains', authMiddleware, asyncHandler(async (req: 
         }
         break;
       }
-      
+
       // TODO: Add other providers here when they support renewal
       // case 'other_provider': {
       //   // Call other provider's listRenewableDomains function
       //   break;
       // }
-      
+
       default:
         sendError(res, `Provider type '${type}' does not support domain renewal`);
         return;

--- a/server/src/routes/rdap.ts
+++ b/server/src/routes/rdap.ts
@@ -1,11 +1,11 @@
 /**
  * RDAP 公开查询路由
- * 
+ *
  * 提供符合 RFC 7483 标准的 RDAP 查询接口
  * - 无需鉴权，开放查询
  * - 直接使用 WHOIS/RDAP 系统，不走数据库
  * - 返回国际标准 JSON 格式
- * 
+ *
  * 端点:
  *   GET /api/rdap/domain/{domain}     - 查询域名信息
  *   GET /api/rdap/nameserver/{name}   - 查询 Nameserver（预留）
@@ -15,14 +15,15 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { asyncHandler } from '../middleware/errorHandler';
 import { whoisService, getRootDomain } from '../service/whois';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { normalizeDomain, isValidDomain, toUnicode } from '../utils/dns';
 
+const log = createLogger('HTTP').sub('Route').sub('Rdap');
 const router = Router();
 
 /**
  * RDAP 查询函数（使用内部分层查询）
- * 
+ *
  * 查询策略（分层并行竞速）：
  * 1. 顶域RDAP 并行查询（所有匹配的RDAP提供商竞速）
  * 2. 顶域WHOIS 并行查询（所有匹配的WHOIS提供商竞速）
@@ -32,31 +33,31 @@ const router = Router();
  * 6. 子域WHOIS 并行平级查询（试图查询其它子域提供商）
  * 7. 第三方RDAP 并行查询
  * 8. 第三方WHOIS 并行查询
- * 
+ *
  * 注意：此函数不会查询 DNS 提供商，因为：
  * - DNS 提供商查询需要数据库握手（获取账号配置）
  * - 公开 RDAP 接口无需鉴权，无法传递账号信息
  * - DNS 提供商查询仅在内部定时任务中执行（checker.ts）
- * 
+ *
  * @returns { type: 'RDAP' | 'WHOIS', raw: string, ... } 或 null
  */
 async function queryRdapWithLayers(domain: string): Promise<any | null> {
   const rootDomain = getRootDomain(domain);
   const isSubdomain = domain !== rootDomain;
-  
-  log.info('RDAP', `Layered RDAP query for ${domain} (isSubdomain: ${isSubdomain})`);
-  
+
+  log.info(`Layered RDAP query for ${domain} (isSubdomain: ${isSubdomain})`);
+
   // 使用完整的分层查询服务
   const result = await whoisService.query(domain, {
     preferSubdomain: true,
     useCache: false,        // 公开 RDAP 不使用缓存，确保实时性
     skipUplevel: true,      // 禁用平级查询，避免查询其他提供商
   });
-  
+
   if (!result) {
     return null;
   }
-  
+
   // 判断查询类型：检查 raw 是否为 JSON
   let queryType: 'RDAP' | 'WHOIS' = 'WHOIS';
   try {
@@ -70,7 +71,7 @@ async function queryRdapWithLayers(domain: string): Promise<any | null> {
     // 不能解析为 JSON，是 WHOIS 文本
     queryType = 'WHOIS';
   }
-  
+
   return {
     ...result,
     queryType,  // 添加查询类型标记
@@ -84,7 +85,7 @@ async function queryRdapWithLayers(domain: string): Promise<any | null> {
 function convertToRdapFormat(domain: string, whoisResult: any): any {
   // 获取 Unicode 格式的域名用于显示
   const unicodeDomain = toUnicode(domain);
-  
+
   const rdapResponse: any = {
     objectClassName: 'domain',
     // ldhName: 字母-数字-连字符格式（Punycode）
@@ -92,25 +93,25 @@ function convertToRdapFormat(domain: string, whoisResult: any): any {
     // 如果域名包含非 ASCII 字符，添加 unicodeName 字段
     ...(unicodeDomain !== domain.toLowerCase() && { unicodeName: unicodeDomain }),
     handle: domain.toUpperCase(),
-    
+
     // 域名状态
     status: whoisResult.status ? [whoisResult.status] : [],
-    
+
     // 事件信息
     events: [],
-    
+
     // 域名服务器
     nameservers: [],
-    
+
     // 实体信息（注册商等）
     entities: [],
-    
+
     // RDAP  conformant
     rdapConformance: [
       'rdap_level_0',
       'icann_rdap_technical_implementation_guide_0',
     ],
-    
+
     //  notices: [
     //   {
     //     title: 'Terms of Use',
@@ -193,9 +194,9 @@ function convertToRdapFormat(domain: string, whoisResult: any): any {
 
 /**
  * GET /api/rdap/domain/{domain}
- * 
+ *
  * 查询域名的 RDAP 信息
- * 
+ *
  * 示例:
  *   GET /api/rdap/domain/example.com
  *   GET /api/rdap/domain/hins.io.ht
@@ -205,7 +206,7 @@ router.get(
   asyncHandler(async (req, res, next): Promise<void> => {
     // 获取原始域名参数（可能是 Unicode 或 Punycode）
     const rawDomain = req.params.domain.trim();
-    
+
     // 使用 IDN-aware 归一化（将 Unicode 转换为 Punycode）
     const domain = normalizeDomain(rawDomain);
 
@@ -220,7 +221,7 @@ router.get(
     }
 
     try {
-      log.info('RDAP', `Public RDAP query for domain: ${domain}`);
+      log.info(`Public RDAP query for domain: ${domain}`);
 
       // 使用完整的分层 RDAP 查询
       const queryResult = await queryRdapWithLayers(domain);
@@ -235,32 +236,32 @@ router.get(
       }
 
       let rdapResponse: any;
-      
+
       // 根据查询类型决定处理方式
       if (queryResult.queryType === 'RDAP') {
         // RDAP 查询：直接返回原始 JSON（不转换）
-        log.info('RDAP', 'Returning raw RDAP response');
+        log.info('Returning raw RDAP response');
         try {
           rdapResponse = JSON.parse(queryResult.raw);
         } catch (e) {
           // 如果解析失败，降级为转换模式
-          log.warn('RDAP', 'Failed to parse RDAP JSON, falling back to conversion');
+          log.warn('Failed to parse RDAP JSON, falling back to conversion');
           rdapResponse = convertToRdapFormat(domain, queryResult);
         }
       } else {
         // WHOIS 查询：转换为 RDAP 格式
         // 注：DNS 提供商查询不会在此触发（需要认证，公开 RDAP 不支持）
-        log.info('RDAP', 'Converting WHOIS data to RDAP format');
+        log.info('Converting WHOIS data to RDAP format');
         rdapResponse = convertToRdapFormat(domain, queryResult);
       }
 
       // 设置正确的 Content-Type
       res.setHeader('Content-Type', 'application/rdap+json');
       res.setHeader('Access-Control-Allow-Origin', '*');
-      
+
       res.json(rdapResponse);
     } catch (error) {
-      log.error('RDAP', `Error querying domain ${domain}:`, {
+      log.error(`Error querying domain ${domain}:`, {
         error: error instanceof Error ? error.message : String(error),
       });
 
@@ -275,7 +276,7 @@ router.get(
 
 /**
  * GET /api/rdap/help
- * 
+ *
  * 返回 RDAP 帮助信息
  */
 router.get(

--- a/server/src/routes/records.ts
+++ b/server/src/routes/records.ts
@@ -9,11 +9,12 @@ import { normalizeRole } from '../utils/roles';
 import { logAuditOperation } from '../service/audit';
 import { parseInteger, sendError, sendSuccess } from '../utils/http';
 import { DomainOperations, DnsAccountOperations } from '../db/bal/business-adapter';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { wsService } from '../service/websocket';
 import { normalizeDomain, isValidDomain, isValidHostname } from '../utils/dns';
 import { getAvailableTemplates, getEmailTemplate, generatePreview } from '../lib/dns/emailTemplate';
 
+const log = createLogger('HTTP').sub('Route').sub('Records');
 const router = Router({ mergeParams: true });
 
 // Create a separate router for email templates to avoid route conflicts with /:domainId/records
@@ -95,24 +96,24 @@ function canWriteSubdomain(writeSubs: string[] | null, fullName: string, domainN
 }
 
 async function getAdapterForDomain(domain: Domain) {
-  log.info('Records', 'Getting adapter for domain', { domainId: domain.id, domainName: domain.name, accountId: domain.account_id, thirdId: domain.third_id });
+  log.info('Getting adapter for domain', { domainId: domain.id, domainName: domain.name, accountId: domain.account_id, thirdId: domain.third_id });
   const account = await DnsAccountOperations.getById(domain.account_id) as DnsAccount | undefined;
   if (!account) {
-    log.error('Records', 'Account not found', { accountId: domain.account_id });
+    log.error('Account not found', { accountId: domain.account_id });
     throw new Error('Account not found');
   }
-  log.info('Records', 'Found account', { accountType: account.type, accountName: account.name });
+  log.info('Found account', { accountType: account.type, accountName: account.name });
   // MySQL JSON type returns object directly, SQLite/PostgreSQL returns string
   const cfg = typeof account.config === 'string' ? JSON.parse(account.config) as Record<string, string> : account.config as Record<string, string>;
-  
+
   // For HiDNS provider, use third_id (remote domain ID) as domainId
   // For other providers, use local domain.id
   const isHiDNS = account.type === 'hidns';
   const domainId = isHiDNS && domain.third_id ? domain.third_id : String(domain.id);
-  
-  log.info('Records', 'Creating adapter', { type: account.type, domain: domain.name, thirdId: domain.third_id, localDomainId: domain.id, effectiveDomainId: domainId, isHiDNS });
+
+  log.info('Creating adapter', { type: account.type, domain: domain.name, thirdId: domain.third_id, localDomainId: domain.id, effectiveDomainId: domainId, isHiDNS });
   const adapter = createAdapter(account.type, cfg, domain.name, domain.third_id, domainId);
-  log.info('Records', 'Adapter created');
+  log.info('Adapter created');
   return adapter;
 }
 
@@ -151,36 +152,36 @@ async function updateDomainRecordCount(domainId: number, count: number): Promise
  *         description: List of DNS records
  */
 router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response, next) => {
-  log.info('Records', '=== GET /records route entered ===', { domainId: req.params.domainId, path: req.path, originalUrl: req.originalUrl });
-  
+  log.info('=== GET /records route entered ===', { domainId: req.params.domainId, path: req.path, originalUrl: req.originalUrl });
+
   // 检查是否有 domainId 参数，如果没有则交给下一个路由处理（如 email-templates）
   if (!req.params.domainId) {
-    log.info('Records', 'No domainId parameter, passing to next route');
+    log.info('No domainId parameter, passing to next route');
     return next();
   }
-  
+
   const domainId = parseInteger(req.params.domainId) ?? 0;
-  log.info('Records', 'Parsed domainId', { domainId });
+  log.info('Parsed domainId', { domainId });
   const access = await getDomainAccess(domainId, req.user!.userId, normalizeRole(req.user!.role));
-  log.info('Records', 'Got domain access', { hasDomain: !!access.domain, canRead: access.canRead });
+  log.info('Got domain access', { hasDomain: !!access.domain, canRead: access.canRead });
   if (!access.domain || !access.canRead) {
     sendError(res, 'Domain not found');
     return;
   }
   const { page = '1', pageSize = '100', keyword, subdomain, value, type, line, status } = req.query as Record<string, string>;
   try {
-    log.info('Records', 'Fetching records', { domainId: access.domain.id, page, pageSize, keyword, subdomain, value, type, line, status });
+    log.info('Fetching records', { domainId: access.domain.id, page, pageSize, keyword, subdomain, value, type, line, status });
     const dnsAdapter = await getAdapterForDomain(access.domain);
-    log.info('Records', 'Got adapter, calling getDomainRecords');
+    log.info('Got adapter, calling getDomainRecords');
     const result = await dnsAdapter.getDomainRecords(
       parseInt(page), parseInt(pageSize), keyword, subdomain, value, type, line,
       status !== undefined ? parseInt(status) : undefined
     );
-    log.info('Records', 'Got records result', { total: result.total, count: result.list.length });
+    log.info('Got records result', { total: result.total, count: result.list.length });
     await updateDomainRecordCount(access.domain.id, result.total);
     sendSuccess(res, { total: result.total, list: result.list.map(toApiRecord) });
   } catch (e) {
-    log.error('Records', 'Error fetching records', { error: e instanceof Error ? e.message : String(e), stack: e instanceof Error ? e.stack : undefined });
+    log.error('Error fetching records', { error: e instanceof Error ? e.message : String(e), stack: e instanceof Error ? e.stack : undefined });
     sendError(res, e instanceof Error ? e.message : String(e));
   }
 }));
@@ -272,10 +273,10 @@ router.post('/', authMiddleware, requireTokenDomainPermission('domainId'), async
       return;
     }
     await logAuditOperation(req.user!.userId, 'add_record', access.domain.name, { name, type, value }, req);
-    
+
     // 获取新创建的记录数据用于 WebSocket 推送
     const newRecord = await dnsAdapter.getDomainRecordInfo(recordId);
-    
+
     // 推送 WebSocket 消息
     try {
       wsService.broadcast({
@@ -289,9 +290,9 @@ router.post('/', authMiddleware, requireTokenDomainPermission('domainId'), async
         },
       });
     } catch (error) {
-      log.error('Records', 'Failed to broadcast record_created event', { error });
+      log.error('Failed to broadcast record_created event', { error });
     }
-    
+
     sendSuccess(res, { id: recordId });
   } catch (e) {
     sendError(res, e instanceof Error ? e.message : String(e));
@@ -323,13 +324,13 @@ emailTemplatesRouter.get('/', authMiddleware, asyncHandler(async (req: Request, 
  */
 emailTemplatesRouter.get('/:templateId', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
   const templateId = req.params.templateId;
-  
+
   const template = getEmailTemplate(templateId);
   if (!template) {
     sendError(res, 'Template not found', 404);
     return;
   }
-  
+
   sendSuccess(res, { template });
 }));
 
@@ -356,18 +357,18 @@ emailTemplatesRouter.get('/:templateId', authMiddleware, asyncHandler(async (req
 emailTemplatesRouter.get('/:templateId/preview', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
   const templateId = req.params.templateId;
   const { domain } = req.query;
-  
+
   if (!domain || typeof domain !== 'string') {
     sendError(res, 'Domain parameter is required', 400);
     return;
   }
-  
+
   const template = getEmailTemplate(templateId);
   if (!template) {
     sendError(res, 'Template not found', 404);
     return;
   }
-  
+
   const preview = generatePreview(templateId, domain);
   sendSuccess(res, { preview });
 }));
@@ -383,12 +384,12 @@ router.post('/batch', authMiddleware, requireTokenDomainPermission('domainId'), 
     sendError(res, 'Permission denied');
     return;
   }
-  
+
   const records = req.body.records as Array<{
     name: string; type: string; value: string; line?: string;
     ttl?: number; mx?: number; weight?: number; remark?: string;
   }>;
-  
+
   if (!Array.isArray(records) || records.length === 0) {
     sendError(res, 'records array is required');
     return;
@@ -412,7 +413,7 @@ router.post('/batch', authMiddleware, requireTokenDomainPermission('domainId'), 
   const dnsAdapter = await getAdapterForDomain(access.domain);
   const addedIds: string[] = [];
   const errors: string[] = [];
-  
+
   for (const r of records) {
     try {
       const recordId = await dnsAdapter.addDomainRecord(r.name, r.type, r.value, r.line, r.ttl, r.mx, r.weight, r.remark);
@@ -429,7 +430,7 @@ router.post('/batch', authMiddleware, requireTokenDomainPermission('domainId'), 
   if (addedIds.length > 0) {
     await logAuditOperation(req.user!.userId, 'add_records_batch', access.domain.name, { count: addedIds.length }, req);
   }
-    
+
   if (errors.length > 0) {
     sendError(res, errors.join('; '), 200, { addedIds });
   } else {
@@ -491,7 +492,7 @@ router.put('/:recordId', authMiddleware, requireTokenDomainPermission('domainId'
       return;
     }
     await logAuditOperation(req.user!.userId, 'update_record', access.domain.name, { recordId, name, type, value }, req);
-    
+
     // 推送 WebSocket 消息
     try {
       wsService.broadcast({
@@ -502,9 +503,9 @@ router.put('/:recordId', authMiddleware, requireTokenDomainPermission('domainId'
         },
       });
     } catch (error) {
-      log.error('Records', 'Failed to broadcast record_updated event', { error });
+      log.error('Failed to broadcast record_updated event', { error });
     }
-    
+
     sendSuccess(res);
   } catch (e) {
     sendError(res, e instanceof Error ? e.message : String(e));
@@ -553,7 +554,7 @@ router.delete('/:recordId', authMiddleware, requireTokenDomainPermission('domain
       return;
     }
     await logAuditOperation(req.user!.userId, 'delete_record', access.domain.name, { recordId }, req);
-    
+
     // 推送 WebSocket 消息
     try {
       wsService.broadcast({
@@ -564,9 +565,9 @@ router.delete('/:recordId', authMiddleware, requireTokenDomainPermission('domain
         },
       });
     } catch (error) {
-      log.error('Records', 'Failed to broadcast record_deleted event', { error });
+      log.error('Failed to broadcast record_deleted event', { error });
     }
-    
+
     sendSuccess(res);
   } catch (e) {
     sendError(res, e instanceof Error ? e.message : String(e));
@@ -607,7 +608,7 @@ router.put('/:recordId/status', authMiddleware, requireTokenDomainPermission('do
       return;
     }
     await logAuditOperation(req.user!.userId, status === 1 ? 'enable_record' : 'disable_record', access.domain.name, { recordId });
-    
+
     // 推送 WebSocket 消息
     try {
       wsService.broadcast({
@@ -619,9 +620,9 @@ router.put('/:recordId/status', authMiddleware, requireTokenDomainPermission('do
         },
       });
     } catch (error) {
-      log.error('Records', 'Failed to broadcast record_status_changed event', { error });
+      log.error('Failed to broadcast record_status_changed event', { error });
     }
-    
+
     sendSuccess(res);
   } catch (e) {
     sendError(res, e instanceof Error ? e.message : String(e));

--- a/server/src/routes/security.ts
+++ b/server/src/routes/security.ts
@@ -3,9 +3,10 @@ import { authMiddleware, adminOnly, noTokenAuth } from '../middleware/auth';
 import { SecurityPolicyOperations, TrustedDeviceOperations, getDbType, UserOperations } from '../db/bal/business-adapter';
 import { getSecurityPolicy, updateSecurityPolicy, checkPasswordStrength, validatePassword, requires2FA, has2FAEnabled } from '../service/securityPolicy';
 import { generateTOTPSecret, enableTOTP, disableTOTP, getTOTPStatus, verifyTOTPToken } from '../service/totp';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { wsService } from '../service/websocket';
 
+const log = createLogger('HTTP').sub('Route').sub('Security');
 const router = Router();
 
 // 获取安全策略
@@ -14,7 +15,7 @@ router.get('/policy', authMiddleware, noTokenAuth('security settings'), adminOnl
     const policy = await getSecurityPolicy();
     res.json({ code: 0, data: policy, msg: 'success' });
   } catch (error) {
-    log.error('Security', 'Failed to get security policy:', { error });
+    log.error('Failed to get security policy:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to get security policy' });
   }
 });
@@ -26,7 +27,7 @@ router.put('/policy', authMiddleware, noTokenAuth('security settings'), adminOnl
     await updateSecurityPolicy(policy);
     res.json({ code: 0, msg: 'Security policy updated' });
   } catch (error) {
-    log.error('Security', 'Failed to update security policy:', { error });
+    log.error('Failed to update security policy:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to update security policy' });
   }
 });
@@ -42,7 +43,7 @@ router.post('/password-strength', async (req, res) => {
     const result = checkPasswordStrength(password);
     res.json({ code: 0, data: result, msg: 'success' });
   } catch (error) {
-    log.error('Security', 'Failed to check password strength:', { error });
+    log.error('Failed to check password strength:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to check password strength' });
   }
 });
@@ -58,7 +59,7 @@ router.post('/validate-password', async (req, res) => {
     const result = await validatePassword(password);
     res.json({ code: 0, data: result, msg: 'success' });
   } catch (error) {
-    log.error('Security', 'Failed to validate password:', { error });
+    log.error('Failed to validate password:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to validate password' });
   }
 });
@@ -70,7 +71,7 @@ router.get('/requires-2fa', authMiddleware, async (req, res) => {
     const required = await requires2FA(userId);
     res.json({ code: 0, data: { required }, msg: 'success' });
   } catch (error) {
-    log.error('Security', 'Failed to check 2FA requirement:', { error });
+    log.error('Failed to check 2FA requirement:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to check 2FA requirement' });
   }
 });
@@ -93,7 +94,7 @@ router.get('/2fa-status', authMiddleware, async (req, res) => {
       msg: 'success',
     });
   } catch (error) {
-    log.error('Security', 'Failed to check 2FA status:', { error });
+    log.error('Failed to check 2FA status:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to check 2FA status' });
   }
 });
@@ -121,7 +122,7 @@ router.get('/users/:userId/require-2fa', authMiddleware, noTokenAuth('security s
       msg: 'success',
     });
   } catch (error) {
-    log.error('Security', 'Failed to get user 2FA requirement:', { error });
+    log.error('Failed to get user 2FA requirement:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to get user 2FA requirement' });
   }
 });
@@ -153,7 +154,7 @@ router.put('/users/:userId/require-2fa', authMiddleware, noTokenAuth('security s
       msg: 'User 2FA requirement updated',
     });
   } catch (error) {
-    log.error('Security', 'Failed to update user 2FA requirement:', { error });
+    log.error('Failed to update user 2FA requirement:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to update user 2FA requirement' });
   }
 });
@@ -173,7 +174,7 @@ router.post('/2fa/setup', authMiddleware, async (req, res) => {
     const setup = await generateTOTPSecret(userId, email || username);
     res.json({ code: 0, data: setup, msg: 'success' });
   } catch (error) {
-    log.error('Security', 'Failed to setup 2FA:', { error });
+    log.error('Failed to setup 2FA:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to setup 2FA' });
   }
 });
@@ -194,7 +195,7 @@ router.post('/2fa/enable', authMiddleware, async (req, res) => {
     }
 
     await enableTOTP(userId, secret, backupCodes);
-    
+
     // 推送 WebSocket 消息给当前用户
     try {
       wsService.sendToClient(userId, {
@@ -205,12 +206,12 @@ router.post('/2fa/enable', authMiddleware, async (req, res) => {
         },
       });
     } catch (error) {
-      log.error('Security', 'Failed to send 2fa_enabled event', { error });
+      log.error('Failed to send 2fa_enabled event', { error });
     }
-    
+
     res.json({ code: 0, msg: '2FA enabled successfully' });
   } catch (error) {
-    log.error('Security', 'Failed to enable 2FA:', { error });
+    log.error('Failed to enable 2FA:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to enable 2FA' });
   }
 });
@@ -228,7 +229,7 @@ router.post('/2fa/disable', authMiddleware, async (req, res) => {
     }
 
     await disableTOTP(userId);
-    
+
     // 推送 WebSocket 消息给当前用户
     try {
       wsService.sendToClient(userId, {
@@ -239,12 +240,12 @@ router.post('/2fa/disable', authMiddleware, async (req, res) => {
         },
       });
     } catch (error) {
-      log.error('Security', 'Failed to send 2fa_disabled event', { error });
+      log.error('Failed to send 2fa_disabled event', { error });
     }
-    
+
     res.json({ code: 0, msg: '2FA disabled successfully' });
   } catch (error) {
-    log.error('Security', 'Failed to disable 2FA:', { error });
+    log.error('Failed to disable 2FA:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to disable 2FA' });
   }
 });
@@ -256,7 +257,7 @@ router.get('/trusted-devices', authMiddleware, async (req, res) => {
     const devices = await TrustedDeviceOperations.getByUser(userId);
     res.json({ code: 0, data: devices, msg: 'success' });
   } catch (error) {
-    log.error('Security', 'Failed to get trusted devices:', { error });
+    log.error('Failed to get trusted devices:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to get trusted devices' });
   }
 });
@@ -280,15 +281,15 @@ router.delete('/trusted-devices/:deviceId', authMiddleware, async (req, res) => 
           },
         });
       } catch (error) {
-        log.error('Security', 'Failed to send trusted_device_removed event', { error });
+        log.error('Failed to send trusted_device_removed event', { error });
       }
-      
+
       res.json({ code: 0, msg: 'Device removed' });
     } else {
       res.status(404).json({ code: 1, msg: 'Device not found' });
     }
   } catch (error) {
-    log.error('Security', 'Failed to remove trusted device:', { error });
+    log.error('Failed to remove trusted device:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to remove trusted device' });
   }
 });
@@ -300,7 +301,7 @@ router.delete('/trusted-devices', authMiddleware, async (req, res) => {
     await TrustedDeviceOperations.deleteByUser(userId);
     res.json({ code: 0, msg: 'All devices removed' });
   } catch (error) {
-    log.error('Security', 'Failed to remove all trusted devices:', { error });
+    log.error('Failed to remove all trusted devices:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to remove all trusted devices' });
   }
 });
@@ -316,7 +317,7 @@ router.post('/user-require-2fa', authMiddleware, noTokenAuth('security settings'
     await SecurityPolicyOperations.updateUser2FARequirement(userId, require2FA);
     res.json({ code: 0, msg: 'User 2FA requirement updated' });
   } catch (error) {
-    log.error('Security', 'Failed to update user 2FA requirement:', { error });
+    log.error('Failed to update user 2FA requirement:', { error });
     res.status(500).json({ code: 1, msg: 'Failed to update user 2FA requirement' });
   }
 });

--- a/server/src/routes/securityPolicy.ts
+++ b/server/src/routes/securityPolicy.ts
@@ -20,7 +20,6 @@ import {
   DeviceInfo,
 } from '../service/deviceTrust';
 import { getRequestIP } from '../middleware/clientIP';
-import { log } from '../lib/logger';
 
 const router = Router();
 
@@ -109,10 +108,10 @@ router.post('/password-strength', asyncHandler(async (req: Request, res: Respons
     sendError(res, 'Password is required');
     return;
   }
-  
+
   const result = checkPasswordStrength(password);
   const policy = await getSecurityPolicy();
-  
+
   sendSuccess(res, {
     ...result,
     meetsPolicy: result.score >= policy.minPasswordStrength && password.length >= policy.minPasswordLength,
@@ -141,7 +140,7 @@ router.get('/2fa/requirement', authMiddleware, asyncHandler(async (req: Request,
   const validationEnabled = Boolean(policy.require2FAGlobal);
   const forceRequired = validationEnabled && (await requires2FA(userId));
   const enabled = validationEnabled && (await has2FAEnabled(userId));
-  
+
   sendSuccess(res, {
     enabled,
     forceRequired,
@@ -188,7 +187,7 @@ router.get('/trusted-devices', authMiddleware, asyncHandler(async (req: Request,
 router.delete('/trusted-devices/:id', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
   const deviceId = req.params.id;
   const success = await removeTrustedDevice(req.user!.userId, deviceId);
-  
+
   if (success) {
     sendSuccess(res);
   } else {
@@ -213,7 +212,7 @@ router.post('/check-device', authMiddleware, asyncHandler(async (req: Request, r
     userAgent: req.headers['user-agent'] || '',
     ipAddress: getRequestIP(req),
   };
-  
+
   const result = await verifyTrustedDevice(req.user!.userId, deviceInfo);
   sendSuccess(res, result);
 }));

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -5,10 +5,11 @@ import { getLoginLimitConfig, updateLoginLimitConfig, getLoginAttemptStats, unlo
 import { SettingsOperations, NotificationOperations, AuditRuleOperations, DomainExpiryOperations, UserOperations } from '../db/bal/business-adapter';
 import { getSmtpConfig, updateSmtpConfig, sendSmtpEmail } from '../service/smtp';
 import { logAuditOperation } from '../service/audit';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { wsService } from '../service/websocket';
 import { sendError } from '../utils/http';
 
+const log = createLogger('HTTP').sub('Route').sub('Settings');
 const router = Router();
 type SecurityConfig = { jwtViewEmailNotify: boolean; showDnsProviderSecrets: boolean };
 const DEFAULT_SECURITY_CONFIG: SecurityConfig = { jwtViewEmailNotify: true, showDnsProviderSecrets: false };
@@ -204,7 +205,7 @@ router.post('/jwt-secret', authMiddleware, noTokenAuth('system settings'), admin
       }
     }
   } catch (e) {
-    log.warn('Security', 'Failed to send JWT view notification email', { error: e });
+    log.warn('Failed to send JWT view notification email', { error: e });
   }
   res.json({
     code: 0,
@@ -230,7 +231,7 @@ router.get('/notifications', authMiddleware, noTokenAuth('system settings'), adm
 router.put('/notifications', authMiddleware, noTokenAuth('system settings'), adminOnly, async (req: Request, res: Response) => {
   const channels = req.body.channels;
   if (!Array.isArray(channels)) return sendError(res, 'Invalid channels array', 400);
-  
+
   await NotificationOperations.saveChannels(JSON.stringify(channels));
   res.json({ code: 0, msg: 'success' });
 });
@@ -259,7 +260,7 @@ router.get('/audit-rules', authMiddleware, noTokenAuth('system settings'), admin
 router.put('/audit-rules', authMiddleware, noTokenAuth('system settings'), adminOnly, async (req: Request, res: Response) => {
   const rules = req.body.rules;
   if (!rules) return sendError(res, 'Rules required', 400);
-  
+
   await AuditRuleOperations.saveRules(JSON.stringify(rules));
   const defaultRules = {
     enabled: true,
@@ -273,7 +274,7 @@ router.put('/audit-rules', authMiddleware, noTokenAuth('system settings'), admin
 
 router.get('/security', authMiddleware, noTokenAuth('system settings'), adminOnly, async (_req: Request, res: Response) => {
   const value = await SettingsOperations.get('security_config');
-  
+
   const expiryNotifyValue = await DomainExpiryOperations.getNotification();
   const expiryDaysValue = await DomainExpiryOperations.getDays();
 
@@ -282,7 +283,7 @@ router.get('/security', authMiddleware, noTokenAuth('system settings'), adminOnl
     domainExpiryNotify: expiryNotifyValue ? (expiryNotifyValue === '1' || expiryNotifyValue === 'true') : false,
     domainExpiryDays: expiryDaysValue ? parseInt(expiryDaysValue) : 30
   };
-  
+
   if (!value) {
     res.json({ code: 0, data: defaultConf, msg: 'success' });
     return;
@@ -298,7 +299,7 @@ router.get('/security', authMiddleware, noTokenAuth('system settings'), adminOnl
 
 router.put('/security', authMiddleware, noTokenAuth('system settings'), adminOnly, async (req: Request, res: Response) => {
   const { jwtViewEmailNotify, domainExpiryNotify, domainExpiryDays, showDnsProviderSecrets } = req.body;
-  const config = { 
+  const config = {
     jwtViewEmailNotify: !!jwtViewEmailNotify,
     showDnsProviderSecrets: !!showDnsProviderSecrets
   };
@@ -321,7 +322,7 @@ router.put('/security', authMiddleware, noTokenAuth('system settings'), adminOnl
       },
     });
   } catch (error) {
-    log.error('Settings', 'Failed to broadcast security_config_updated event', { error });
+    log.error('Failed to broadcast security_config_updated event', { error });
   }
 
   res.json({ code: 0, msg: 'success' });
@@ -340,7 +341,7 @@ router.put('/smtp', authMiddleware, noTokenAuth('system settings'), adminOnly, a
   try {
     const next = await updateSmtpConfig(req.body || {});
     await logAuditOperation(req.user!.userId, 'update_smtp_config', 'system', { enabled: next.enabled, host: next.host, port: next.port }, req);
-    
+
     // 推送 WebSocket 消息
     try {
       wsService.broadcast({
@@ -351,9 +352,9 @@ router.put('/smtp', authMiddleware, noTokenAuth('system settings'), adminOnly, a
         },
       });
     } catch (error) {
-      log.error('Settings', 'Failed to broadcast smtp_updated event', { error });
+      log.error('Failed to broadcast smtp_updated event', { error });
     }
-    
+
     res.json({ code: 0, data: next, msg: 'success' });
   } catch (error) {
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to update SMTP config' });
@@ -369,15 +370,15 @@ router.post('/smtp/test', authMiddleware, adminOnly, async (req: Request, res: R
       res.status(400).json({ code: 400, msg: 'Target email is required' });
       return;
     }
-    log.info('SMTP', 'Sending test email', { to: target, fromUser: req.user!.userId });
+    log.info('Sending test email', { to: target, fromUser: req.user!.userId });
     await sendSmtpEmail(target, 'HiDNS SMTP Test', 'This is a test email from HiDNS SMTP settings.');
     await logAuditOperation(req.user!.userId, 'smtp_test_email', 'system', { to: target }, req);
-    log.info('SMTP', 'Test email sent successfully', { to: target });
+    log.info('Test email sent successfully', { to: target });
     res.json({ code: 0, msg: 'success' });
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
     const errorStack = error instanceof Error ? error.stack : undefined;
-    log.error('SMTP', 'Failed to send test email', { 
+    log.error('Failed to send test email', {
       error: errorMsg,
       stack: errorStack,
       to: to || '(not provided)',
@@ -400,7 +401,7 @@ router.put('/oauth', authMiddleware, noTokenAuth('system settings'), adminOnly, 
   try {
     const config = await updateOAuthConfig({ ...(req.body || {}), template: 'generic' });
     await logAuditOperation(req.user!.userId, 'update_oauth_config', 'system', { enabled: config.enabled, providerName: config.providerName, issuer: config.issuer }, req);
-    
+
     // 推送 WebSocket 消息
     try {
       wsService.broadcast({
@@ -411,9 +412,9 @@ router.put('/oauth', authMiddleware, noTokenAuth('system settings'), adminOnly, 
         },
       });
     } catch (error) {
-      log.error('Settings', 'Failed to broadcast oauth_updated event', { error });
+      log.error('Failed to broadcast oauth_updated event', { error });
     }
-    
+
     res.json({ code: 0, data: config, msg: 'success' });
   } catch (error) {
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to update OAuth config' });
@@ -433,7 +434,7 @@ router.put('/oauth/logto', authMiddleware, noTokenAuth('system settings'), admin
   try {
     const config = await updateLogtoOAuthConfig(req.body || {});
     await logAuditOperation(req.user!.userId, 'update_logto_oauth_config', 'system', { enabled: config.enabled, providerName: config.providerName, logtoDomain: config.logtoDomain }, req);
-    
+
     // 推送 WebSocket 消息
     try {
       wsService.broadcast({
@@ -444,9 +445,9 @@ router.put('/oauth/logto', authMiddleware, noTokenAuth('system settings'), admin
         },
       });
     } catch (error) {
-      log.error('Settings', 'Failed to broadcast oauth_updated event', { error });
+      log.error('Failed to broadcast oauth_updated event', { error });
     }
-    
+
     res.json({ code: 0, data: config, msg: 'success' });
   } catch (error) {
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to update Logto OAuth config' });
@@ -539,18 +540,18 @@ router.get('/login-limit', authMiddleware, noTokenAuth('system settings'), admin
  */
 router.put('/login-limit', authMiddleware, noTokenAuth('system settings'), adminOnly, async (req: Request, res: Response) => {
   const { enabled, maxAttempts, lockoutDuration } = req.body;
-  
+
   try {
     const updateData: Partial<{ enabled: boolean; maxAttempts: number; lockoutDuration: number }> = {};
-    
+
     if (enabled !== undefined) updateData.enabled = enabled;
     if (maxAttempts !== undefined) updateData.maxAttempts = maxAttempts;
     if (lockoutDuration !== undefined) updateData.lockoutDuration = lockoutDuration;
-    
+
     await updateLoginLimitConfig(updateData);
-    
+
     const config = await getLoginLimitConfig();
-    
+
     // 推送 WebSocket 消息
     try {
       wsService.broadcast({
@@ -562,9 +563,9 @@ router.put('/login-limit', authMiddleware, noTokenAuth('system settings'), admin
         },
       });
     } catch (error) {
-      log.error('Settings', 'Failed to broadcast config_updated event', { error });
+      log.error('Failed to broadcast config_updated event', { error });
     }
-    
+
     res.json({
       code: 0,
       data: config,
@@ -630,12 +631,12 @@ router.get('/login-attempts/stats', authMiddleware, noTokenAuth('system settings
  */
 router.post('/login-attempts/unlock', authMiddleware, noTokenAuth('system settings'), adminOnly, async (req: Request, res: Response) => {
   const { identifier } = req.body;
-  
+
   if (!identifier) {
     sendError(res, 'Identifier is required', 400);
     return;
   }
-  
+
   try {
     await unlockAccount(identifier);
     res.json({

--- a/server/src/routes/teams.ts
+++ b/server/src/routes/teams.ts
@@ -5,11 +5,12 @@ import { Team, TeamMember } from '../types';
 import { ROLE_ADMIN, isAdmin, isSuper } from '../utils/roles';
 import { logAuditOperation } from '../service/audit';
 import { sendError, sendSuccess } from '../utils/http';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { TeamOperations, DomainPermissionOperations, UserOperations } from '../db/bal/business-adapter';
 import { wsService } from '../service/websocket';
 import { getDisplayDomain } from '../utils/dns';
 
+const log = createLogger('HTTP').sub('Route').sub('Teams');
 const router = Router();
 
 /**
@@ -27,14 +28,14 @@ const router = Router();
 router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   let teams: Team[];
   if (isSuper(role)) {
     teams = await TeamOperations.getAll() as unknown as Team[];
   } else {
     teams = await TeamOperations.getByUserId(userId) as unknown as Team[];
   }
-  
+
   // Get member count and my_role for each team
   const teamsWithDetails = await Promise.all(
     teams.map(async (team) => {
@@ -50,7 +51,7 @@ router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response)
       return { ...team, member_count: members.length, my_role: myRole };
     })
   );
-  
+
   sendSuccess(res, teamsWithDetails);
 }));
 
@@ -81,23 +82,23 @@ router.get('/', authMiddleware, asyncHandler(async (req: Request, res: Response)
 router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
   const { name, description } = req.body as { name: string; description?: string };
   const userId = req.user!.userId;
-  
+
   if (!name || name.trim().length === 0) {
     sendError(res, 'Team name is required');
     return;
   }
-  
+
   const id = await TeamOperations.create({
     name: name.trim(),
     description: description?.trim() || '',
     created_by: userId,
   });
-  
+
   // Add creator as admin
   await TeamOperations.addMember(id, userId, 'admin');
-  
+
   await logAuditOperation(userId, 'create_team', name.trim(), { teamId: id }, req as any);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -108,9 +109,9 @@ router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response
       },
     });
   } catch (error) {
-    log.error('Teams', 'Failed to broadcast team_created event', { error });
+    log.error('Failed to broadcast team_created event', { error });
   }
-  
+
   sendSuccess(res, { id }, 'Team created successfully');
 }));
 
@@ -136,22 +137,22 @@ router.get('/:id', authMiddleware, asyncHandler(async (req: Request, res: Respon
   const teamId = parseInt(req.params.id);
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check if user is member
   const isMember = await TeamOperations.isMember(teamId, userId);
   if (!isSuper(role) && !isMember) {
     sendError(res, 'Access denied', 403);
     return;
   }
-  
+
   const members = await TeamOperations.getMembers(teamId) as unknown as TeamMember[];
-  
+
   sendSuccess(res, { ...team, members });
 }));
 
@@ -189,28 +190,28 @@ router.put('/:id', authMiddleware, asyncHandler(async (req: Request, res: Respon
   const { name, description } = req.body as { name?: string; description?: string };
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check permission (admin or creator)
   const member = await TeamOperations.getMemberWithRole(teamId, userId);
   if (!isSuper(role) && team.created_by !== userId && member?.role !== 'admin') {
     sendError(res, 'Permission denied', 403);
     return;
   }
-  
+
   const updates: { name?: string; description?: string } = {};
   if (name !== undefined) updates.name = name.trim();
   if (description !== undefined) updates.description = description.trim();
-  
+
   await TeamOperations.update(teamId, updates);
-  
+
   await logAuditOperation(userId, 'update_team', team.name, { teamId, ...updates }, req as any);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -221,9 +222,9 @@ router.put('/:id', authMiddleware, asyncHandler(async (req: Request, res: Respon
       },
     });
   } catch (error) {
-    log.error('Teams', 'Failed to broadcast team_updated event', { error });
+    log.error('Failed to broadcast team_updated event', { error });
   }
-  
+
   sendSuccess(res);
 }));
 
@@ -249,23 +250,23 @@ router.delete('/:id', authMiddleware, asyncHandler(async (req: Request, res: Res
   const teamId = parseInt(req.params.id);
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Only super admin or creator can delete
   if (!isSuper(role) && team.created_by !== userId) {
     sendError(res, 'Permission denied', 403);
     return;
   }
-  
+
   await TeamOperations.delete(teamId);
-  
+
   await logAuditOperation(userId, 'delete_team', team.name, { teamId }, req as any);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -276,9 +277,9 @@ router.delete('/:id', authMiddleware, asyncHandler(async (req: Request, res: Res
       },
     });
   } catch (error) {
-    log.error('Teams', 'Failed to broadcast team_deleted event', { error });
+    log.error('Failed to broadcast team_deleted event', { error });
   }
-  
+
   sendSuccess(res);
 }));
 
@@ -304,20 +305,20 @@ router.get('/:id/members', authMiddleware, asyncHandler(async (req: Request, res
   const teamId = parseInt(req.params.id);
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check if user is member
   const isMember = await TeamOperations.isMember(teamId, userId);
   if (!isSuper(role) && !isMember) {
     sendError(res, 'Access denied', 403);
     return;
   }
-  
+
   const members = await TeamOperations.getMembers(teamId) as unknown as TeamMember[];
   sendSuccess(res, members);
 }));
@@ -359,43 +360,43 @@ router.post('/:id/members', authMiddleware, asyncHandler(async (req: Request, re
   const targetUserId = user_id || bodyUserId;
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   if (!targetUserId) {
     sendError(res, 'User ID is required');
     return;
   }
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check permission (admin or creator)
   const member = await TeamOperations.getMemberWithRole(teamId, userId);
   if (!isSuper(role) && team.created_by !== userId && member?.role !== 'admin') {
     sendError(res, 'Permission denied', 403);
     return;
   }
-  
+
   // Check if user exists
   const targetUser = await UserOperations.getById(targetUserId);
   if (!targetUser) {
     sendError(res, 'User not found');
     return;
   }
-  
+
   // Check if already member
   const isAlreadyMember = await TeamOperations.isMember(teamId, targetUserId);
   if (isAlreadyMember) {
     sendError(res, 'User is already a member of this team');
     return;
   }
-  
+
   await TeamOperations.addMember(teamId, targetUserId, memberRole || 'member');
-  
+
   await logAuditOperation(userId, 'add_team_member', team.name, { teamId, targetUserId, role: memberRole }, req as any);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -407,9 +408,9 @@ router.post('/:id/members', authMiddleware, asyncHandler(async (req: Request, re
       },
     });
   } catch (error) {
-    log.error('Teams', 'Failed to broadcast team_member_added event', { error });
+    log.error('Failed to broadcast team_member_added event', { error });
   }
-  
+
   sendSuccess(res);
 }));
 
@@ -453,28 +454,28 @@ router.put('/:id/members/:userId', authMiddleware, asyncHandler(async (req: Requ
   const { role: newRole } = req.body as { role: 'admin' | 'member' };
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check permission (admin or creator)
   const member = await TeamOperations.getMemberWithRole(teamId, userId);
   if (!isSuper(role) && team.created_by !== userId && member?.role !== 'admin') {
     sendError(res, 'Permission denied', 403);
     return;
   }
-  
+
   // Cannot change own role
   if (targetUserId === userId) {
     sendError(res, 'Cannot change your own role');
     return;
   }
-  
+
   await TeamOperations.updateMemberRole(teamId, targetUserId, newRole);
-  
+
   await logAuditOperation(userId, 'update_team_member_role', team.name, { teamId, targetUserId, newRole }, req as any);
   sendSuccess(res);
 }));
@@ -507,30 +508,30 @@ router.delete('/:id/members/:userId', authMiddleware, asyncHandler(async (req: R
   const targetUserId = parseInt(req.params.userId);
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check permission (admin or creator)
   const member = await TeamOperations.getMemberWithRole(teamId, userId);
   if (!isSuper(role) && team.created_by !== userId && member?.role !== 'admin') {
     sendError(res, 'Permission denied', 403);
     return;
   }
-  
+
   // Cannot remove creator
   if (targetUserId === team.created_by) {
     sendError(res, 'Cannot remove team creator');
     return;
   }
-  
+
   await TeamOperations.removeMember(teamId, targetUserId);
-  
+
   await logAuditOperation(userId, 'remove_team_member', team.name, { teamId, targetUserId }, req as any);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -541,9 +542,9 @@ router.delete('/:id/members/:userId', authMiddleware, asyncHandler(async (req: R
       },
     });
   } catch (error) {
-    log.error('Teams', 'Failed to broadcast team_member_removed event', { error });
+    log.error('Failed to broadcast team_member_removed event', { error });
   }
-  
+
   sendSuccess(res);
 }));
 
@@ -570,28 +571,28 @@ router.get('/:id/domain-permissions', authMiddleware, asyncHandler(async (req: R
   const userId = req.user!.userId;
   const role = req.user!.role;
   const tokenPayload = (req as any).tokenPayload;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check permission
   const member = await TeamOperations.getMemberWithRole(teamId, userId);
   if (!isSuper(role) && team.created_by !== userId && member?.role !== 'admin') {
     sendError(res, 'Permission denied', 403);
     return;
   }
-  
+
   const permissions = await DomainPermissionOperations.getByTeamId(teamId);
-  
+
   // For Session auth, convert Punycode to Unicode; for Token auth, keep raw
   const displayPermissions = tokenPayload ? permissions : permissions.map((p: any) => ({
     ...p,
     domain_name: p.domain_name ? getDisplayDomain(p.domain_name, true) : p.domain_name,
   }));
-  
+
   sendSuccess(res, displayPermissions);
 }));
 
@@ -633,34 +634,34 @@ router.post('/:id/domain-permissions', authMiddleware, asyncHandler(async (req: 
   const { domain_id, permission, sub } = req.body as { domain_id: number; permission: 'read' | 'write'; sub?: string };
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check permission
   const member = await TeamOperations.getMemberWithRole(teamId, userId);
   if (!isSuper(role) && team.created_by !== userId && member?.role !== 'admin') {
     sendError(res, 'Permission denied', 403);
     return;
   }
-  
+
   // Check if already exists
   const existing = await DomainPermissionOperations.getByTeamDomainAndSub(teamId, domain_id, sub || '');
   if (existing) {
     sendError(res, 'Permission already exists for this domain');
     return;
   }
-  
+
   await DomainPermissionOperations.create({
     domain_id,
     team_id: teamId,
     permission,
     sub: sub || '',
   });
-  
+
   await logAuditOperation(userId, 'add_team_domain_permission', team.name, { teamId, domainId: domain_id, permission, sub }, req as any);
   sendSuccess(res);
 }));
@@ -705,22 +706,22 @@ router.put('/:id/domain-permissions/:permissionId', authMiddleware, asyncHandler
   const { permission } = req.body as { permission: 'read' | 'write' };
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check permission
   const member = await TeamOperations.getMemberWithRole(teamId, userId);
   if (!isSuper(role) && team.created_by !== userId && member?.role !== 'admin') {
     sendError(res, 'Permission denied', 403);
     return;
   }
-  
+
   await DomainPermissionOperations.updatePermission(permissionId, permission);
-  
+
   await logAuditOperation(userId, 'update_team_domain_permission', team.name, { teamId, permissionId, permission }, req as any);
   sendSuccess(res);
 }));
@@ -753,22 +754,22 @@ router.delete('/:id/domain-permissions/:permissionId', authMiddleware, asyncHand
   const permissionId = parseInt(req.params.permissionId);
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check permission
   const member = await TeamOperations.getMemberWithRole(teamId, userId);
   if (!isSuper(role) && team.created_by !== userId && member?.role !== 'admin') {
     sendError(res, 'Permission denied', 403);
     return;
   }
-  
+
   await DomainPermissionOperations.deleteByTeamAndId(permissionId, teamId);
-  
+
   await logAuditOperation(userId, 'remove_team_domain_permission', team.name, { teamId, permissionId }, req as any);
   sendSuccess(res);
 }));
@@ -802,35 +803,35 @@ router.get('/:id/members/:userId/domain-permissions', authMiddleware, asyncHandl
   const userId = req.user!.userId;
   const role = req.user!.role;
   const tokenPayload = (req as any).tokenPayload;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check permission (admin or creator can view any member's permissions, members can view their own)
   const member = await TeamOperations.getMemberWithRole(teamId, userId);
   if (!isSuper(role) && team.created_by !== userId && member?.role !== 'admin' && userId !== targetUserId) {
     sendError(res, 'Permission denied', 403);
     return;
   }
-  
+
   // Check if target user is a team member
   const isMember = await TeamOperations.isMember(teamId, targetUserId);
   if (!isMember) {
     sendError(res, 'User is not a member of this team', 404);
     return;
   }
-  
+
   const permissions = await DomainPermissionOperations.getByUserIdWithDomainName(targetUserId);
-  
+
   // For Session auth, convert Punycode to Unicode; for Token auth, keep raw
   const displayPermissions = tokenPayload ? permissions : permissions.map((p: any) => ({
     ...p,
     domain_name: p.domain_name ? getDisplayDomain(p.domain_name, true) : p.domain_name,
   }));
-  
+
   sendSuccess(res, displayPermissions);
 }));
 
@@ -878,34 +879,34 @@ router.post('/:id/members/:userId/domain-permissions', authMiddleware, asyncHand
   const { domain_id, permission, sub } = req.body as { domain_id: number; permission: 'read' | 'write'; sub?: string };
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check permission
   const member = await TeamOperations.getMemberWithRole(teamId, userId);
   if (!isSuper(role) && team.created_by !== userId && member?.role !== 'admin') {
     sendError(res, 'Permission denied', 403);
     return;
   }
-  
+
   // Check if target user is a team member
   const isMember = await TeamOperations.isMember(teamId, targetUserId);
   if (!isMember) {
     sendError(res, 'User is not a member of this team');
     return;
   }
-  
+
   // Check if already exists
   const existing = await DomainPermissionOperations.getByUserDomainAndSub(targetUserId, domain_id, sub || '');
   if (existing) {
     sendError(res, 'Permission already exists for this domain');
     return;
   }
-  
+
   await DomainPermissionOperations.create({
     domain_id,
     user_id: targetUserId,
@@ -913,7 +914,7 @@ router.post('/:id/members/:userId/domain-permissions', authMiddleware, asyncHand
     permission,
     sub: sub || '',
   });
-  
+
   await logAuditOperation(userId, 'add_domain_permission', team.name, { teamId, targetUserId, domainId: domain_id, permission, sub }, req as any);
   sendSuccess(res);
 }));
@@ -952,22 +953,22 @@ router.delete('/:id/members/:userId/domain-permissions/:permissionId', authMiddl
   const permissionId = parseInt(req.params.permissionId);
   const userId = req.user!.userId;
   const role = req.user!.role;
-  
+
   const team = await TeamOperations.getById(teamId) as Team | undefined;
   if (!team) {
     sendError(res, 'Team not found', 404);
     return;
   }
-  
+
   // Check permission
   const member = await TeamOperations.getMemberWithRole(teamId, userId);
   if (!isSuper(role) && team.created_by !== userId && member?.role !== 'admin') {
     sendError(res, 'Permission denied', 403);
     return;
   }
-  
+
   await DomainPermissionOperations.deleteByUserAndId(permissionId, targetUserId);
-  
+
   await logAuditOperation(userId, 'remove_domain_permission', team.name, { teamId, targetUserId, permissionId }, req as any);
   sendSuccess(res);
 }));

--- a/server/src/routes/tokens.ts
+++ b/server/src/routes/tokens.ts
@@ -4,8 +4,9 @@ import { createUserToken, getUserTokens, deleteUserToken, toggleTokenStatus, upd
 import { DomainOperations } from '../db/bal/business-adapter';
 import { normalizeRole } from '../utils/roles';
 import { wsService } from '../service/websocket';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('HTTP').sub('Route').sub('Tokens');
 const router = Router();
 
 /**
@@ -156,7 +157,7 @@ router.post('/', authMiddleware, noTokenAuth('token management'), async (req: Re
       },
       msg: 'Token created successfully',
     });
-    
+
     // 推送 WebSocket 消息给当前用户
     try {
       wsService.sendToClient(req.user!.userId, {
@@ -167,7 +168,7 @@ router.post('/', authMiddleware, noTokenAuth('token management'), async (req: Re
         },
       });
     } catch (error) {
-      log.error('Tokens', 'Failed to send token_created event', { error });
+      log.error('Failed to send token_created event', { error });
     }
   } catch (error) {
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to create token' });
@@ -207,7 +208,7 @@ router.delete('/:id', authMiddleware, noTokenAuth('token management'), async (re
   try {
     await deleteUserToken(tokenId, req.user!.userId);
     res.json({ code: 0, msg: 'Token deleted successfully' });
-    
+
     // 推送 WebSocket 消息给当前用户
     try {
       wsService.sendToClient(req.user!.userId, {
@@ -217,7 +218,7 @@ router.delete('/:id', authMiddleware, noTokenAuth('token management'), async (re
         },
       });
     } catch (error) {
-      log.error('Tokens', 'Failed to send token_revoked event', { error });
+      log.error('Failed to send token_revoked event', { error });
     }
   } catch (error) {
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to delete token' });
@@ -344,7 +345,7 @@ router.put('/:id', authMiddleware, noTokenAuth('token management'), async (req: 
       start_time,
       end_time,
     });
-    
+
     // 推送 WebSocket 消息给当前用户
     try {
       wsService.sendToClient(req.user!.userId, {
@@ -355,9 +356,9 @@ router.put('/:id', authMiddleware, noTokenAuth('token management'), async (req: 
         },
       });
     } catch (error) {
-      log.error('Tokens', 'Failed to send token_updated event', { error });
+      log.error('Failed to send token_updated event', { error });
     }
-    
+
     res.json({ code: 0, msg: 'Token permissions updated successfully' });
   } catch (error) {
     res.status(500).json({ code: 500, msg: error instanceof Error ? error.message : 'Failed to update token permissions' });

--- a/server/src/routes/tunnels.ts
+++ b/server/src/routes/tunnels.ts
@@ -5,21 +5,22 @@ import { CloudflareAdapter } from '../lib/dns/providers';
 import { DnsAccount } from '../types';
 import { isSuper, normalizeRole } from '../utils/roles';
 import { wsService } from '../service/websocket';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('HTTP').sub('Route').sub('Tunnels');
 const router = Router();
 
 async function getAccessibleCloudflareAccounts(userId: number, role: number): Promise<DnsAccount[]> {
   if (isSuper(role)) {
     return await DnsAccountOperations.getByType('cloudflare') as unknown as DnsAccount[];
   }
-  
+
   const teamIds = await TeamOperations.getTeamIdsByUserId(userId);
-  
+
   if (teamIds.length > 0) {
     return await DnsAccountOperations.getByTypeAndUserOrTeams('cloudflare', userId, teamIds) as unknown as DnsAccount[];
   }
-  
+
   return await DnsAccountOperations.getByTypeAndUser('cloudflare', userId) as unknown as DnsAccount[];
 }
 
@@ -64,7 +65,7 @@ router.get('/:accountId/:tunnelId', authMiddleware, async (req: Request, res: Re
       normalizeRole(req.user?.role)
     );
     if (!acc) return res.status(404).json({ code: 404, msg: 'Account not found' });
-    
+
     // MySQL JSON type returns object directly, SQLite/PostgreSQL returns string
     const cfg = typeof acc.config === 'string' ? JSON.parse(acc.config) : acc.config;
     const cf = new CloudflareAdapter(cfg);
@@ -83,7 +84,7 @@ router.put('/:accountId/:tunnelId/config', authMiddleware, async (req: Request, 
       normalizeRole(req.user?.role)
     );
     if (!acc) return res.status(404).json({ code: 404, msg: 'Account not found' });
-    
+
     // MySQL JSON type returns object directly, SQLite/PostgreSQL returns string
     const cfg = typeof acc.config === 'string' ? JSON.parse(acc.config) : acc.config;
     const cf = new CloudflareAdapter(cfg);
@@ -99,9 +100,9 @@ router.put('/:accountId/:tunnelId/config', authMiddleware, async (req: Request, 
           },
         });
       } catch (error) {
-        log.error('Tunnels', 'Failed to broadcast tunnel_config_updated event', { error });
+        log.error('Failed to broadcast tunnel_config_updated event', { error });
       }
-      
+
       res.json({ code: 0, msg: 'success' });
     } else {
       res.json({ code: -1, msg: 'Failed to update tunnel config' });
@@ -119,7 +120,7 @@ router.delete('/:accountId/:tunnelId', authMiddleware, async (req: Request, res:
       normalizeRole(req.user?.role)
     );
     if (!acc) return res.status(404).json({ code: 404, msg: 'Account not found' });
-    
+
     // MySQL JSON type returns object directly, SQLite/PostgreSQL returns string
     const cfg = typeof acc.config === 'string' ? JSON.parse(acc.config) : acc.config;
     const cf = new CloudflareAdapter(cfg);
@@ -135,9 +136,9 @@ router.delete('/:accountId/:tunnelId', authMiddleware, async (req: Request, res:
           },
         });
       } catch (error) {
-        log.error('Tunnels', 'Failed to broadcast tunnel_deleted event', { error });
+        log.error('Failed to broadcast tunnel_deleted event', { error });
       }
-      
+
       res.json({ code: 0, msg: 'success' });
     } else {
       res.json({ code: -1, msg: 'Failed to delete tunnel' });

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -8,8 +8,9 @@ import { parseInteger, sendError, sendSuccess } from '../utils/http';
 import { isValidUsername } from '../utils/validation';
 import { UserOperations } from '../db/bal/business-adapter';
 import { wsService } from '../service/websocket';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('HTTP').sub('Route').sub('Users');
 const router = Router();
 
 /**
@@ -94,7 +95,7 @@ router.post('/', authMiddleware, noTokenAuth('user management'), adminOnly, asyn
       role: roleText,
       role_level: roleLevel,
     });
-    
+
     // 推送 WebSocket 消息
     try {
       wsService.broadcast({
@@ -106,9 +107,9 @@ router.post('/', authMiddleware, noTokenAuth('user management'), adminOnly, asyn
         },
       });
     } catch (error) {
-      log.error('Users', 'Failed to broadcast user_created event', { error });
+      log.error('Failed to broadcast user_created event', { error });
     }
-    
+
     sendSuccess(res, { id });
   } catch {
     sendError(res, 'Username already exists');
@@ -162,20 +163,20 @@ router.put('/:id', authMiddleware, noTokenAuth('user management'), adminOnly, as
   };
   const callerRole = normalizeRole(req.user?.role);
   const targetRole = normalizeRole(user.role);
-  
+
   // Super admin cannot be modified
   if (targetRole === ROLE_SUPER) {
     sendError(res, 'Super admin cannot be modified');
     return;
   }
-  
+
   // Admin cannot modify users with same or higher role level (peer protection)
   // This prevents admins from modifying other admins or being modified by other admins
   if (callerRole === ROLE_ADMIN && targetRole >= ROLE_ADMIN) {
     sendError(res, 'Permission denied: Cannot modify users with same or higher role level');
     return;
   }
-  
+
   // Admin cannot upgrade users to admin level
   if (callerRole === ROLE_ADMIN && role !== undefined) {
     const newRoleLevel = normalizeRole(role);
@@ -184,9 +185,9 @@ router.put('/:id', authMiddleware, noTokenAuth('user management'), adminOnly, as
       return;
     }
   }
-  
+
   const updates: { nickname?: string; email?: string; role_level?: number; role?: string; status?: number; password_hash?: string } = {};
-  
+
   if (nickname !== undefined) {
     updates.nickname = nickname.trim() || user.username;
   }
@@ -206,9 +207,9 @@ router.put('/:id', authMiddleware, noTokenAuth('user management'), adminOnly, as
   }
   if (status !== undefined) { updates.status = status; }
   if (password) { updates.password_hash = bcrypt.hashSync(password, 10); }
-  
+
   await UserOperations.update(id, updates);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -219,9 +220,9 @@ router.put('/:id', authMiddleware, noTokenAuth('user management'), adminOnly, as
       },
     });
   } catch (error) {
-    log.error('Users', 'Failed to broadcast user_updated event', { error });
+    log.error('Failed to broadcast user_updated event', { error });
   }
-  
+
   sendSuccess(res);
 }));
 
@@ -256,21 +257,21 @@ router.delete('/:id', authMiddleware, noTokenAuth('user management'), adminOnly,
   }
   const callerRole = normalizeRole(req.user?.role);
   const targetRole = normalizeRole(target.role);
-  
+
   // Super admin cannot be deleted
   if (targetRole === ROLE_SUPER) {
     sendError(res, 'Super admin cannot be deleted');
     return;
   }
-  
+
   // Admin cannot delete users with same or higher role level (peer protection)
   if (callerRole === ROLE_ADMIN && targetRole >= ROLE_ADMIN) {
     sendError(res, 'Permission denied: Cannot delete users with same or higher role level');
     return;
   }
-  
+
   await UserOperations.delete(id);
-  
+
   // 推送 WebSocket 消息
   try {
     wsService.broadcast({
@@ -281,9 +282,9 @@ router.delete('/:id', authMiddleware, noTokenAuth('user management'), adminOnly,
       },
     });
   } catch (error) {
-    log.error('Users', 'Failed to broadcast user_deleted event', { error });
+    log.error('Failed to broadcast user_deleted event', { error });
   }
-  
+
   sendSuccess(res);
 }));
 

--- a/server/src/service/audit.ts
+++ b/server/src/service/audit.ts
@@ -1,9 +1,10 @@
 import { AuditLogOperations, UserOperations } from '../db/bal/business-adapter';
 import { checkAuditRules } from './auditRules';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { Request } from 'express';
 import { wsService } from './websocket';
 
+const log = createLogger('Audit');
 /**
  * 记录审计操作
  * @param userId - 用户 ID（可能是 Token 关联的用户 ID）
@@ -27,7 +28,7 @@ export async function logAuditOperation(
   const tokenPayload = (req as any)?.tokenPayload;
   if (tokenPayload) {
     authSource = 'token';
-    
+
     // Token 认证时，尝试获取实际用户信息
     try {
       const user = await UserOperations.getById(userId) as { username?: string; nickname?: string } | undefined;
@@ -37,7 +38,7 @@ export async function logAuditOperation(
         operatorName = `user:${userId}`;
       }
     } catch (err) {
-      log.warn('Audit', 'Failed to get user info for token auth', { userId, error: err });
+      log.warn('Failed to get user info for token auth', { userId, error: err });
       operatorName = `user:${userId}`;
     }
   } else {
@@ -50,7 +51,7 @@ export async function logAuditOperation(
         operatorName = `user:${userId}`;
       }
     } catch (err) {
-      log.warn('Audit', 'Failed to get user info for JWT auth', { userId, error: err });
+      log.warn('Failed to get user info for JWT auth', { userId, error: err });
       operatorName = `user:${userId}`;
     }
   }
@@ -67,9 +68,9 @@ export async function logAuditOperation(
 
   // Async check against audit rules
   checkAuditRules(actualUserId, action, domain, auditData).catch(err => {
-    log.error('Audit', 'Audit rule engine error', { error: err });
+    log.error('Audit rule engine error', { error: err });
   });
-  
+
   // 推送 WebSocket 消息给管理员（异步，不阻塞）
   try {
     wsService.broadcastToRole('3', {
@@ -81,6 +82,6 @@ export async function logAuditOperation(
       },
     });
   } catch (err) {
-    log.warn('Audit', 'Failed to broadcast audit_log_created event', { error: err });
+    log.warn('Failed to broadcast audit_log_created event', { error: err });
   }
 }

--- a/server/src/service/deviceTrust.ts
+++ b/server/src/service/deviceTrust.ts
@@ -5,15 +5,16 @@
 
 import crypto from 'crypto';
 import { TrustedDeviceOperations, getDbType } from '../db/bal/business-adapter';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { getSecurityPolicy } from './securityPolicy';
 
+const log = createLogger('Security').sub('DeviceTrust');
 /**
  * 初始化受信任设备表
  */
 export async function initTrustedDevicesTable(): Promise<void> {
   // 表初始化已在业务适配器中处理，此函数保留用于兼容性
-  log.debug('DeviceTrust', 'Trusted devices table initialized');
+  log.debug('Trusted devices table initialized');
 }
 
 export interface TrustedDevice {
@@ -77,7 +78,7 @@ export async function addTrustedDevice(
     expiresAt.toISOString()
   );
 
-  log.info('DeviceTrust', `Added trusted device for user ${userId}: ${name}`);
+  log.info(`Added trusted device for user ${userId}: ${name}`);
   return deviceId;
 }
 
@@ -108,7 +109,7 @@ export async function verifyTrustedDevice(
   if (expiresAt < new Date()) {
     // 删除过期设备
     await TrustedDeviceOperations.delete(device.id as string);
-    log.debug('DeviceTrust', `Removed expired device ${device.id}`);
+    log.debug(`Removed expired device ${device.id}`);
     return { trusted: false };
   }
 
@@ -139,7 +140,7 @@ export async function removeTrustedDevice(userId: number, deviceId: string): Pro
   const changes = await TrustedDeviceOperations.deleteByUserAndId(userId, deviceId);
 
   if (changes > 0) {
-    log.info('DeviceTrust', `Removed trusted device ${deviceId} for user ${userId}`);
+    log.info(`Removed trusted device ${deviceId} for user ${userId}`);
     return true;
   }
 
@@ -151,7 +152,7 @@ export async function removeTrustedDevice(userId: number, deviceId: string): Pro
  */
 export async function removeAllUserTrustedDevices(userId: number): Promise<void> {
   await TrustedDeviceOperations.deleteByUser(userId);
-  log.info('DeviceTrust', `Removed all trusted devices for user ${userId}`);
+  log.info(`Removed all trusted devices for user ${userId}`);
 }
 
 /**
@@ -161,7 +162,7 @@ export async function cleanupExpiredDevices(): Promise<number> {
   const count = await TrustedDeviceOperations.cleanupExpired();
 
   if (count > 0) {
-    log.info('DeviceTrust', `Cleaned up ${count} expired devices`);
+    log.info(`Cleaned up ${count} expired devices`);
   }
 
   return count;

--- a/server/src/service/dns-provider-service.ts
+++ b/server/src/service/dns-provider-service.ts
@@ -1,15 +1,16 @@
 /**
  * DNS 提供商服务
- * 
+ *
  * 封装 DNS 适配器调用逻辑，供 MCP 和其他模块复用
  */
 
 import { DnsAdapter, DnsRecord, PageResult } from '../lib/dns/DnsInterface';
 import { createAdapter } from '../lib/dns/DnsHelper';
 import { DomainOperations, DnsAccountOperations } from '../db/bal/business-adapter';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import type { Domain, DnsAccount } from '../types';
 
+const log = createLogger('DnsProviderService');
 export class DnsProviderService {
   /**
    * 获取域名的 DNS 适配器
@@ -28,7 +29,7 @@ export class DnsProviderService {
    * 为域名创建适配器（内部方法）
    */
   private static async getAdapterForDomain(domain: Domain): Promise<DnsAdapter> {
-    log.info('DnsProviderService', 'Getting adapter for domain', {
+    log.info('Getting adapter for domain', {
       domainId: domain.id,
       domainName: domain.name,
       accountId: domain.account_id,
@@ -38,11 +39,11 @@ export class DnsProviderService {
     // 2. 获取账号信息
     const account = await DnsAccountOperations.getById(domain.account_id as number) as DnsAccount | undefined;
     if (!account) {
-      log.error('DnsProviderService', 'Account not found', { accountId: domain.account_id });
+      log.error('Account not found', { accountId: domain.account_id });
       throw new Error('Account not found');
     }
 
-    log.info('DnsProviderService', 'Found account', {
+    log.info('Found account', {
       accountType: account.type,
       accountName: account.name,
     });
@@ -56,7 +57,7 @@ export class DnsProviderService {
     const isHiDNS = account.type === 'hidns';
     const effectiveDomainId = isHiDNS && domain.third_id ? domain.third_id : String(domain.id);
 
-    log.info('DnsProviderService', 'Creating adapter', {
+    log.info('Creating adapter', {
       type: account.type,
       domain: domain.name,
       thirdId: domain.third_id,
@@ -74,7 +75,7 @@ export class DnsProviderService {
       effectiveDomainId
     );
 
-    log.info('DnsProviderService', 'Adapter created successfully');
+    log.info('Adapter created successfully');
     return adapter;
   }
 
@@ -191,16 +192,16 @@ export class DnsProviderService {
    */
   static async getRecordInfo(recordId: string, domainId: number): Promise<DnsRecord | null> {
     const adapter = await this.getAdapter(domainId);
-    
+
     // 先尝试直接获取
     let record = await adapter.getDomainRecordInfo(recordId);
-    
+
     // 如果失败，尝试从列表中查找
     if (!record) {
       const result = await adapter.getDomainRecords(1, 1000);
       record = result.list.find((item) => item.RecordId === recordId) ?? null;
     }
-    
+
     return record;
   }
 

--- a/server/src/service/domainRenewalJob.ts
+++ b/server/src/service/domainRenewalJob.ts
@@ -7,8 +7,9 @@ import { DnsAccountOperations, RenewableDomainOperations } from '../db/bal/busin
 import { renewalRegistry } from './renewalScheduler';
 import { taskManager } from './taskManager';
 import { logAuditOperation } from './audit';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('Job').sub('DomainRenewal');
 let renewalInterval: NodeJS.Timeout | null = null;
 
 /**
@@ -16,14 +17,14 @@ let renewalInterval: NodeJS.Timeout | null = null;
  */
 export async function executeDomainRenewal(): Promise<void> {
   try {
-    log.info('DomainRenewalJob', 'Starting automatic domain renewal');
+    log.info('Starting automatic domain renewal');
 
     // 获取所有 DNSHE 账号
     const accounts = await DnsAccountOperations.getAll() as any[];
     const dnsheAccounts = accounts.filter((acc: any) => acc.type === 'dnshe');
 
     if (dnsheAccounts.length === 0) {
-      log.info('DomainRenewalJob', 'No DNSHE accounts found, skipping renewal');
+      log.info('No DNSHE accounts found, skipping renewal');
       return;
     }
 
@@ -34,33 +35,33 @@ export async function executeDomainRenewal(): Promise<void> {
     for (const account of dnsheAccounts) {
       try {
         const config = typeof account.config === 'string' ? JSON.parse(account.config) : account.config;
-        
+
         // 获取该提供商类型的续期调度器
         const scheduler = renewalRegistry.getScheduler(account.type);
-        
+
         if (!scheduler) {
-          log.warn('DomainRenewalJob', 'No renewal scheduler registered for provider type', {
+          log.warn('No renewal scheduler registered for provider type', {
             accountId: account.id,
             accountName: account.name,
             type: account.type,
           });
           continue;
         }
-        
+
         // 通过调度器获取可续期的域名列表
         const renewableDomains = await scheduler.listRenewableDomains({
           apiKey: config.apiKey,
           apiSecret: config.apiSecret,
           useProxy: !!config.useProxy,
         });
-        
-        log.info('DomainRenewalJob', 'Fetched renewable domains via scheduler', {
+
+        log.info('Fetched renewable domains via scheduler', {
           accountId: account.id,
           accountName: account.name,
           type: account.type,
           count: renewableDomains.length,
         });
-        
+
         // 注意：DNSHE listSubdomains API 不返回 expires_at
         // 所以我们对所有子域名尝试续期，让 API 自己判断是否需要续期
         const domainsToRenew = renewableDomains;
@@ -70,7 +71,7 @@ export async function executeDomainRenewal(): Promise<void> {
           try {
             const domainId = domain.id;
             if (!domainId) {
-              log.warn('DomainRenewalJob', 'Domain has no id, skipping', {
+              log.warn('Domain has no id, skipping', {
                 domainName: domain.name || domain.full_domain,
               });
               continue;
@@ -79,7 +80,7 @@ export async function executeDomainRenewal(): Promise<void> {
             // Check if domain is enabled in database
             const dbDomain = await RenewableDomainOperations.getById(Number(domainId));
             if (!dbDomain) {
-              log.warn('DomainRenewalJob', 'Domain not found in database, skipping', {
+              log.warn('Domain not found in database, skipping', {
                 domainId,
                 domainName: domain.name || domain.full_domain,
               });
@@ -87,7 +88,7 @@ export async function executeDomainRenewal(): Promise<void> {
             }
 
             if (!dbDomain.enabled) {
-              log.info('DomainRenewalJob', 'Skipping disabled domain', {
+              log.info('Skipping disabled domain', {
                 domainId,
                 domainName: dbDomain.full_domain,
                 enabled: dbDomain.enabled,
@@ -95,7 +96,7 @@ export async function executeDomainRenewal(): Promise<void> {
               continue;
             }
 
-            log.info('DomainRenewalJob', 'Attempting domain renewal via scheduler', {
+            log.info('Attempting domain renewal via scheduler', {
               domainName: domain.name || domain.full_domain,
               domainId,
               // Note: expires_at is not available from listSubdomains API
@@ -113,7 +114,7 @@ export async function executeDomainRenewal(): Promise<void> {
 
             if (result) {
               renewedCount++;
-              log.info('DomainRenewalJob', 'Domain renewed successfully', {
+              log.info('Domain renewed successfully', {
                 domainName: result.domain_name,
                 previousExpiresAt: result.previous_expires_at,
                 newExpiresAt: result.new_expires_at,
@@ -124,12 +125,12 @@ export async function executeDomainRenewal(): Promise<void> {
               if (result.new_expires_at) {
                 try {
                   await RenewableDomainOperations.updateExpiresAt(Number(domainId), result.new_expires_at);
-                  log.debug('DomainRenewalJob', 'Updated expires_at in renewable_domains', {
+                  log.debug('Updated expires_at in renewable_domains', {
                     domainId,
                     newExpiresAt: result.new_expires_at,
                   });
                 } catch (updateError) {
-                  log.error('DomainRenewalJob', 'Failed to update expires_at in renewable_domains', {
+                  log.error('Failed to update expires_at in renewable_domains', {
                     domainId,
                     error: updateError instanceof Error ? updateError.message : String(updateError),
                   });
@@ -137,21 +138,21 @@ export async function executeDomainRenewal(): Promise<void> {
               }
             } else {
               failedCount++;
-              log.error('DomainRenewalJob', 'Domain renewal failed', {
+              log.error('Domain renewal failed', {
                 domainName: domain.name || domain.full_domain,
                 domainId,
               });
             }
           } catch (error) {
             failedCount++;
-            log.error('DomainRenewalJob', 'Domain renewal error', {
+            log.error('Domain renewal error', {
               domainName: domain.name || domain.full_domain,
               error: error instanceof Error ? error.message : String(error),
             });
           }
         }
       } catch (error) {
-        log.error('DomainRenewalJob', 'Failed to process account', {
+        log.error('Failed to process account', {
           accountId: account.id,
           accountName: account.name,
           error: error instanceof Error ? error.message : String(error),
@@ -159,13 +160,13 @@ export async function executeDomainRenewal(): Promise<void> {
       }
     }
 
-    log.info('DomainRenewalJob', 'Automatic domain renewal completed', {
+    log.info('Automatic domain renewal completed', {
       renewedCount,
       failedCount,
       totalAccounts: dnsheAccounts.length,
     });
   } catch (error) {
-    log.error('DomainRenewalJob', 'Automatic domain renewal failed', {
+    log.error('Automatic domain renewal failed', {
       error: error instanceof Error ? error.message : String(error),
     });
   }
@@ -180,10 +181,10 @@ export async function startDomainRenewalJob(): Promise<void> {
   const now = new Date();
   const nextRun = new Date(now);
   nextRun.setUTCHours(24, 0, 0, 0); // 明天 UTC 0:00
-  
+
   const initialDelay = nextRun.getTime() - now.getTime();
-  
-  log.info('DomainRenewalJob', 'Starting domain renewal job', {
+
+  log.info('Starting domain renewal job', {
     nextRun: nextRun.toISOString(),
     initialDelayMs: initialDelay,
     initialDelayHours: Math.round(initialDelay / (1000 * 60 * 60) * 100) / 100,
@@ -201,8 +202,8 @@ export async function startDomainRenewalJob(): Promise<void> {
         retryDelay: 60000,    // 重试间隔1分钟
       },
       executeDomainRenewal
-    ).catch(err => log.error('DomainRenewalJob', 'Initial renewal error:', { error: err }));
-    
+    ).catch(err => log.error('Initial renewal error:', { error: err }));
+
     // 之后每 24 小时执行一次
     setInterval(() => {
       taskManager.submit(
@@ -215,7 +216,7 @@ export async function startDomainRenewalJob(): Promise<void> {
           retryDelay: 60000,    // 重试间隔1分钟
         },
         executeDomainRenewal
-      ).catch(err => log.error('DomainRenewalJob', 'Scheduled renewal error:', { error: err }));
+      ).catch(err => log.error('Scheduled renewal error:', { error: err }));
     }, 24 * 60 * 60 * 1000);
   }, initialDelay);
 }
@@ -227,6 +228,6 @@ export function stopDomainRenewalJob(): void {
   if (renewalInterval) {
     clearInterval(renewalInterval);
     renewalInterval = null;
-    log.info('DomainRenewalJob', 'Domain renewal job stopped');
+    log.info('Domain renewal job stopped');
   }
 }

--- a/server/src/service/domainSyncJob.ts
+++ b/server/src/service/domainSyncJob.ts
@@ -8,9 +8,10 @@ import { DnsAccountOperations, DomainOperations, RenewableDomainOperations } fro
 import { createAdapter } from '../lib/dns/DnsHelper';
 import { taskManager } from './taskManager';
 import { logAuditOperation } from './audit';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { normalizeDomain } from '../utils/dns';
 
+const log = createLogger('Job').sub('DomainSync');
 let syncInterval: NodeJS.Timeout | null = null;
 
 /**
@@ -19,43 +20,43 @@ let syncInterval: NodeJS.Timeout | null = null;
 async function syncRenewableDomains(account: any, providerDomainSet: Set<string>): Promise<void> {
   const accountId = account.id;
   const accountName = account.name;
-  
+
   try {
     // 获取该账户的所有续期域名
     const renewableDomains = await RenewableDomainOperations.getByAccountId(accountId);
-    
+
     if (renewableDomains.length === 0) {
       return;
     }
-    
-    log.info('DomainSyncJob', `Checking ${renewableDomains.length} renewable domains for account: ${accountName}`);
-    
+
+    log.info(`Checking ${renewableDomains.length} renewable domains for account: ${accountName}`);
+
     let disabledCount = 0;
     const disabledDomains: string[] = [];
-    
+
     for (const renewableDomain of renewableDomains) {
       // 使用 normalizeDomain 标准化续期域名，支持 IDN 域名
       const rawDomainName = (renewableDomain as any).full_domain || (renewableDomain as any).domain_name;
       const domainName = rawDomainName ? normalizeDomain(rawDomainName) : '';
-      
+
       if (!domainName) {
-        log.warn('DomainSyncJob', 'Renewable domain has no name, skipping', {
+        log.warn('Renewable domain has no name, skipping', {
           id: (renewableDomain as any).id,
         });
         continue;
       }
-      
+
       // 如果域名不在提供商列表中，且当前状态是启用，则禁用
       const isEnabled = Boolean((renewableDomain as any).enabled);
       if (!providerDomainSet.has(domainName) && isEnabled) {
-        log.warn('DomainSyncJob', `Renewable domain not found in provider, disabling: ${domainName}`, {
+        log.warn(`Renewable domain not found in provider, disabling: ${domainName}`, {
           accountId,
           renewableDomainId: (renewableDomain as any).id,
         });
-        
+
         // 禁用续期域名
         await RenewableDomainOperations.toggleEnabled((renewableDomain as any).id, false);
-        
+
         // 记录审计日志（使用系统用户 ID 0）
         try {
           await logAuditOperation(
@@ -71,32 +72,32 @@ async function syncRenewableDomains(account: any, providerDomainSet: Set<string>
             undefined // No request object for scheduled tasks
           );
         } catch (auditError) {
-          log.error('DomainSyncJob', 'Failed to log audit operation for renewable domain', {
+          log.error('Failed to log audit operation for renewable domain', {
             domain: domainName,
             error: auditError,
           });
         }
-        
+
         disabledCount++;
         disabledDomains.push(domainName);
       } else if (!providerDomainSet.has(domainName)) {
         // 域名不在提供商列表中，但已经是禁用状态，跳过
-        log.debug('DomainSyncJob', `Renewable domain already disabled, skipping: ${domainName}`, {
+        log.debug(`Renewable domain already disabled, skipping: ${domainName}`, {
           accountId,
           renewableDomainId: (renewableDomain as any).id,
         });
       }
     }
-    
+
     if (disabledCount > 0) {
-      log.info('DomainSyncJob', `Disabled ${disabledCount} renewable domains`, {
+      log.info(`Disabled ${disabledCount} renewable domains`, {
         accountId,
         accountName,
         disabledDomains,
       });
     }
   } catch (error) {
-    log.error('DomainSyncJob', `Failed to sync renewable domains`, {
+    log.error(`Failed to sync renewable domains`, {
       accountId,
       accountName,
       error: error instanceof Error ? error.message : String(error),
@@ -110,34 +111,34 @@ async function syncRenewableDomains(account: any, providerDomainSet: Set<string>
 async function syncAccountDomains(account: any): Promise<void> {
   const accountId = account.id;
   const accountName = account.name;
-  
+
   try {
-    log.info('DomainSyncJob', `Starting domain sync for account: ${accountName} (ID: ${accountId})`);
-    
+    log.info(`Starting domain sync for account: ${accountName} (ID: ${accountId})`);
+
     // 解析配置
-    const cfg = typeof account.config === 'string' 
-      ? JSON.parse(account.config) as Record<string, string> 
+    const cfg = typeof account.config === 'string'
+      ? JSON.parse(account.config) as Record<string, string>
       : account.config as Record<string, string>;
-    
+
     // 创建适配器
     const dnsAdapter = createAdapter(account.type, cfg);
-    
+
     // 分页获取所有域名
     const providerDomains: Array<{ Domain: string; ThirdId: string }> = [];
     let page = 1;
     const pageSize = 50;
     let hasMore = true;
     let apiError = false;
-    
+
     while (hasMore) {
       try {
         const result = await dnsAdapter.getDomainList(undefined, page, pageSize);
-        
+
         if (!result.list || result.list.length === 0) {
           hasMore = false;
           break;
         }
-        
+
         // 适配不同提供商的返回格式
         result.list.forEach((domain: any) => {
           providerDomains.push({
@@ -145,25 +146,25 @@ async function syncAccountDomains(account: any): Promise<void> {
             ThirdId: domain.ThirdId || domain.third_id || domain.id,
           });
         });
-        
+
         // 检查是否还有更多页面
         if (result.list.length < pageSize) {
           hasMore = false;
         } else {
           page++;
         }
-        
+
         // 避免请求过快
         await new Promise(resolve => setTimeout(resolve, 500));
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
-        
+
         // Check for timeout or 404 errors
-        if (errorMsg.includes('timeout') || 
+        if (errorMsg.includes('timeout') ||
             errorMsg.includes('ETIMEDOUT') ||
             errorMsg.includes('404') ||
             errorMsg.includes('Not Found')) {
-          log.error('DomainSyncJob', `API timeout or 404, skipping sync for this account`, {
+          log.error(`API timeout or 404, skipping sync for this account`, {
             accountId,
             page,
             error: errorMsg,
@@ -172,8 +173,8 @@ async function syncAccountDomains(account: any): Promise<void> {
           hasMore = false;
           break;
         }
-        
-        log.error('DomainSyncJob', `Failed to fetch domains page ${page}`, {
+
+        log.error(`Failed to fetch domains page ${page}`, {
           accountId,
           page,
           error: errorMsg,
@@ -181,49 +182,49 @@ async function syncAccountDomains(account: any): Promise<void> {
         hasMore = false;
       }
     }
-    
+
     // If API failed, skip the sync to avoid disabling domains incorrectly
     if (apiError) {
-      log.warn('DomainSyncJob', `Skipping domain sync due to API error`, {
+      log.warn(`Skipping domain sync due to API error`, {
         accountId,
         accountName,
       });
       return;
     }
-    
-    log.info('DomainSyncJob', `Fetched ${providerDomains.length} domains from provider`, {
+
+    log.info(`Fetched ${providerDomains.length} domains from provider`, {
       accountId,
       accountName,
     });
-    
+
     // 获取数据库中该账户的所有域名
     const dbDomains = await DomainOperations.getByAccountId(accountId);
-    
+
     // 创建提供商域名集合（用于快速查找）
     // 使用 normalizeDomain 将域名标准化为 Punycode，支持 IDN 域名
     const providerDomainSet = new Set(
       providerDomains.map(d => normalizeDomain(d.Domain))
     );
-    
+
     // 检查数据库中的域名是否在提供商列表中
     let disabledCount = 0;
     const disabledDomains: string[] = [];
-    
+
     for (const dbDomain of dbDomains) {
       // 使用 normalizeDomain 标准化数据库中的域名（已经是 Punycode，但确保一致性）
       const domainName = normalizeDomain((dbDomain as any).name);
-      
+
       // 如果域名不在提供商列表中，且当前状态是启用，则禁用
       const isEnabled = Boolean((dbDomain as any).enabled);
       if (!providerDomainSet.has(domainName) && isEnabled) {
-        log.warn('DomainSyncJob', `Domain not found in provider, disabling: ${(dbDomain as any).name}`, {
+        log.warn(`Domain not found in provider, disabling: ${(dbDomain as any).name}`, {
           accountId,
           domainId: (dbDomain as any).id,
         });
-        
+
         // 禁用域名
         await DomainOperations.update((dbDomain as any).id, { enabled: 0 });
-        
+
         // 记录审计日志（使用系统用户 ID 0）
         try {
           await logAuditOperation(
@@ -239,40 +240,40 @@ async function syncAccountDomains(account: any): Promise<void> {
             undefined // No request object for scheduled tasks
           );
         } catch (auditError) {
-          log.error('DomainSyncJob', 'Failed to log audit operation', {
+          log.error('Failed to log audit operation', {
             domain: (dbDomain as any).name,
             error: auditError,
           });
         }
-        
+
         disabledCount++;
         disabledDomains.push((dbDomain as any).name);
       } else if (!providerDomainSet.has(domainName)) {
         // 域名不在提供商列表中，但已经是禁用状态，跳过
-        log.debug('DomainSyncJob', `Domain already disabled, skipping: ${(dbDomain as any).name}`, {
+        log.debug(`Domain already disabled, skipping: ${(dbDomain as any).name}`, {
           accountId,
           domainId: (dbDomain as any).id,
         });
       }
     }
-    
+
     if (disabledCount > 0) {
-      log.info('DomainSyncJob', `Disabled ${disabledCount} domains`, {
+      log.info(`Disabled ${disabledCount} domains`, {
         accountId,
         accountName,
         disabledDomains,
       });
     } else {
-      log.info('DomainSyncJob', 'All domains are synchronized', {
+      log.info('All domains are synchronized', {
         accountId,
         accountName,
       });
     }
-    
+
     // Sync renewable_domains table
     await syncRenewableDomains(account, providerDomainSet);
   } catch (error) {
-    log.error('DomainSyncJob', `Failed to sync account domains`, {
+    log.error(`Failed to sync account domains`, {
       accountId,
       accountName,
       error: error instanceof Error ? error.message : String(error),
@@ -285,19 +286,19 @@ async function syncAccountDomains(account: any): Promise<void> {
  */
 export async function executeDomainSync(): Promise<void> {
   try {
-    log.info('DomainSyncJob', 'Starting domain synchronization detection');
-    
+    log.info('Starting domain synchronization detection');
+
     // 获取所有启用的 DNS 账户
     const accounts = await DnsAccountOperations.getAll() as any[];
     const activeAccounts = accounts.filter((acc: any) => acc.enabled !== false);
-    
+
     if (activeAccounts.length === 0) {
-      log.info('DomainSyncJob', 'No active DNS accounts found, skipping sync');
+      log.info('No active DNS accounts found, skipping sync');
       return;
     }
-    
-    log.info('DomainSyncJob', `Found ${activeAccounts.length} active accounts to sync`);
-    
+
+    log.info(`Found ${activeAccounts.length} active accounts to sync`);
+
     // 使用任务管理器并发处理（最多同时3个账户）
     const tasks = activeAccounts.map(account => {
       return taskManager.submit(
@@ -314,13 +315,13 @@ export async function executeDomainSync(): Promise<void> {
         }
       );
     });
-    
+
     // 等待所有任务完成
     await Promise.all(tasks);
-    
-    log.info('DomainSyncJob', 'Domain synchronization completed');
+
+    log.info('Domain synchronization completed');
   } catch (error) {
-    log.error('DomainSyncJob', 'Domain synchronization failed', {
+    log.error('Domain synchronization failed', {
       error: error instanceof Error ? error.message : String(error),
     });
   }
@@ -332,14 +333,14 @@ export async function executeDomainSync(): Promise<void> {
  */
 export function startDomainSyncJob(intervalHours: number = 6): void {
   if (syncInterval) {
-    log.warn('DomainSyncJob', 'Domain sync job already started');
+    log.warn('Domain sync job already started');
     return;
   }
-  
+
   const intervalMs = intervalHours * 60 * 60 * 1000;
-  
-  log.info('DomainSyncJob', `Starting domain sync job scheduler (interval: ${intervalHours} hours)`);
-  
+
+  log.info(`Starting domain sync job scheduler (interval: ${intervalHours} hours)`);
+
   // 启动后 2 分钟运行第一次（给系统一些启动时间）
   setTimeout(() => {
     taskManager.submit(
@@ -352,8 +353,8 @@ export function startDomainSyncJob(intervalHours: number = 6): void {
         retryDelay: 30000,
       },
       executeDomainSync
-    ).catch(err => log.error('DomainSyncJob', 'Initial sync error:', { error: err }));
-    
+    ).catch(err => log.error('Initial sync error:', { error: err }));
+
     // 之后按设定的间隔执行
     syncInterval = setInterval(() => {
       taskManager.submit(
@@ -366,7 +367,7 @@ export function startDomainSyncJob(intervalHours: number = 6): void {
           retryDelay: 30000,
         },
         executeDomainSync
-      ).catch(err => log.error('DomainSyncJob', 'Scheduled sync error:', { error: err }));
+      ).catch(err => log.error('Scheduled sync error:', { error: err }));
     }, intervalMs);
   }, 2 * 60 * 1000);
 }
@@ -378,6 +379,6 @@ export function stopDomainSyncJob(): void {
   if (syncInterval) {
     clearInterval(syncInterval);
     syncInterval = null;
-    log.info('DomainSyncJob', 'Domain sync job stopped');
+    log.info('Domain sync job stopped');
   }
 }

--- a/server/src/service/failoverJob.ts
+++ b/server/src/service/failoverJob.ts
@@ -2,8 +2,9 @@ import { FailoverOperations, getDbType } from '../db/bal/business-adapter';
 import { getFailoverConfig, getFailoverStatus, performHealthCheck, performFailover, FailoverConfig } from './failover';
 import { taskManager } from './taskManager';
 import { connect } from '../db/dal/connection';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('Job').sub('Failover');
 export async function startFailoverJob() {
   // 每 10 秒检查一次，但使用任务管理器控制并发
   setInterval(async () => {
@@ -74,15 +75,15 @@ export async function startFailoverJob() {
     } catch (e) {
       // Check if it's a connection error, try to reconnect
       if (e instanceof Error && e.message.includes('Database connection not initialized')) {
-        log.warn('FailoverJob', 'Database connection lost, attempting to reconnect...');
+        log.warn('Database connection lost, attempting to reconnect...');
         try {
           await connect();
-          log.info('FailoverJob', 'Database reconnected successfully');
+          log.info('Database reconnected successfully');
         } catch (reconnectError) {
-          log.error('FailoverJob', 'Failed to reconnect to database', { error: reconnectError });
+          log.error('Failed to reconnect to database', { error: reconnectError });
         }
       } else {
-        log.error('FailoverJob', 'Error', { error: e });
+        log.error('Error', { error: e });
       }
     }
   }, 10000); // check every 10 seconds, but inside we respect checkInterval

--- a/server/src/service/loginLimit.ts
+++ b/server/src/service/loginLimit.ts
@@ -1,7 +1,8 @@
 import { LoginLimitOperations, getDbType } from '../db/bal/business-adapter';
 import { checkAuditRules } from './auditRules';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('Security').sub('LoginLimit');
 /**
  * 将日期格式化为数据库兼容的格式 (YYYY-MM-DD HH:mm:ss)
  */
@@ -45,7 +46,7 @@ export async function getLoginLimitConfig(): Promise<LoginLimitConfig> {
       return { ...DEFAULT_CONFIG, ...JSON.parse((result as { value: string }).value) };
     }
   } catch (e) {
-    log.error('LoginLimit', 'Failed to get config', { error: e });
+    log.error('Failed to get config', { error: e });
   }
   return DEFAULT_CONFIG;
 }
@@ -93,7 +94,7 @@ export async function checkLoginAllowed(identifier: string, ipAddress: string = 
       remainingAttempts,
     };
   } catch (e) {
-    log.error('LoginLimit', 'Failed to check login allowed', { error: e });
+    log.error('Failed to check login allowed', { error: e });
     return { allowed: true };
   }
 }
@@ -138,7 +139,7 @@ export async function recordFailedAttempt(identifier: string, ipAddress: string 
 
         await LoginLimitOperations.updateAttempt(attempt.id, newCount, formatDateForDB(lockedUntil));
 
-        checkAuditRules(0, 'login_failed', '', { identifier: normalizedIdentifier, ip: ipAddress, attemptCount: newCount }).catch(e => log.error('LoginLimit', 'Audit rule check failed', { error: e }));
+        checkAuditRules(0, 'login_failed', '', { identifier: normalizedIdentifier, ip: ipAddress, attemptCount: newCount }).catch(e => log.error('Audit rule check failed', { error: e }));
 
         return {
           locked: true,
@@ -149,7 +150,7 @@ export async function recordFailedAttempt(identifier: string, ipAddress: string 
       // Update attempt count
       await LoginLimitOperations.updateAttempt(attempt.id, newCount, null);
 
-      checkAuditRules(0, 'login_failed', '', { identifier: normalizedIdentifier, ip: ipAddress, attemptCount: newCount }).catch(e => log.error('LoginLimit', 'Audit rule check failed', { error: e }));
+      checkAuditRules(0, 'login_failed', '', { identifier: normalizedIdentifier, ip: ipAddress, attemptCount: newCount }).catch(e => log.error('Audit rule check failed', { error: e }));
 
       const remainingAttempts = config.maxAttempts - newCount;
       return {
@@ -167,7 +168,7 @@ export async function recordFailedAttempt(identifier: string, ipAddress: string 
       };
     }
   } catch (e) {
-    log.error('LoginLimit', 'Failed to record failed attempt', { error: e });
+    log.error('Failed to record failed attempt', { error: e });
     return { locked: false };
   }
 }
@@ -177,7 +178,7 @@ export async function clearLoginAttempts(identifier: string): Promise<void> {
   try {
     await LoginLimitOperations.clearAttempts(identifier);
   } catch (e) {
-    log.error('LoginLimit', 'Failed to clear attempts', { error: e });
+    log.error('Failed to clear attempts', { error: e });
   }
 }
 
@@ -208,7 +209,7 @@ export async function getLoginAttemptStats(): Promise<{
       topIdentifiers,
     };
   } catch (e) {
-    log.error('LoginLimit', 'Failed to get stats', { error: e });
+    log.error('Failed to get stats', { error: e });
     return { totalLocked: 0, recentAttempts: 0, topIdentifiers: [] };
   }
 }

--- a/server/src/service/mcp-permission.ts
+++ b/server/src/service/mcp-permission.ts
@@ -1,6 +1,6 @@
 /**
  * MCP 权限验证服务
- * 
+ *
  * 权限模型：
  * - 全局开关仅控制启用/禁用，不影响具体权限
  * - 权限由用户角色决定
@@ -10,12 +10,13 @@
 
 import { McpOperations, UserOperations } from '../db/bal/business-adapter';
 import { AppError } from '../middleware/errorHandler';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { ROLE_USER, ROLE_ADMIN, ROLE_SUPER } from '../utils/roles';
 
+const log = createLogger('Security').sub('McpPermission');
 export type McpPermissionLevel = 'disabled' | 'read' | 'write';
 
-export type McpModule = 
+export type McpModule =
   | 'ns_monitor'
   | 'domain_management'
   | 'renewal_management'
@@ -58,7 +59,7 @@ function minPermission(a: McpPermissionLevel, b: McpPermissionLevel): McpPermiss
     read: 1,
     write: 2,
   };
-  
+
   return levels[a] <= levels[b] ? a : b;
 }
 
@@ -70,14 +71,14 @@ export async function isMcpEnabled(): Promise<boolean> {
     const config = await McpOperations.getGlobalConfig();
     return config?.enabled || false;
   } catch (error) {
-    log.error('MCP Permission', 'Failed to check MCP status', { error });
+    log.error('Failed to check MCP status', { error });
     return false;
   }
 }
 
 /**
  * 获取用户在某个模块的权限
- * 
+ *
  * @param userId 用户ID
  * @param module 模块名称
  * @returns 权限级别
@@ -94,7 +95,7 @@ export async function getUserModulePermission(
   // 2. 获取用户角色
   const user = await UserOperations.getById(userId);
   if (!user) {
-    log.warn('MCP Permission', 'User not found', { userId });
+    log.warn('User not found', { userId });
     return 'disabled';
   }
 
@@ -112,7 +113,7 @@ export async function getUserModulePermission(
   // 4. 返回角色对应的权限
   const rolePermissions = ROLE_PERMISSIONS[roleName];
   if (!rolePermissions) {
-    log.warn('MCP Permission', 'Unknown role', { userId, role: user.role });
+    log.warn('Unknown role', { userId, role: user.role });
     return 'disabled';
   }
 
@@ -121,7 +122,7 @@ export async function getUserModulePermission(
 
 /**
  * 验证工具调用权限
- * 
+ *
  * @param userId 用户ID
  * @param toolName 工具名称
  * @param requiredPermission 所需权限级别
@@ -135,7 +136,7 @@ export async function validateToolPermission(
   tokenScope?: string
 ): Promise<void> {
   const module = getModuleByToolName(toolName);
-  
+
   if (!module) {
     throw new AppError(400, `Unknown MCP tool: ${toolName}`);
   }
@@ -152,14 +153,14 @@ export async function validateToolPermission(
 
     if (requiredPermission === 'write') {
       if (!scopes.includes(writeScope)) {
-        log.warn('MCP Permission', 'OAuth token scope insufficient for write', {
+        log.warn('OAuth token scope insufficient for write', {
           userId, module, toolName, tokenScope
         });
         throw new AppError(403, `Token does not have '${writeScope}' scope`);
       }
     } else {
       if (!scopes.includes(requiredScope) && !scopes.includes(writeScope)) {
-        log.warn('MCP Permission', 'OAuth token scope insufficient for read', {
+        log.warn('OAuth token scope insufficient for read', {
           userId, module, toolName, tokenScope
         });
         throw new AppError(403, `Token does not have '${requiredScope}' scope`);
@@ -170,29 +171,29 @@ export async function validateToolPermission(
   const userPermission = await getUserModulePermission(userId, module);
 
   if (userPermission === 'disabled') {
-    log.warn('MCP Permission', 'Module disabled or no permission', { 
-      userId, 
-      module, 
-      toolName 
+    log.warn('Module disabled or no permission', {
+      userId,
+      module,
+      toolName
     });
     throw new AppError(403, `MCP module '${module}' is disabled or you have no permission`);
   }
 
   if (requiredPermission === 'write' && userPermission !== 'write') {
-    log.warn('MCP Permission', 'Insufficient permission for write operation', { 
-      userId, 
-      module, 
+    log.warn('Insufficient permission for write operation', {
+      userId,
+      module,
       toolName,
-      userPermission 
+      userPermission
     });
     throw new AppError(403, `Write permission required for '${module}' module`);
   }
 
-  log.debug('MCP Permission', 'Permission validated', { 
-    userId, 
-    module, 
+  log.debug('Permission validated', {
+    userId,
+    module,
     toolName,
-    permission: userPermission 
+    permission: userPermission
   });
 }
 
@@ -206,7 +207,7 @@ export function getModuleByToolName(toolName: string): McpModule | null {
     'check_ns_status': 'ns_monitor',
     'get_ns_info': 'ns_monitor',
     'refresh_ns_monitor': 'ns_monitor',
-    
+
     // 域名管理模块
     'list_domains': 'domain_management',
     'list_domains_filtered': 'domain_management',
@@ -218,26 +219,26 @@ export function getModuleByToolName(toolName: string): McpModule | null {
     'add_domain': 'domain_management',
     'delete_domain': 'domain_management',
     'update_domain': 'domain_management',
-    
+
     // DNS 解析记录管理
     'list_domain_records': 'domain_management',
     'get_dns_lines': 'domain_management',
     'create_dns_record': 'domain_management',
     'update_dns_record': 'domain_management',
     'delete_dns_record': 'domain_management',
-    
+
     // 续期管理模块
     'get_renewable_domains': 'renewal_management',
     'check_domain_expiry': 'renewal_management',
     'get_expiry_alerts': 'renewal_management',
     'manual_renew_domain': 'renewal_management',
     'disable_domain_renewal': 'renewal_management',
-    
+
     // 日志查询模块
     'query_audit_logs': 'log_query',
     'get_audit_stats': 'log_query',
     'export_audit_logs': 'log_query',
-    
+
     // 故障转移模块
     'list_failover_rules': 'failover_management',
     'get_failover_config': 'failover_management',
@@ -251,7 +252,7 @@ export function getModuleByToolName(toolName: string): McpModule | null {
 
 /**
  * 计算 OAuth2 授权的实际权限范围
- * 
+ *
  * @param userId 用户ID
  * @param requestedScopes 请求的权限范围
  * @returns 实际授权的权限范围
@@ -269,7 +270,7 @@ export async function calculateOAuthScope(
 
     // 获取用户在该模块的实际权限
     const userPermission = await getUserModulePermission(userId, module as McpModule);
-    
+
     // 取请求权限和用户权限的最小值
     actualScopes[module as McpModule] = minPermission(
       requested as McpPermissionLevel,
@@ -291,7 +292,7 @@ function isValidModule(module: string): boolean {
     'log_query',
     'failover_management',
   ];
-  
+
   return validModules.includes(module as McpModule);
 }
 
@@ -325,7 +326,7 @@ export async function logMcpAction(data: {
     });
   } catch (error) {
     // 审计日志失败不应影响主流程
-    log.error('MCP Audit', 'Failed to log MCP action', { error, data });
+    log.error('Failed to log MCP action', { error, data });
   }
 }
 
@@ -335,7 +336,7 @@ export async function logMcpAction(data: {
 export async function trackApiKeyUsage(keyId: number, userId: number, ipAddress?: string): Promise<void> {
   try {
     await McpOperations.updateApiKeyLastUsed(keyId);
-    
+
     // 记录审计日志
     await logMcpAction({
       userId,
@@ -346,6 +347,6 @@ export async function trackApiKeyUsage(keyId: number, userId: number, ipAddress?
       ipAddress,
     });
   } catch (error) {
-    log.error('MCP Audit', 'Failed to track API key usage', { error, keyId });
+    log.error('Failed to track API key usage', { error, keyId });
   }
 }

--- a/server/src/service/mcpOAuthCleanupJob.ts
+++ b/server/src/service/mcpOAuthCleanupJob.ts
@@ -1,7 +1,8 @@
 import { McpOperations } from '../db/bal/business-adapter';
 import { taskManager } from './taskManager';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('Job').sub('McpOAuthCleanup');
 export function startMcpOAuthCleanupJob() {
   // 每 5 分钟清理一次超过 25 分钟仍未授权的临时客户端
   setInterval(async () => {
@@ -18,14 +19,14 @@ export function startMcpOAuthCleanupJob() {
         async () => {
           const deletedCount = await McpOperations.cleanupExpiredUnassignedClients();
           if (deletedCount > 0) {
-            log.info('MCP OAuth', `Cleaned up ${deletedCount} unassigned temporary clients (expired 10min)`);
+            log.info(`Cleaned up ${deletedCount} unassigned temporary clients (expired 10min)`);
           }
         }
       );
     } catch (err) {
-      log.error('MCP OAuth', 'Failed to cleanup expired unassigned clients', { error: err });
+      log.error('Failed to cleanup expired unassigned clients', { error: err });
     }
   }, 5 * 60 * 1000);
 
-  log.info('MCP OAuth', 'Temporary client cleanup job started (interval: 5min)');
+  log.info('Temporary client cleanup job started (interval: 5min)');
 }

--- a/server/src/service/notification.ts
+++ b/server/src/service/notification.ts
@@ -1,8 +1,9 @@
 import { SettingsOperations } from '../db/bal/business-adapter';
 import { sendSmtpEmail } from './smtp';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { fetchWithFallback } from '../lib/proxy-http';
 
+const log = createLogger('Notification');
 export interface NotificationChannel {
   id: string;
   type: 'webhook' | 'telegram' | 'dingtalk' | 'email';
@@ -30,31 +31,31 @@ async function withRetry<T>(
   maxRetries: number = RETRY_CONFIG.maxRetries
 ): Promise<T | null> {
   let lastError: Error | null = null;
-  
+
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       const result = await fn();
       if (attempt > 1) {
-        log.info('Notification', `Success for ${channelName} on attempt ${attempt}`);
+        log.info(`Success for ${channelName} on attempt ${attempt}`);
       }
       return result;
     } catch (error) {
       lastError = error as Error;
-      log.warn('Notification', `Attempt ${attempt}/${maxRetries} failed for ${channelName}`, { error: (error as Error).message });
-      
+      log.warn(`Attempt ${attempt}/${maxRetries} failed for ${channelName}`, { error: (error as Error).message });
+
       if (attempt < maxRetries) {
         // 指数退避策略
         const retryDelay = Math.min(
           RETRY_CONFIG.retryDelay * Math.pow(2, attempt - 1),
           RETRY_CONFIG.maxDelay
         );
-        log.info('Notification', `Retrying ${channelName} in ${retryDelay}ms...`);
+        log.info(`Retrying ${channelName} in ${retryDelay}ms...`);
         await delay(retryDelay);
       }
     }
   }
-  
-  log.error('Notification', `All ${maxRetries} attempts failed for ${channelName}`, { error: lastError });
+
+  log.error(`All ${maxRetries} attempts failed for ${channelName}`, { error: lastError });
   return null;
 }
 
@@ -102,7 +103,7 @@ export async function sendEmailToUser(
   htmlMessage?: string
 ): Promise<boolean> {
   if (!email) {
-    log.warn('Notification', 'Cannot send email: email address is empty');
+    log.warn('Cannot send email: email address is empty');
     return false;
   }
 
@@ -113,7 +114,7 @@ export async function sendEmailToUser(
     );
     return result !== null;
   } catch (error) {
-    log.warn('Notification', 'Failed to send email to user', { email, error });
+    log.warn('Failed to send email to user', { email, error });
     return false;
   }
 }
@@ -126,7 +127,7 @@ async function sendWebhookWithRetry(
 ): Promise<boolean> {
   const { url, method = 'POST', headers = {}, useProxy } = channel.config;
   if (!url) return false;
-  
+
   const result = await withRetry(
     () => fetchWithFallback(url, {
       method,
@@ -149,7 +150,7 @@ async function sendTelegramWithRetry(
 ): Promise<boolean> {
   const { botToken, chatId, useProxy } = channel.config;
   if (!botToken || !chatId) return false;
-  
+
   const text = `*${title}*\n\n${message}`;
   const result = await withRetry(
     () => fetchWithFallback(`https://api.telegram.org/bot${botToken}/sendMessage`, {
@@ -176,7 +177,7 @@ async function sendDingtalkWithRetry(
 ): Promise<boolean> {
   const { webhook, useProxy } = channel.config;
   if (!webhook) return false;
-  
+
   const result = await withRetry(
     () => fetchWithFallback(webhook, {
       method: 'POST',
@@ -200,18 +201,18 @@ async function sendDingtalkWithRetry(
 export async function sendNotification(title: string, message: string, htmlMessage?: string) {
   const channels = await getNotificationChannels();
   const enabledChannels = channels.filter(c => c.enabled);
-  
+
   if (enabledChannels.length === 0) {
-    log.info('Notification', 'No enabled channels found');
+    log.info('No enabled channels found');
     return;
   }
-  
+
   const results: { channel: string; success: boolean }[] = [];
-  
+
   for (const channel of enabledChannels) {
     try {
       let success = false;
-      
+
       switch (channel.type) {
         case 'email':
           success = await sendEmailWithRetry(channel, title, message, htmlMessage);
@@ -226,26 +227,26 @@ export async function sendNotification(title: string, message: string, htmlMessa
           success = await sendDingtalkWithRetry(channel, title, message);
           break;
         default:
-          log.warn('Notification', `Unknown channel type: ${channel.type}`);
+          log.warn(`Unknown channel type: ${channel.type}`);
       }
-      
+
       results.push({ channel: channel.name, success });
     } catch (e) {
-      log.error('Notification', `Unexpected error for ${channel.name} (${channel.type})`, { error: e });
+      log.error(`Unexpected error for ${channel.name} (${channel.type})`, { error: e });
       results.push({ channel: channel.name, success: false });
     }
   }
-  
+
   // 汇总通知结果
   const successCount = results.filter(r => r.success).length;
   const failCount = results.length - successCount;
-  
+
   if (failCount > 0) {
-    log.warn('Notification', `Summary: ${successCount} succeeded, ${failCount} failed`);
+    log.warn(`Summary: ${successCount} succeeded, ${failCount} failed`);
     results.filter(r => !r.success).forEach(r => {
-      log.warn('Notification', `Failed: ${r.channel}`);
+      log.warn(`Failed: ${r.channel}`);
     });
   } else {
-    log.info('Notification', `All ${successCount} channels succeeded`);
+    log.info(`All ${successCount} channels succeeded`);
   }
 }

--- a/server/src/service/nsMonitorJob.ts
+++ b/server/src/service/nsMonitorJob.ts
@@ -7,8 +7,9 @@ import { NSMonitorOperations, DomainOperations, AuditOperations, UserOperations,
 import { resolveNsRecords, getNsStatus, validateNsRecords } from '../lib/dns/ns-lookup';
 import { sendNotification, sendEmailToUser } from './notification';
 import { taskManager } from './taskManager';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('Job').sub('NsMonitor');
 let monitorInterval: NodeJS.Timeout | null = null;
 
 // 告警抑制配置：同一问题在30分钟内只发送一次通知
@@ -30,7 +31,7 @@ async function shouldSuppressAlert(monitorId: number, alertType: string, lastAle
 
     // 如果在抑制时间内，则抑制告警
     if (now - lastAlertTime < suppressTimeMs) {
-      log.info('NSMonitorJob', 'Alert suppressed (recent alert exists)', {
+      log.info('Alert suppressed (recent alert exists)', {
         monitorId,
         alertType,
         lastAlertAt,
@@ -41,7 +42,7 @@ async function shouldSuppressAlert(monitorId: number, alertType: string, lastAle
 
     return false;
   } catch (error) {
-    log.error('NSMonitorJob', 'Failed to check alert suppression', { monitorId, alertType, error });
+    log.error('Failed to check alert suppression', { monitorId, alertType, error });
     return false; // 出错时不抑制，确保告警能被发送
   }
 }
@@ -70,7 +71,7 @@ async function logNsAlertToAudit(
       'poisoned': 'DNS污染检测',
     };
     const alertTypeText = alertTypeMap[status] || 'NS异常';
-    
+
     const detailsObj: Record<string, unknown> = {
       domain: monitor.domain_name,
       alertType: status,
@@ -78,14 +79,14 @@ async function logNsAlertToAudit(
       expectedNs: expectedNs.join(', ') || '未配置',
       monitorId: monitor.id,
     };
-    
+
     // 添加DNS污染检测详情
     if (isPoisoned) {
       detailsObj.isPoisoned = true;
       detailsObj.encryptedNs = encryptedNs?.join(', ') || '无';
       detailsObj.plainNs = plainNs?.join(', ') || '无';
     }
-    
+
     const details = JSON.stringify(detailsObj);
 
     // 使用系统用户ID (0) 或者配置的创建者ID
@@ -99,14 +100,14 @@ async function logNsAlertToAudit(
       details: `${alertTypeText}: ${monitor.domain_name} - ${details}`,
     });
 
-    log.info('NSMonitorJob', 'NS alert logged to audit', {
+    log.info('NS alert logged to audit', {
       domain: monitor.domain_name,
       status,
       isPoisoned,
       userId,
     });
   } catch (error) {
-    log.error('NSMonitorJob', 'Failed to log NS alert to audit', { error });
+    log.error('Failed to log NS alert to audit', { error });
   }
 }
 
@@ -124,7 +125,7 @@ async function checkDomainNs(monitor: {
   last_alert_at: string | null;
 }): Promise<void> {
   try {
-    log.info('NSMonitorJob', 'Checking NS records', { domain: monitor.domain_name, monitorId: monitor.id });
+    log.info('Checking NS records', { domain: monitor.domain_name, monitorId: monitor.id });
 
     // 查询当前 NS 记录（带DNS污染检测）
     const nsResult = await resolveNsRecords(monitor.domain_name);
@@ -165,7 +166,7 @@ async function checkDomainNs(monitor: {
 
     // 如果状态异常且与上次不同，发送告警
     if (status !== 'ok' && monitor.status !== status) {
-      log.warn('NSMonitorJob', 'NS record anomaly detected', {
+      log.warn('NS record anomaly detected', {
         domain: monitor.domain_name,
         status,
         isPoisoned: nsResult.isPoisoned,
@@ -194,14 +195,14 @@ async function checkDomainNs(monitor: {
       }
     }
 
-    log.info('NSMonitorJob', 'NS check completed', {
+    log.info('NS check completed', {
       domain: monitor.domain_name,
       status,
       isPoisoned: nsResult.isPoisoned,
       currentNs: currentNsStr,
     });
   } catch (error) {
-    log.error('NSMonitorJob', 'Failed to check NS records', {
+    log.error('Failed to check NS records', {
       domain: monitor.domain_name,
       error,
     });
@@ -237,14 +238,14 @@ async function sendNsAlert(
     `告警类型: ${alertTypeText}\n` +
     `当前 NS: ${currentNs.join(', ') || '无'}\n` +
     `预期 NS: ${expectedNs.join(', ') || '未配置'}\n`;
-  
+
   // 添加DNS污染检测详情
   if (isPoisoned && encryptedNs && plainNs) {
     message += `加密 DNS 结果: ${encryptedNs.join(', ') || '无'}\n` +
       `明文 DNS 结果: ${plainNs.join(', ') || '无'}\n` +
       `⚠️ 警告: 加密DNS与明文DNS查询结果不一致，可能存在DNS污染!\n`;
   }
-  
+
   message += `时间: ${new Date().toLocaleString('zh-CN')}`;
 
   try {
@@ -279,7 +280,7 @@ async function sendNsAlert(
         if (user && user.email) {
           const emailSent = await sendEmailToUser(user.email as string, title, plainMessage, plainMessage);
           if (emailSent) {
-            log.info('NSMonitorJob', 'Email notification sent to user', {
+            log.info('Email notification sent to user', {
               domain: monitor.domain_name,
               userId,
               email: user.email,
@@ -287,20 +288,20 @@ async function sendNsAlert(
               isPoisoned,
             });
           } else {
-            log.warn('NSMonitorJob', 'Failed to send email notification to user', {
+            log.warn('Failed to send email notification to user', {
               domain: monitor.domain_name,
               userId,
               email: user.email,
             });
           }
         } else {
-          log.warn('NSMonitorJob', 'User has no email configured, skipping email notification', {
+          log.warn('User has no email configured, skipping email notification', {
             domain: monitor.domain_name,
             userId,
           });
         }
       } catch (emailError) {
-        log.warn('NSMonitorJob', 'Error sending email to user', {
+        log.warn('Error sending email to user', {
           domain: monitor.domain_name,
           userId,
           error: emailError,
@@ -312,14 +313,14 @@ async function sendNsAlert(
     if (shouldSendChannels) {
       try {
         await sendNotification(title, plainMessage, plainMessage);
-        log.info('NSMonitorJob', 'Channel notification sent', {
+        log.info('Channel notification sent', {
           domain: monitor.domain_name,
           status,
           isPoisoned,
           userId,
         });
       } catch (channelError) {
-        log.warn('NSMonitorJob', 'Error sending channel notification', {
+        log.warn('Error sending channel notification', {
           domain: monitor.domain_name,
           userId,
           error: channelError,
@@ -328,13 +329,13 @@ async function sendNsAlert(
     }
 
     if (!shouldSendEmail && !shouldSendChannels) {
-      log.info('NSMonitorJob', 'Notification skipped (disabled in user preferences)', {
+      log.info('Notification skipped (disabled in user preferences)', {
         domain: monitor.domain_name,
         userId,
       });
     }
   } catch (error) {
-    log.error('NSMonitorJob', 'Failed to send alert notification', {
+    log.error('Failed to send alert notification', {
       domain: monitor.domain_name,
       error,
     });
@@ -346,7 +347,7 @@ async function sendNsAlert(
  */
 async function runNsMonitorJob(): Promise<void> {
   try {
-    log.info('NSMonitorJob', 'Starting NS monitor job');
+    log.info('Starting NS monitor job');
 
     // 获取所有启用的监测配置
     const monitors = await NSMonitorOperations.getAllEnabled() as unknown as Array<{
@@ -361,11 +362,11 @@ async function runNsMonitorJob(): Promise<void> {
     }>;
 
     if (monitors.length === 0) {
-      log.info('NSMonitorJob', 'No enabled NS monitor configurations');
+      log.info('No enabled NS monitor configurations');
       return;
     }
 
-    log.info('NSMonitorJob', `Checking ${monitors.length} domains`);
+    log.info(`Checking ${monitors.length} domains`);
 
     // 使用任务管理器并发检查（最多同时5个）
     const tasks = monitors.map(monitor => {
@@ -387,9 +388,9 @@ async function runNsMonitorJob(): Promise<void> {
     // 等待所有任务完成
     await Promise.all(tasks);
 
-    log.info('NSMonitorJob', 'NS monitor job completed');
+    log.info('NS monitor job completed');
   } catch (error) {
-    log.error('NSMonitorJob', 'NS monitor job failed', { error });
+    log.error('NS monitor job failed', { error });
   }
 }
 
@@ -398,14 +399,14 @@ async function runNsMonitorJob(): Promise<void> {
  */
 export function startNsMonitorJob(): void {
   if (monitorInterval) {
-    log.warn('NSMonitorJob', 'NS monitor job already started');
+    log.warn('NS monitor job already started');
     return;
   }
 
   // 每 5 分钟检查一次
   monitorInterval = setInterval(runNsMonitorJob, 5 * 60 * 1000);
 
-  log.info('NSMonitorJob', 'NS monitor job started (interval: 5 minutes)');
+  log.info('NS monitor job started (interval: 5 minutes)');
 
   // 立即执行一次
   runNsMonitorJob();
@@ -418,7 +419,7 @@ export function stopNsMonitorJob(): void {
   if (monitorInterval) {
     clearInterval(monitorInterval);
     monitorInterval = null;
-    log.info('NSMonitorJob', 'NS monitor job stopped');
+    log.info('NS monitor job stopped');
   }
 }
 

--- a/server/src/service/recordCountCache.ts
+++ b/server/src/service/recordCountCache.ts
@@ -1,29 +1,30 @@
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { DomainOperations, DnsAccountOperations } from '../db/bal/business-adapter';
 import { taskManager } from './taskManager';
 import { createAdapter } from '../lib/dns/DnsHelper';
 import { Domain, DnsAccount } from '../types';
 
+const log = createLogger('RecordCountCache');
 /**
  * 刷新单个域名的记录数缓存
  */
 async function refreshDomainRecordCount(domain: Domain, account: DnsAccount): Promise<void> {
   try {
     // MySQL JSON type returns object directly, SQLite/PostgreSQL returns string
-    const cfg = typeof account.config === 'string' 
-      ? JSON.parse(account.config) as Record<string, string> 
+    const cfg = typeof account.config === 'string'
+      ? JSON.parse(account.config) as Record<string, string>
       : account.config as Record<string, string>;
-    
+
     const dnsAdapter = createAdapter(account.type, cfg, domain.name, domain.third_id);
     const result = await dnsAdapter.getDomainRecords(1, 10);
-    
+
     if (result.total !== domain.record_count) {
       await DomainOperations.updateRecordCount(domain.id, result.total);
-      log.info('RecordCountCache', `Updated record count for ${domain.name}: ${domain.record_count} -> ${result.total}`);
+      log.info(`Updated record count for ${domain.name}: ${domain.record_count} -> ${result.total}`);
     }
   } catch (error) {
-    log.warn('RecordCountCache', `Failed to refresh record count for ${domain.name}`, { 
-      error: error instanceof Error ? error.message : String(error) 
+    log.warn(`Failed to refresh record count for ${domain.name}`, {
+      error: error instanceof Error ? error.message : String(error)
     });
   }
 }
@@ -33,24 +34,24 @@ async function refreshDomainRecordCount(domain: Domain, account: DnsAccount): Pr
  * 使用串行处理避免同时发起大量请求
  */
 export async function refreshAllDomainRecordCounts(): Promise<void> {
-  log.info('RecordCountCache', 'Starting record count cache refresh');
-  
+  log.info('Starting record count cache refresh');
+
   try {
     // 获取所有域名
     const domains = await DomainOperations.getAll() as unknown as Domain[];
-    
+
     if (domains.length === 0) {
-      log.info('RecordCountCache', 'No domains to refresh');
+      log.info('No domains to refresh');
       return;
     }
-    
-    log.info('RecordCountCache', `Found ${domains.length} domains to refresh`);
-    
+
+    log.info(`Found ${domains.length} domains to refresh`);
+
     // 按账号分组，减少重复获取账号信息
     const accountCache = new Map<number, DnsAccount>();
     let successCount = 0;
     let failCount = 0;
-    
+
     // 串行处理，避免并发过多请求
     for (const domain of domains) {
       // 获取或缓存账号信息
@@ -58,27 +59,27 @@ export async function refreshAllDomainRecordCounts(): Promise<void> {
       if (!account) {
         account = await DnsAccountOperations.getById(domain.account_id) as DnsAccount | undefined;
         if (!account) {
-          log.warn('RecordCountCache', `Account not found for domain ${domain.name} (id: ${domain.account_id})`);
+          log.warn(`Account not found for domain ${domain.name} (id: ${domain.account_id})`);
           failCount++;
           continue;
         }
         accountCache.set(domain.account_id, account);
       }
-      
+
       // 刷新该域名的记录数
       await refreshDomainRecordCount(domain, account);
       successCount++;
-      
+
       // 每处理 10 个域名后稍作延迟，避免请求过快
       if (successCount % 10 === 0) {
         await new Promise(resolve => setTimeout(resolve, 1000));
       }
     }
-    
-    log.info('RecordCountCache', `Cache refresh completed: ${successCount} succeeded, ${failCount} failed`);
+
+    log.info(`Cache refresh completed: ${successCount} succeeded, ${failCount} failed`);
   } catch (error) {
-    log.error('RecordCountCache', 'Failed to refresh record count cache', { 
-      error: error instanceof Error ? error.message : String(error) 
+    log.error('Failed to refresh record count cache', {
+      error: error instanceof Error ? error.message : String(error)
     });
   }
 }
@@ -89,9 +90,9 @@ export async function refreshAllDomainRecordCounts(): Promise<void> {
  */
 export function startRecordCountCacheRefresh(intervalMinutes: number = 30): void {
   const intervalMs = intervalMinutes * 60 * 1000;
-  
-  log.info('RecordCountCache', `Starting periodic cache refresh (interval: ${intervalMinutes} minutes)`);
-  
+
+  log.info(`Starting periodic cache refresh (interval: ${intervalMinutes} minutes)`);
+
   // 立即执行一次（高优先级）
   taskManager.submit(
     {
@@ -105,9 +106,9 @@ export function startRecordCountCacheRefresh(intervalMinutes: number = 30): void
     },
     refreshAllDomainRecordCounts
   ).catch(err => {
-    log.error('RecordCountCache', 'Initial cache refresh failed', { error: err });
+    log.error('Initial cache refresh failed', { error: err });
   });
-  
+
   // 设置定时任务（高优先级）
   setInterval(() => {
     taskManager.submit(
@@ -122,7 +123,7 @@ export function startRecordCountCacheRefresh(intervalMinutes: number = 30): void
       },
       refreshAllDomainRecordCounts
     ).catch(err => {
-      log.error('RecordCountCache', 'Periodic cache refresh failed', { error: err });
+      log.error('Periodic cache refresh failed', { error: err });
     });
   }, intervalMs);
 }

--- a/server/src/service/securityPolicy.ts
+++ b/server/src/service/securityPolicy.ts
@@ -4,8 +4,9 @@
  */
 
 import { SecurityPolicyOperations } from '../db/bal/business-adapter';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('Security').sub('SecurityPolicy');
 // zxcvbn 是 CommonJS 模块，需要这样导入
 import zxcvbn from 'zxcvbn';
 
@@ -75,10 +76,10 @@ export async function initSecurityPolicyTable(): Promise<void> {
         DEFAULT_POLICY.trustedDeviceDays,
         DEFAULT_POLICY.requirePasswordChangeOnFirstLogin ? 1 : 0,
       ]);
-      log.info('SecurityPolicy', 'Initialized default security policy');
+      log.info('Initialized default security policy');
     }
   } catch (error) {
-    log.error('SecurityPolicy', 'Failed to init table:', { error });
+    log.error('Failed to init table:', { error });
     throw error;
   }
 }
@@ -102,7 +103,7 @@ export async function getSecurityPolicy(): Promise<SecurityPolicy> {
       requirePasswordChangeOnFirstLogin: Boolean(row.requirePasswordChangeOnFirstLogin),
     } as SecurityPolicy;
   } catch (error) {
-    log.error('SecurityPolicy', 'Failed to get policy:', { error });
+    log.error('Failed to get policy:', { error });
     return DEFAULT_POLICY;
   }
 }
@@ -146,7 +147,7 @@ export async function updateSecurityPolicy(policy: Partial<SecurityPolicy>): Pro
 
   await SecurityPolicyOperations.updatePolicy(updates, current.id!);
 
-  log.info('SecurityPolicy', 'Policy updated', policy);
+  log.info('Policy updated', policy);
 }
 
 /**

--- a/server/src/service/smtp.ts
+++ b/server/src/service/smtp.ts
@@ -1,8 +1,9 @@
 import net from 'net';
 import tls from 'tls';
 import { SmtpOperations, getDbType } from '../db/bal/business-adapter';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('Smtp');
 export interface SmtpConfig {
   enabled: boolean;
   host: string;
@@ -90,7 +91,7 @@ async function sendRawSmtpMail(config: SmtpConfig, to: string, subject: string, 
   const timeoutMs = Number(process.env.SMTP_TIMEOUT_MS || 15000);
   const useImplicitTls = config.secure || config.port === 465;
 
-  log.info('SMTP', 'Connecting to SMTP server', {
+  log.info('Connecting to SMTP server', {
     host: config.host,
     port: config.port,
     secure: config.secure,
@@ -104,9 +105,9 @@ async function sendRawSmtpMail(config: SmtpConfig, to: string, subject: string, 
     socket = useImplicitTls
       ? tls.connect({ host: config.host, port: config.port, servername: config.host })
       : net.connect({ host: config.host, port: config.port });
-    log.info('SMTP', 'Socket created');
+    log.info('Socket created');
   } catch (e) {
-    log.error('SMTP', 'Failed to create socket', { error: e instanceof Error ? e.message : String(e) });
+    log.error('Failed to create socket', { error: e instanceof Error ? e.message : String(e) });
     throw e;
   }
 
@@ -167,49 +168,49 @@ async function sendRawSmtpMail(config: SmtpConfig, to: string, subject: string, 
   };
 
   const sendCmd = async (command: string, expectedPrefix?: string | string[]): Promise<string> => {
-    log.debug('SMTP', 'Sending command', { command: command.substring(0, 50) });
+    log.debug('Sending command', { command: command.substring(0, 50) });
     socket.write(command + '\r\n');
     const response = await waitForCode(expectedPrefix);
-    log.debug('SMTP', 'Got response', { response: response.substring(0, 100) });
+    log.debug('Got response', { response: response.substring(0, 100) });
     return response;
   };
 
   try {
-    log.info('SMTP', 'Waiting for 220 greeting...');
+    log.info('Waiting for 220 greeting...');
     await waitForCode('220');
-    log.info('SMTP', 'Got 220 greeting');
+    log.info('Got 220 greeting');
 
     let ehloResp = await sendCmd('EHLO hidns.local', '250');
-    log.info('SMTP', 'EHLO response received');
+    log.info('EHLO response received');
 
     // If server supports STARTTLS, upgrade plaintext connection before AUTH/MAIL.
     if (!useImplicitTls && /(^|\r?\n)250[ -].*STARTTLS/i.test(ehloResp)) {
-      log.info('SMTP', 'Server supports STARTTLS, upgrading connection...');
+      log.info('Server supports STARTTLS, upgrading connection...');
       await sendCmd('STARTTLS', '220');
       socket = await new Promise<tls.TLSSocket>((resolve, reject) => {
         const tlsSocket = tls.connect({ socket, servername: config.host }, () => resolve(tlsSocket));
         tlsSocket.once('error', reject);
       });
-      log.info('SMTP', 'STARTTLS upgrade complete');
+      log.info('STARTTLS upgrade complete');
       ehloResp = await sendCmd('EHLO hidns.local', '250');
     }
 
     if (config.username && config.password) {
-      log.info('SMTP', 'Authenticating...');
+      log.info('Authenticating...');
       await sendCmd('AUTH LOGIN', '334');
       await sendCmd(Buffer.from(config.username).toString('base64'), '334');
       await sendCmd(Buffer.from(config.password).toString('base64'), '235');
-      log.info('SMTP', 'Authentication successful');
+      log.info('Authentication successful');
     }
 
-    log.info('SMTP', 'Sending MAIL FROM...');
+    log.info('Sending MAIL FROM...');
     await sendCmd(`MAIL FROM:<${config.fromEmail}>`, '250');
-    log.info('SMTP', 'Sending RCPT TO...');
+    log.info('Sending RCPT TO...');
     await sendCmd(`RCPT TO:<${to}>`, ['250', '251']);
-    log.info('SMTP', 'Sending DATA...');
+    log.info('Sending DATA...');
     await sendCmd('DATA', '354');
   } catch (e) {
-    log.error('SMTP', 'SMTP command failed', { error: e instanceof Error ? e.message : String(e) });
+    log.error('SMTP command failed', { error: e instanceof Error ? e.message : String(e) });
     throw e;
   }
 
@@ -228,24 +229,24 @@ async function sendRawSmtpMail(config: SmtpConfig, to: string, subject: string, 
 }
 
 export async function sendSmtpEmail(to: string, subject: string, text: string): Promise<void> {
-  log.info('SMTP', 'Preparing to send email', { to, subject });
+  log.info('Preparing to send email', { to, subject });
   const config = await getSmtpConfig();
-  log.debug('SMTP', 'SMTP config loaded', { 
-    host: config.host, 
+  log.debug('SMTP config loaded', {
+    host: config.host,
     port: config.port,
     enabled: config.enabled,
     secure: config.secure,
     hasAuth: !!(config.username && config.password)
   });
   if (!config.enabled) {
-    log.error('SMTP', 'SMTP is not enabled in configuration');
+    log.error('SMTP is not enabled in configuration');
     throw new Error('SMTP is not enabled');
   }
   try {
     await sendRawSmtpMail(config, to, subject, text);
-    log.info('SMTP', 'Email sent successfully', { to });
+    log.info('Email sent successfully', { to });
   } catch (error) {
-    log.error('SMTP', 'Failed to send raw SMTP mail', { 
+    log.error('Failed to send raw SMTP mail', {
       error: error instanceof Error ? error.message : String(error),
       to,
       host: config.host,

--- a/server/src/service/taskManager.ts
+++ b/server/src/service/taskManager.ts
@@ -3,8 +3,9 @@
  * 实现任务队列、并发控制和执行调度，避免多个任务同时执行导致系统卡顿
  */
 
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('Job').sub('TaskManager');
 export type TaskStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
 
 export type TaskPriority = 'low' | 'normal' | 'high' | 'critical';
@@ -57,7 +58,7 @@ class TaskManager {
    */
   setMaxConcurrentTasks(max: number): void {
     this.maxConcurrentTasks = max;
-    log.info('TaskManager', `Max concurrent tasks set to ${max}`);
+    log.info(`Max concurrent tasks set to ${max}`);
     this.processQueue();
   }
 
@@ -98,8 +99,8 @@ class TaskManager {
 
       // 根据优先级插入队列（高优先级插队）
       this.insertTaskByPriority(queuedTask);
-      
-      log.debug('TaskManager', `Task queued: ${options.name} (${options.id})`, {
+
+      log.debug(`Task queued: ${options.name} (${options.id})`, {
         queueLength: this.taskQueue.length,
         priority: options.priority || 'normal',
       });
@@ -114,7 +115,7 @@ class TaskManager {
    */
   private insertTaskByPriority(task: QueuedTask): void {
     const priorityValue = this.getPriorityValue(task.options.priority || 'normal');
-    
+
     // 找到第一个优先级低于当前任务的位置
     let insertIndex = this.taskQueue.length;
     for (let i = 0; i < this.taskQueue.length; i++) {
@@ -124,12 +125,12 @@ class TaskManager {
         break;
       }
     }
-    
+
     // 插入到合适的位置
     this.taskQueue.splice(insertIndex, 0, task);
-    
+
     if (insertIndex < this.taskQueue.length - 1) {
-      log.info('TaskManager', `High priority task inserted at position ${insertIndex}: ${task.options.name}`, {
+      log.info(`High priority task inserted at position ${insertIndex}: ${task.options.name}`, {
         priority: task.options.priority,
       });
     }
@@ -176,7 +177,7 @@ class TaskManager {
 
     // 检查是否已有相同ID的任务在运行
     if (this.runningTasks.has(taskId)) {
-      log.warn('TaskManager', `Task already running, re-queuing: ${options.name}`, { taskId });
+      log.warn(`Task already running, re-queuing: ${options.name}`, { taskId });
       this.taskQueue.unshift(queuedTask);
       return;
     }
@@ -190,7 +191,7 @@ class TaskManager {
     };
 
     this.runningTasks.set(taskId, taskInfo);
-    log.info('TaskManager', `Task started: ${options.name}`, {
+    log.info(`Task started: ${options.name}`, {
       taskId,
       runningCount: this.runningTasks.size,
       queuedCount: this.taskQueue.length,
@@ -221,7 +222,7 @@ class TaskManager {
       taskInfo.endTime = Date.now();
       taskInfo.duration = taskInfo.endTime - taskInfo.startTime!;
 
-      log.info('TaskManager', `Task completed: ${options.name}`, {
+      log.info(`Task completed: ${options.name}`, {
         taskId,
         duration: taskInfo.duration,
       });
@@ -229,12 +230,12 @@ class TaskManager {
       resolve();
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
-      
+
       // 重试逻辑
       const maxRetries = options.retries || 0;
       if (attempts < maxRetries) {
         const retryDelay = options.retryDelay || 1000;
-        log.warn('TaskManager', `Task failed, retrying (${attempts + 1}/${maxRetries}): ${options.name}`, {
+        log.warn(`Task failed, retrying (${attempts + 1}/${maxRetries}): ${options.name}`, {
           taskId,
           error: err.message,
           retryDelay,
@@ -255,7 +256,7 @@ class TaskManager {
         taskInfo.duration = taskInfo.endTime - taskInfo.startTime!;
         taskInfo.error = err;
 
-        log.error('TaskManager', `Task failed: ${options.name}`, {
+        log.error(`Task failed: ${options.name}`, {
           taskId,
           attempts: attempts + 1,
           error: err.message,
@@ -266,7 +267,7 @@ class TaskManager {
     } finally {
       // 移除运行中的任务
       this.runningTasks.delete(taskId);
-      
+
       // 继续处理队列
       this.processQueue();
     }
@@ -281,13 +282,13 @@ class TaskManager {
     if (index !== -1) {
       const removed = this.taskQueue.splice(index, 1)[0];
       removed.reject(new Error('Task cancelled'));
-      log.info('TaskManager', `Task cancelled from queue: ${removed.options.name}`, { taskId });
+      log.info(`Task cancelled from queue: ${removed.options.name}`, { taskId });
       return true;
     }
 
     // 无法取消正在运行的任务，只能标记
     if (this.runningTasks.has(taskId)) {
-      log.warn('TaskManager', `Cannot cancel running task, it will complete: ${taskId}`);
+      log.warn(`Cannot cancel running task, it will complete: ${taskId}`);
       return false;
     }
 
@@ -303,7 +304,7 @@ class TaskManager {
       task.reject(new Error('Queue cleared'));
     });
     this.taskQueue = [];
-    log.info('TaskManager', `Queue cleared, removed ${count} tasks`);
+    log.info(`Queue cleared, removed ${count} tasks`);
   }
 
   /**

--- a/server/src/service/websocket.ts
+++ b/server/src/service/websocket.ts
@@ -7,12 +7,13 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { IncomingMessage } from 'http';
 import jwt from 'jsonwebtoken';
 import { verifyToken } from './token';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 import { getClientIP } from '../middleware/clientIP';
 import { JwtPayload } from '../types';
 import { TokenPayload } from '../types/token';
 import crypto from 'crypto';
 
+const log = createLogger('Websocket');
 // JWT密钥配置
 const BASE_JWT_SECRET = process.env.JWT_SECRET || crypto.randomBytes(32).toString('hex');
 const RUNTIME_SECRET_KEY = 'jwt_runtime';
@@ -20,7 +21,7 @@ let runtimeSecretCache: string | null = null;
 
 async function getRuntimeSecret(): Promise<string> {
   if (runtimeSecretCache) return runtimeSecretCache;
-  
+
   try {
     const { SecretOperations } = await import('../db/bal/business-adapter');
     const value = await SecretOperations.getRuntimeSecret(RUNTIME_SECRET_KEY);
@@ -31,7 +32,7 @@ async function getRuntimeSecret(): Promise<string> {
   } catch {
     // Table might not exist
   }
-  
+
   return crypto.randomBytes(32).toString('hex');
 }
 
@@ -60,7 +61,7 @@ class WSService {
    * 初始化 WebSocket 服务器
    */
   initialize(server: any): void {
-    this.wss = new WebSocketServer({ 
+    this.wss = new WebSocketServer({
       server,
       path: '/api/socket/ws',
       maxPayload: 1024 * 1024, // 1MB
@@ -71,13 +72,13 @@ class WSService {
     });
 
     this.wss.on('error', (error: Error) => {
-      log.error('WSService', 'WebSocket server error', { error: error.message });
+      log.error('WebSocket server error', { error: error.message });
     });
 
     // 启动心跳检测
     this.startHeartbeat();
 
-    log.info('WSService', 'WebSocket server initialized on /api/socket/ws');
+    log.info('WebSocket server initialized on /api/socket/ws');
   }
 
   /**
@@ -86,16 +87,16 @@ class WSService {
   private async handleConnection(ws: WebSocket, req: IncomingMessage): Promise<void> {
     // 使用 getClientIP 获取真实客户端 IP（支持反向代理）
     const clientIp = getClientIP(req as any);
-    log.info('WSService', 'New WebSocket connection attempt', { ip: clientIp });
-    
+    log.info('New WebSocket connection attempt', { ip: clientIp });
+
     try {
       // 从 URL 参数或 Cookie 中获取 token
       const url = new URL(req.url || '', `http://${req.headers.host}`);
-      const token = url.searchParams.get('token') || 
+      const token = url.searchParams.get('token') ||
                     req.headers.cookie?.match(/token=([^;]+)/)?.[1];
 
       if (!token) {
-        log.warn('WSService', 'WebSocket connection rejected: no token', { ip: clientIp });
+        log.warn('WebSocket connection rejected: no token', { ip: clientIp });
         ws.close(4001, 'Authentication required');
         return;
       }
@@ -111,25 +112,25 @@ class WSService {
         userId = payload.userId;
         role = String(payload.role);
         authType = 'jwt';
-        log.info('WSService', 'JWT authentication successful', { userId, role, ip: clientIp });
+        log.info('JWT authentication successful', { userId, role, ip: clientIp });
       } catch (jwtError) {
         // JWT 验证失败，尝试验证为 API Token
         const tokenPayload = await verifyToken(token);
         if (!tokenPayload) {
-          log.warn('WSService', 'WebSocket connection rejected: invalid token', { ip: clientIp });
+          log.warn('WebSocket connection rejected: invalid token', { ip: clientIp });
           ws.close(4002, 'Invalid token');
           return;
         }
         userId = tokenPayload.userId;
         role = String(tokenPayload.maxRole);
         authType = 'api';
-        log.info('WSService', 'API token authentication successful', { userId, role, ip: clientIp });
+        log.info('API token authentication successful', { userId, role, ip: clientIp });
       }
 
       // 如果已存在连接，关闭旧连接
       const existingClient = this.clients.get(userId);
       if (existingClient) {
-        log.info('WSService', 'Closing existing WebSocket connection', { userId });
+        log.info('Closing existing WebSocket connection', { userId });
         existingClient.ws.close(4000, 'New connection established');
       }
 
@@ -146,11 +147,11 @@ class WSService {
 
       this.clients.set(userId, client);
 
-      log.info('WSService', 'WebSocket client connected', { 
-        userId, 
+      log.info('WebSocket client connected', {
+        userId,
         role,
         authType,
-        totalClients: this.clients.size 
+        totalClients: this.clients.size
       });
 
       // 发送欢迎消息
@@ -171,9 +172,9 @@ class WSService {
 
       // 处理错误
       ws.on('error', (error: Error) => {
-        log.error('WSService', 'WebSocket client error', { 
-          userId, 
-          error: error.message 
+        log.error('WebSocket client error', {
+          userId,
+          error: error.message
         });
         this.handleDisconnect(userId);
       });
@@ -187,8 +188,8 @@ class WSService {
       });
 
     } catch (error) {
-      log.error('WSService', 'WebSocket connection error', { 
-        error: error instanceof Error ? error.message : String(error) 
+      log.error('WebSocket connection error', {
+        error: error instanceof Error ? error.message : String(error)
       });
       ws.close(4003, 'Internal server error');
     }
@@ -215,9 +216,9 @@ class WSService {
     // Check rate limit
     client.messageCount++;
     if (client.messageCount > MAX_MESSAGES_PER_WINDOW) {
-      log.warn('WSService', 'Rate limit exceeded, closing connection', { 
-        userId, 
-        messageCount: client.messageCount 
+      log.warn('Rate limit exceeded, closing connection', {
+        userId,
+        messageCount: client.messageCount
       });
       client.ws.close(4004, 'Rate limit exceeded');
       return;
@@ -227,14 +228,14 @@ class WSService {
 
     try {
       const data = JSON.parse(message);
-      log.debug('WSService', 'Received message from client', { userId, type: data.type });
+      log.debug('Received message from client', { userId, type: data.type });
 
       // Limit message size to 64KB
       if (message.length > 64 * 1024) {
-        log.warn('WSService', 'Message too large', { userId, size: message.length });
-        this.sendToClient(userId, { 
-          type: 'error', 
-          data: { message: 'Message too large (max 64KB)' } 
+        log.warn('Message too large', { userId, size: message.length });
+        this.sendToClient(userId, {
+          type: 'error',
+          data: { message: 'Message too large (max 64KB)' }
         });
         return;
       }
@@ -245,12 +246,12 @@ class WSService {
           this.sendToClient(userId, { type: 'pong' });
           break;
         default:
-          log.warn('WSService', 'Unknown message type', { userId, type: data.type });
+          log.warn('Unknown message type', { userId, type: data.type });
       }
     } catch (error) {
-      log.error('WSService', 'Failed to parse message', { 
-        userId, 
-        error: error instanceof Error ? error.message : String(error) 
+      log.error('Failed to parse message', {
+        userId,
+        error: error instanceof Error ? error.message : String(error)
       });
     }
   }
@@ -262,9 +263,9 @@ class WSService {
     const client = this.clients.get(userId);
     if (client) {
       this.clients.delete(userId);
-      log.info('WSService', 'WebSocket client disconnected', { 
+      log.info('WebSocket client disconnected', {
         userId,
-        totalClients: this.clients.size 
+        totalClients: this.clients.size
       });
     }
   }
@@ -276,7 +277,7 @@ class WSService {
     this.heartbeatInterval = setInterval(() => {
       this.clients.forEach((client, userId) => {
         if (!client.isAlive) {
-          log.warn('WSService', 'Client failed heartbeat, disconnecting', { userId });
+          log.warn('Client failed heartbeat, disconnecting', { userId });
           client.ws.terminate();
           this.clients.delete(userId);
           return;
@@ -301,9 +302,9 @@ class WSService {
       client.ws.send(JSON.stringify(message));
       return true;
     } catch (error) {
-      log.error('WSService', 'Failed to send message to client', { 
-        userId, 
-        error: error instanceof Error ? error.message : String(error) 
+      log.error('Failed to send message to client', {
+        userId,
+        error: error instanceof Error ? error.message : String(error)
       });
       return false;
     }
@@ -319,9 +320,9 @@ class WSService {
         try {
           client.ws.send(data);
         } catch (error) {
-          log.error('WSService', 'Failed to broadcast to client', { 
-            userId, 
-            error: error instanceof Error ? error.message : String(error) 
+          log.error('Failed to broadcast to client', {
+            userId,
+            error: error instanceof Error ? error.message : String(error)
           });
         }
       }
@@ -338,10 +339,10 @@ class WSService {
         try {
           client.ws.send(data);
         } catch (error) {
-          log.error('WSService', 'Failed to broadcast to role', { 
-            userId, 
+          log.error('Failed to broadcast to role', {
+            userId,
             role,
-            error: error instanceof Error ? error.message : String(error) 
+            error: error instanceof Error ? error.message : String(error)
           });
         }
       }
@@ -358,7 +359,7 @@ class WSService {
         const data = JSON.stringify(message);
         client.ws.send(data);
       } catch (error) {
-        log.error('WSService', 'Failed to send message to user', {
+        log.error('Failed to send message to user', {
           userId,
           error: error instanceof Error ? error.message : String(error)
         });
@@ -385,7 +386,7 @@ class WSService {
       this.wss = null;
     }
 
-    log.info('WSService', 'WebSocket server shut down');
+    log.info('WebSocket server shut down');
   }
 
   /**

--- a/server/src/service/whois/cache.ts
+++ b/server/src/service/whois/cache.ts
@@ -1,13 +1,14 @@
 /**
  * WHOIS 缓存管理
- * 
+ *
  * 负责 WHOIS 结果的数据库缓存读写
  */
 
 import { WhoisOperations } from '../../db/bal/business-adapter';
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 import { extractStatus } from './data-parser';
 
+const log = createLogger('WhoisService').sub('Cache');
 // WHOIS 数据库缓存配置
 const CACHE_TTL = 3 * 60 * 60 * 1000; // 3 小时
 const CACHE_TTL_SECONDS = Math.floor(CACHE_TTL / 1000);
@@ -44,10 +45,10 @@ function formatDateForMySQL(date: Date): string {
 export async function getCachedWhois(domain: string): Promise<WhoisResult | null> {
   try {
     const row = await WhoisOperations.getCachedWhois(domain, CACHE_TTL_SECONDS);
-    
+
     if (row) {
-      log.debug('WhoisCache', `Cache hit for ${domain}`);
-      
+      log.debug(`Cache hit for ${domain}`);
+
       let whoisData: Record<string, unknown> = {};
       try {
         const rawWhoisData = (row as any).whois_data;
@@ -59,7 +60,7 @@ export async function getCachedWhois(domain: string): Promise<WhoisResult | null
       } catch {
         whoisData = {};
       }
-      
+
       const cached: WhoisResult = {
         domain: domain,
         expiryDate: whoisData.expiryDate ? new Date(whoisData.expiryDate as string) : null,
@@ -69,21 +70,21 @@ export async function getCachedWhois(domain: string): Promise<WhoisResult | null
         raw: (whoisData.raw as string) || '',
         status: (row as any).status || null,
       };
-      
+
       // 如果缓存中没有 status，尝试从 raw_data 中解析
       if (!cached.status && cached.raw) {
         cached.status = extractStatus(cached.raw);
         if (cached.status) {
-          log.info('WhoisCache', `Parsed status from cache for ${domain}: ${cached.status}`);
+          log.info(`Parsed status from cache for ${domain}: ${cached.status}`);
         }
       }
-      
+
       return cached;
     }
-    
+
     return null;
   } catch (error) {
-    log.error('WhoisCache', 'Failed to get cached WHOIS', { domain, error });
+    log.error('Failed to get cached WHOIS', { domain, error });
     return null;
   }
 }
@@ -102,8 +103,8 @@ export async function setCachedWhois(domain: string, result: WhoisResult): Promi
       result.raw || '',
       result.status || null
     );
-    log.debug('WhoisCache', `Cached WHOIS result for ${domain}`, { status: result.status });
+    log.debug(`Cached WHOIS result for ${domain}`, { status: result.status });
   } catch (error) {
-    log.error('WhoisCache', 'Failed to cache WHOIS result', { domain, error });
+    log.error('Failed to cache WHOIS result', { domain, error });
   }
 }

--- a/server/src/service/whois/checker.ts
+++ b/server/src/service/whois/checker.ts
@@ -1,15 +1,16 @@
 /**
  * WHOIS 域名检查器
- * 
+ *
  * 负责单个域名的 WHOIS 查询、缓存管理和状态提取
  */
 
 import { WhoisOperations, DnsAccountOperations } from '../../db/bal/business-adapter';
 import { Domain, DnsAccount } from '../../types';
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 import { queryWhois, getRootDomain, getCachedWhois, setCachedWhois, extractStatus, dnsProviderAdapter, WhoisResult } from './index';
 import { areDomainsEqual } from '../../utils/dns';
 
+const log = createLogger('WhoisService').sub('Checker');
 /**
  * WHOIS 检查结果
  */
@@ -42,53 +43,53 @@ async function getExpiryFromProvider(domainName: string): Promise<Date | null> {
     // 直接查询指定域名的记录，而不是遍历所有域名
     const { DomainOperations } = await import('../../db/bal/business-adapter');
     const domain = await DomainOperations.getByName(domainName) as Domain | undefined;
-    
+
     if (!domain || !domain.account_id) {
-      log.debug('WhoisChecker', `Domain ${domainName} not found or has no account_id`);
+      log.debug(`Domain ${domainName} not found or has no account_id`);
       return null;
     }
 
     const account = await DnsAccountOperations.getById(domain.account_id) as DnsAccount | undefined;
     if (!account) {
-      log.debug('WhoisChecker', `Account ${domain.account_id} not found for domain ${domainName}`);
+      log.debug(`Account ${domain.account_id} not found for domain ${domainName}`);
       return null;
     }
 
     // Check if the DNS account is enabled before querying provider API
     if (!account.enabled) {
-      log.debug('WhoisChecker', `DNS account ${account.id} (${account.name}) is disabled, skipping provider WHOIS for ${domainName}`);
+      log.debug(`DNS account ${account.id} (${account.name}) is disabled, skipping provider WHOIS for ${domainName}`);
       return null;
     }
 
-    log.info('WhoisChecker', `Querying provider ${account.type} for domain ${domainName}`);
+    log.info(`Querying provider ${account.type} for domain ${domainName}`);
 
     // 检查是否有注册的 WHOIS 适配器
     const scheduler = dnsProviderAdapter.getAdapter(account.type);
     if (!scheduler) {
-      log.debug('WhoisChecker', `No WHOIS adapter registered for provider ${account.type}`);
+      log.debug(`No WHOIS adapter registered for provider ${account.type}`);
       return null;
     }
 
     // account.config 可能是字符串或对象，安全解析
-    const config = typeof account.config === 'string' 
-      ? JSON.parse(account.config) 
+    const config = typeof account.config === 'string'
+      ? JSON.parse(account.config)
       : account.config;
-    
-    log.info('WhoisChecker', `Calling ${account.type.toUpperCase()} WHOIS for ${domainName}`);
+
+    log.info(`Calling ${account.type.toUpperCase()} WHOIS for ${domainName}`);
     const whoisResult = await scheduler.queryWhois(config, domainName);
-    
+
     if (whoisResult?.success && whoisResult.expiration_date) {
       const expiryDate = new Date(whoisResult.expiration_date);
       if (!isNaN(expiryDate.getTime())) {
-        log.info('WhoisChecker', `${account.type.toUpperCase()} returned expiry for ${domainName}: ${expiryDate.toISOString()}`);
+        log.info(`${account.type.toUpperCase()} returned expiry for ${domainName}: ${expiryDate.toISOString()}`);
         return expiryDate;
       }
     }
-    
-    log.debug('WhoisChecker', `${account.type.toUpperCase()} query failed or no expiration_date for ${domainName}`);
+
+    log.debug(`${account.type.toUpperCase()} query failed or no expiration_date for ${domainName}`);
     return null;
   } catch (error) {
-    log.error('WhoisChecker', `Failed to get expiry from provider for ${domainName}:`, {
+    log.error(`Failed to get expiry from provider for ${domainName}:`, {
       error: error instanceof Error ? error.message : String(error),
     });
     return null;
@@ -102,34 +103,34 @@ async function getExpiryFromProvider(domainName: string): Promise<Date | null> {
  */
 export async function checkWhoisForDomain(domainName: string, forceRefresh: boolean = false): Promise<WhoisCheckResult> {
   let whoisStatus: string | null = null;
-  
+
   try {
-    log.info('WhoisChecker', `Checking WHOIS for ${domainName}`, { forceRefresh });
-    
+    log.info(`Checking WHOIS for ${domainName}`, { forceRefresh });
+
     // 如果不是强制刷新，先尝试从 DNS 提供商获取（优先于缓存）
     if (!forceRefresh) {
       const providerExpiryDate = await getExpiryFromProvider(domainName);
-      
+
       if (providerExpiryDate) {
         // DNS 提供商查询成功，使用提供商数据
-        log.info('WhoisChecker', `Using provider expiry for ${domainName}: ${providerExpiryDate.toISOString()}`);
-        
+        log.info(`Using provider expiry for ${domainName}: ${providerExpiryDate.toISOString()}`);
+
         // 仍然查询 WHOIS 获取状态等信息
         const whoisResult = await queryWhois(domainName);
         if (whoisResult?.raw) {
           whoisStatus = extractStatus(whoisResult.raw);
         }
-        
+
         // 判断是否为顶域
         const rootDomain = getRootDomain(domainName);
         const isApexDomain = domainName.toLowerCase() === rootDomain.toLowerCase();
-        
+
         let finalApexExpiryDate: Date | null = null;
         if (!isApexDomain && whoisResult?.expiryDate) {
           // 子域：同时保存顶域到期时间
           finalApexExpiryDate = whoisResult.expiryDate;
         }
-        
+
         const result: WhoisResult = {
           domain: domainName,
           expiryDate: providerExpiryDate,
@@ -140,7 +141,7 @@ export async function checkWhoisForDomain(domainName: string, forceRefresh: bool
           status: whoisStatus,
         };
         setCachedWhois(domainName, result);
-        
+
         return {
           expiryDate: providerExpiryDate,
           apexExpiryDate: finalApexExpiryDate,
@@ -149,22 +150,22 @@ export async function checkWhoisForDomain(domainName: string, forceRefresh: bool
           status: whoisStatus,
         };
       }
-      
+
       // DNS 提供商查询失败，尝试使用缓存
-      log.info('WhoisChecker', `Provider query failed, trying cache for ${domainName}`);
+      log.info(`Provider query failed, trying cache for ${domainName}`);
       const cached = await getCachedWhois(domainName);
       if (cached?.expiryDate) {
-        log.info('WhoisChecker', `Using cached expiry for ${domainName}: ${cached.expiryDate.toISOString()}`);
-      
+        log.info(`Using cached expiry for ${domainName}: ${cached.expiryDate.toISOString()}`);
+
         // 如果缓存中没有 status，尝试从 raw_data 中解析
         whoisStatus = cached.status || null;
         if (!whoisStatus && cached.raw) {
           whoisStatus = extractStatus(cached.raw);
           if (whoisStatus) {
-            log.info('WhoisChecker', `Parsed status from cache for ${domainName}: ${whoisStatus}`);
+            log.info(`Parsed status from cache for ${domainName}: ${whoisStatus}`);
           }
         }
-        
+
         return {
           expiryDate: cached.expiryDate,
           apexExpiryDate: cached.apexExpiryDate || null,
@@ -174,18 +175,18 @@ export async function checkWhoisForDomain(domainName: string, forceRefresh: bool
         };
       }
     } else {
-      log.info('WhoisChecker', `Force refresh mode, skipping cache for ${domainName}`);
+      log.info(`Force refresh mode, skipping cache for ${domainName}`);
     }
 
     // 使用 WHOIS 查询（缓存也失败时）
-    log.info('WhoisChecker', `Querying WHOIS for ${domainName}`);
+    log.info(`Querying WHOIS for ${domainName}`);
     const whoisResult = await queryWhois(domainName);
 
     // 提取 WHOIS 状态信息
     if (whoisResult?.raw) {
       whoisStatus = extractStatus(whoisResult.raw);
       if (whoisStatus) {
-        log.info('WhoisChecker', `Extracted status for ${domainName}: ${whoisStatus}`);
+        log.info(`Extracted status for ${domainName}: ${whoisStatus}`);
       }
     }
 
@@ -200,7 +201,7 @@ export async function checkWhoisForDomain(domainName: string, forceRefresh: bool
         status: whoisStatus,
       };
       setCachedWhois(domainName, result);
-      
+
       return {
         expiryDate: whoisResult.expiryDate,
         apexExpiryDate: whoisResult.apexExpiryDate || null,
@@ -210,9 +211,9 @@ export async function checkWhoisForDomain(domainName: string, forceRefresh: bool
       };
     }
 
-    log.warn('WhoisChecker', `No expiry date found for ${domainName}`);
+    log.warn(`No expiry date found for ${domainName}`);
   } catch (error) {
-    log.error('WhoisChecker', `Error checking ${domainName}:`, {
+    log.error(`Error checking ${domainName}:`, {
       error: error instanceof Error ? error.message : String(error),
     });
   }
@@ -243,13 +244,13 @@ export async function syncDomainWhois(domainId: number, forceRefresh: boolean = 
 
     if (whoisResult.expiryDate) {
       const formattedDate = formatDateForMySQL(whoisResult.expiryDate);
-      const formattedApexDate = whoisResult.apexExpiryDate 
-        ? formatDateForMySQL(whoisResult.apexExpiryDate) 
+      const formattedApexDate = whoisResult.apexExpiryDate
+        ? formatDateForMySQL(whoisResult.apexExpiryDate)
         : null;
       await WhoisOperations.updateExpiry(domainId, formattedDate, formattedApexDate, whoisResult.status);
-      
-      return { 
-        success: true, 
+
+      return {
+        success: true,
         expiresAt: whoisResult.expiryDate,
         apexExpiresAt: whoisResult.apexExpiryDate,
       };

--- a/server/src/service/whois/index.ts
+++ b/server/src/service/whois/index.ts
@@ -1,3 +1,4 @@
+const log = createLogger('WhoisService').sub('Index');
 /**
  * WHOIS Service 主入口
  *
@@ -118,7 +119,7 @@ import {
   isSubdomainHosted,
 } from './resolvers/subdomain-providers';
 import { WhoisResult } from './providers/base';
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 import { getRootDomain } from './domain-utils';
 
 /**
@@ -178,12 +179,12 @@ class WhoisService {
   async query(domain: string, options: QueryOptions = {}): Promise<WhoisResult | null> {
     const { preferSubdomain = true, timeout = 30000, skipParentFallback = false, skipUplevel = false } = options;
 
-    log.info('WhoisService', `Querying ${domain}`, { preferSubdomain, skipParentFallback, skipUplevel });
+    log.info(`Querying ${domain}`, { preferSubdomain, skipParentFallback, skipUplevel });
 
     // 检查缓存
     const cached = this.getCached(domain);
     if (cached) {
-      log.debug('WhoisService', `Cache hit for ${domain}`);
+      log.debug(`Cache hit for ${domain}`);
       return cached;
     }
 
@@ -199,12 +200,12 @@ class WhoisService {
     // ========== 子域名查询 ==========
     if (skipParentFallback) {
       // 禁用父域查询模式：仅查询子域，不查询父域
-      log.info('WhoisService', `[SKIP-PARENT] Querying subdomain only (no parent fallback) for ${domain}`);
+      log.info(`[SKIP-PARENT] Querying subdomain only (no parent fallback) for ${domain}`);
       return this.querySubdomainOnly(domain, timeout, skipUplevel);
     }
 
     // 默认模式：顶域和子域并行查询
-    log.info('WhoisService', `[PARALLEL] Starting parallel apex and subdomain queries for ${domain}`);
+    log.info(`[PARALLEL] Starting parallel apex and subdomain queries for ${domain}`);
 
     // 并行启动顶域查询和子域查询
     const apexPromise = this.queryApexCombined(rootDomain, timeout);
@@ -222,7 +223,7 @@ class WhoisService {
         subdomainResult.apexRegistrar = apexResult.registrar;
       }
       this.setCached(domain, subdomainResult);
-      log.info('WhoisService', `[SUCCESS] Subdomain query succeeded for ${domain}`);
+      log.info(`[SUCCESS] Subdomain query succeeded for ${domain}`);
       return subdomainResult;
     }
 
@@ -238,13 +239,13 @@ class WhoisService {
         apexRegistrar: apexResult.registrar,
       };
       this.setCached(domain, result);
-      log.info('WhoisService', `[FALLBACK] Using apex domain expiry for ${domain}`);
+      log.info(`[FALLBACK] Using apex domain expiry for ${domain}`);
       return result;
     }
 
     // ========== 3. 第三方查询（最后备选） ==========
     // 同时查询根域名和子域名，合并结果
-    log.info('WhoisService', `[THIRDPARTY] Starting third-party queries for ${domain} (root: ${rootDomain})`);
+    log.info(`[THIRDPARTY] Starting third-party queries for ${domain} (root: ${rootDomain})`);
 
     // 并行查询根域名和子域名
     const [rootResult, thirdPartySubdomainResult] = await Promise.all([
@@ -259,7 +260,7 @@ class WhoisService {
         thirdPartySubdomainResult.apexRegistrar = rootResult.registrar;
       }
       this.setCached(domain, thirdPartySubdomainResult);
-      log.info('WhoisService', `[SUCCESS] Third-party subdomain query succeeded for ${domain}`);
+      log.info(`[SUCCESS] Third-party subdomain query succeeded for ${domain}`);
       return thirdPartySubdomainResult;
     }
 
@@ -275,11 +276,11 @@ class WhoisService {
         apexRegistrar: rootResult.registrar,
       };
       this.setCached(domain, result);
-      log.info('WhoisService', `[SUCCESS] Third-party root domain query succeeded for ${domain}`);
+      log.info(`[SUCCESS] Third-party root domain query succeeded for ${domain}`);
       return result;
     }
 
-    log.warn('WhoisService', `[FAILED] All queries failed for ${domain}`);
+    log.warn(`[FAILED] All queries failed for ${domain}`);
     return null;
   }
 
@@ -287,7 +288,7 @@ class WhoisService {
    * 仅查询顶域（用于顶域名本身）
    */
   private async queryApexOnly(domain: string, timeout: number): Promise<WhoisResult | null> {
-    log.info('WhoisService', `[APEX-ONLY] Querying apex domain ${domain}`);
+    log.info(`[APEX-ONLY] Querying apex domain ${domain}`);
 
     let result = await this.queryApexRdapParallel(domain, timeout);
     if (!result?.expiryDate) {
@@ -296,7 +297,7 @@ class WhoisService {
 
     if (result?.expiryDate) {
       this.setCached(domain, result);
-      log.info('WhoisService', `[SUCCESS] Apex query succeeded for ${domain}`);
+      log.info(`[SUCCESS] Apex query succeeded for ${domain}`);
       return result;
     }
 
@@ -319,7 +320,7 @@ class WhoisService {
    * 用于 skipParentFallback 模式
    */
   private async querySubdomainOnly(domain: string, timeout: number, skipUplevel: boolean = false): Promise<WhoisResult | null> {
-    log.info('WhoisService', `[SUBDOMAIN-ONLY] Querying subdomain only (no parent) ${domain}`, { skipUplevel });
+    log.info(`[SUBDOMAIN-ONLY] Querying subdomain only (no parent) ${domain}`, { skipUplevel });
 
     // 1. 尝试子域 RDAP/WHOIS
     let result = await this.querySubdomainRdapParallel(domain, timeout);
@@ -329,13 +330,13 @@ class WhoisService {
 
     if (result?.expiryDate) {
       this.setCached(domain, result);
-      log.info('WhoisService', `[SUCCESS] Subdomain query succeeded for ${domain}`);
+      log.info(`[SUCCESS] Subdomain query succeeded for ${domain}`);
       return result;
     }
 
     // 2. 尝试平级查询（uplevel）- 如果允许
     if (!skipUplevel) {
-      log.info('WhoisService', `[SUBDOMAIN-ONLY] Trying uplevel queries for ${domain}`);
+      log.info(`[SUBDOMAIN-ONLY] Trying uplevel queries for ${domain}`);
       result = await this.queryUplevelRdapParallel(domain, timeout);
       if (!result?.expiryDate) {
         result = await this.queryUplevelWhoisParallel(domain, timeout);
@@ -343,15 +344,15 @@ class WhoisService {
 
       if (result?.expiryDate) {
         this.setCached(domain, result);
-        log.info('WhoisService', `[SUCCESS] Uplevel query succeeded for ${domain}`);
+        log.info(`[SUCCESS] Uplevel query succeeded for ${domain}`);
         return result;
       }
     } else {
-      log.info('WhoisService', `[SUBDOMAIN-ONLY] Skipping uplevel queries for ${domain}`);
+      log.info(`[SUBDOMAIN-ONLY] Skipping uplevel queries for ${domain}`);
     }
 
     // 3. 尝试第三方查询（仅查询子域本身，不查询父域）
-    log.info('WhoisService', `[SUBDOMAIN-ONLY] Trying third-party for subdomain ${domain}`);
+    log.info(`[SUBDOMAIN-ONLY] Trying third-party for subdomain ${domain}`);
     result = await this.queryThirdPartyRdapParallel(domain, timeout);
     if (!result?.expiryDate) {
       result = await this.queryThirdPartyWhoisParallel(domain, timeout);
@@ -359,12 +360,12 @@ class WhoisService {
 
     if (result?.expiryDate) {
       this.setCached(domain, result);
-      log.info('WhoisService', `[SUCCESS] Third-party subdomain query succeeded for ${domain}`);
+      log.info(`[SUCCESS] Third-party subdomain query succeeded for ${domain}`);
       return result;
     }
 
     // 放弃，不查询父域
-    log.warn('WhoisService', `[FAILED] All subdomain queries failed for ${domain} (no parent fallback)`);
+    log.warn(`[FAILED] All subdomain queries failed for ${domain} (no parent fallback)`);
     return null;
   }
 
@@ -372,7 +373,7 @@ class WhoisService {
    * 组合查询顶域（RDAP + WHOIS）
    */
   private async queryApexCombined(domain: string, timeout: number): Promise<WhoisResult | null> {
-    log.info('WhoisService', `[APEX-COMBINED] Starting combined apex queries for ${domain}`);
+    log.info(`[APEX-COMBINED] Starting combined apex queries for ${domain}`);
 
     // 并行查询 RDAP 和 WHOIS
     const rdapPromise = this.queryApexRdapParallel(domain, timeout);
@@ -381,13 +382,13 @@ class WhoisService {
     // 使用 Promise.race 获取最快的结果
     const rdapResult = await rdapPromise;
     if (rdapResult?.expiryDate) {
-      log.info('WhoisService', `[APEX-COMBINED] RDAP won for ${domain}`);
+      log.info(`[APEX-COMBINED] RDAP won for ${domain}`);
       return rdapResult;
     }
 
     const whoisResult = await whoisPromise;
     if (whoisResult?.expiryDate) {
-      log.info('WhoisService', `[APEX-COMBINED] WHOIS won for ${domain}`);
+      log.info(`[APEX-COMBINED] WHOIS won for ${domain}`);
       return whoisResult;
     }
 
@@ -398,7 +399,7 @@ class WhoisService {
    * 组合查询子域（所有子域查询方式）
    */
   private async querySubdomainCombined(domain: string, timeout: number, skipUplevel: boolean = false): Promise<WhoisResult | null> {
-    log.info('WhoisService', `[SUBDOMAIN-COMBINED] Starting combined subdomain queries for ${domain}`, { skipUplevel });
+    log.info(`[SUBDOMAIN-COMBINED] Starting combined subdomain queries for ${domain}`, { skipUplevel });
 
     // 并行启动所有子域查询
     const promises = [
@@ -413,7 +414,7 @@ class WhoisService {
         this.queryUplevelWhoisParallel(domain, timeout)
       );
     } else {
-      log.info('WhoisService', `[SUBDOMAIN-COMBINED] Skipping uplevel queries for ${domain}`);
+      log.info(`[SUBDOMAIN-COMBINED] Skipping uplevel queries for ${domain}`);
     }
 
     // 等待所有查询完成，取第一个成功的结果
@@ -422,7 +423,7 @@ class WhoisService {
     for (let i = 0; i < results.length; i++) {
       if (results[i]?.expiryDate) {
         const methods = ['Subdomain-RDAP', 'Subdomain-WHOIS', 'Uplevel-RDAP', 'Uplevel-WHOIS'];
-        log.info('WhoisService', `[SUBDOMAIN-COMBINED] ${methods[i]} won for ${domain}`);
+        log.info(`[SUBDOMAIN-COMBINED] ${methods[i]} won for ${domain}`);
         return results[i];
       }
     }
@@ -445,12 +446,12 @@ class WhoisService {
     if (queries.length === 1) return queries[0]();
 
     const startTime = Date.now();
-    log.info('WhoisService', `${raceName} Starting race with ${queries.length} queries`);
+    log.info(`${raceName} Starting race with ${queries.length} queries`);
 
     // 创建带超时的 Promise
     const timeoutPromise = new Promise<WhoisResult | null>((resolve) => {
       setTimeout(() => {
-        log.debug('WhoisService', `${raceName} Timeout after ${timeout}ms`);
+        log.debug(`${raceName} Timeout after ${timeout}ms`);
         resolve(null);
       }, timeout);
     });
@@ -463,12 +464,12 @@ class WhoisService {
       query().then((result) => {
         if (result?.expiryDate) {
           const elapsed = Date.now() - startTime;
-          log.info('WhoisService', `${raceName} Query ${index + 1} won in ${elapsed}ms`);
+          log.info(`${raceName} Query ${index + 1} won in ${elapsed}ms`);
           return result;
         }
         return null;
       }).catch((error) => {
-        log.warn('WhoisService', `${raceName} Query ${index + 1} failed`, {
+        log.warn(`${raceName} Query ${index + 1} failed`, {
           error: error instanceof Error ? error.message : String(error),
         });
         return null;
@@ -487,7 +488,7 @@ class WhoisService {
 
       // 检查是否超时
       if (winner === null) {
-        log.warn('WhoisService', `${raceName} Timeout, ${pendingQueries.length} queries still pending`);
+        log.warn(`${raceName} Timeout, ${pendingQueries.length} queries still pending`);
         break;
       }
 
@@ -513,7 +514,7 @@ class WhoisService {
       }
     }
 
-    log.warn('WhoisService', `${raceName} All queries failed or timed out`);
+    log.warn(`${raceName} All queries failed or timed out`);
     return null;
   }
 
@@ -530,14 +531,14 @@ class WhoisService {
     const logPrefix = `[${context.level}+${context.method}${uplevelTag}+${provider.name}]`;
 
     try {
-      log.info('WhoisService', `${logPrefix} Querying ${domain} via ${provider.server}`);
+      log.info(`${logPrefix} Querying ${domain} via ${provider.server}`);
       const result = await method.query(domain, provider.server);
       if (result?.expiryDate) {
-        log.info('WhoisService', `${logPrefix} Success for ${domain}, expiry: ${result.expiryDate}`);
+        log.info(`${logPrefix} Success for ${domain}, expiry: ${result.expiryDate}`);
         return result;
       }
     } catch (error) {
-      log.warn('WhoisService', `${logPrefix} Failed for ${domain}`, {
+      log.warn(`${logPrefix} Failed for ${domain}`, {
         error: error instanceof Error ? error.message : String(error),
       });
     }
@@ -557,7 +558,7 @@ class WhoisService {
     // 首先尝试从 IANA RDAP 列表查找（异步）
     const ianaProvider = await findApexRdapProvider(domain);
     if (ianaProvider) {
-      log.debug('WhoisService', `[APEX+RDAP] Matched IANA provider: ${ianaProvider.name} for ${domain}`);
+      log.debug(`[APEX+RDAP] Matched IANA provider: ${ianaProvider.name} for ${domain}`);
       queries.push(() => this.queryWithProvider(
         domain,
         ianaProvider,
@@ -572,14 +573,14 @@ class WhoisService {
       if (ianaProvider && provider.suffixes.some(s => ianaProvider.suffixes.includes(s))) {
         continue;
       }
-      
+
       const isMatch = provider.suffixes.some(suffix => {
         if (domain.toLowerCase() === suffix) return true;
         return domain.toLowerCase().endsWith('.' + suffix);
       });
 
       if (isMatch) {
-        log.debug('WhoisService', `[APEX+RDAP] Matched built-in provider: ${provider.name} for ${domain}`);
+        log.debug(`[APEX+RDAP] Matched built-in provider: ${provider.name} for ${domain}`);
         queries.push(() => this.queryWithProvider(
           domain,
           provider,
@@ -590,11 +591,11 @@ class WhoisService {
     }
 
     if (queries.length === 0) {
-      log.warn('WhoisService', `[APEX+RDAP] No matching providers for ${domain}`);
+      log.warn(`[APEX+RDAP] No matching providers for ${domain}`);
       return null;
     }
 
-    log.info('WhoisService', `[APEX+RDAP] Starting parallel queries with ${queries.length} providers for ${domain}`);
+    log.info(`[APEX+RDAP] Starting parallel queries with ${queries.length} providers for ${domain}`);
     return this.raceQueries(queries, timeout, `[APEX+RDAP+PARALLEL]`);
   }
 
@@ -623,7 +624,7 @@ class WhoisService {
     }
 
     if (queries.length === 0) {
-      log.debug('WhoisService', `[APEX+WHOIS] No matching providers for ${domain}`);
+      log.debug(`[APEX+WHOIS] No matching providers for ${domain}`);
       return null;
     }
 
@@ -656,7 +657,7 @@ class WhoisService {
     }
 
     if (queries.length === 0) {
-      log.debug('WhoisService', `[SUBDOMAIN+RDAP] No matching registered providers for ${domain}`);
+      log.debug(`[SUBDOMAIN+RDAP] No matching registered providers for ${domain}`);
       return null;
     }
 
@@ -687,7 +688,7 @@ class WhoisService {
     }
 
     if (queries.length === 0) {
-      log.debug('WhoisService', `[SUBDOMAIN+WHOIS] No matching registered providers for ${domain}`);
+      log.debug(`[SUBDOMAIN+WHOIS] No matching registered providers for ${domain}`);
       return null;
     }
 
@@ -714,7 +715,7 @@ class WhoisService {
     }
 
     if (queries.length === 0) {
-      log.debug('WhoisService', `[SUBDOMAIN+RDAP+UPLEVEL] No subdomain RDAP providers available for ${domain}`);
+      log.debug(`[SUBDOMAIN+RDAP+UPLEVEL] No subdomain RDAP providers available for ${domain}`);
       return null;
     }
 
@@ -739,7 +740,7 @@ class WhoisService {
     }
 
     if (queries.length === 0) {
-      log.debug('WhoisService', `[SUBDOMAIN+WHOIS+UPLEVEL] No subdomain WHOIS providers available for ${domain}`);
+      log.debug(`[SUBDOMAIN+WHOIS+UPLEVEL] No subdomain WHOIS providers available for ${domain}`);
       return null;
     }
 
@@ -772,7 +773,7 @@ class WhoisService {
     }
 
     if (queries.length === 0) {
-      log.debug('WhoisService', `[第三方+RDAP] No matching providers for ${domain}`);
+      log.debug(`[第三方+RDAP] No matching providers for ${domain}`);
       return null;
     }
 
@@ -803,7 +804,7 @@ class WhoisService {
     }
 
     if (queries.length === 0) {
-      log.debug('WhoisService', `[THIRDPARTY+WHOIS] No matching providers for ${domain}`);
+      log.debug(`[THIRDPARTY+WHOIS] No matching providers for ${domain}`);
       return null;
     }
 
@@ -864,7 +865,7 @@ export {
 } from './cache';
 
 // 导出状态解析器（已升级为数据解析中心）
-export { 
+export {
   extractStatus,
   extractExpiryDate,
   extractRegistrar,

--- a/server/src/service/whois/notifier.ts
+++ b/server/src/service/whois/notifier.ts
@@ -1,14 +1,15 @@
 /**
  * WHOIS 过期通知器
- * 
+ *
  * 负责检查域名到期时间并发送通知
  */
 
 import { WhoisOperations } from '../../db/bal/business-adapter';
 import { Domain } from '../../types';
 import { sendNotification } from '../notification';
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 
+const log = createLogger('WhoisService').sub('Notifier');
 /**
  * 检查并发送过期通知
  */
@@ -30,12 +31,12 @@ export async function checkAndSendNotification(domain: Domain, expiresAt: Date):
           `[HiDNS] Domain Expiring Soon: ${domain.name}`,
           `Your domain ${domain.name} is expiring in ${daysLeft} days (on ${expiresAt.toLocaleDateString()}). Please renew it soon.`
         );
-        log.info('WhoisNotifier', `Sent expiry notification for ${domain.name} (${daysLeft} days left)`);
+        log.info(`Sent expiry notification for ${domain.name} (${daysLeft} days left)`);
       } catch (err) {
-        log.error('WhoisNotifier', `Failed to send notification for ${domain.name}`);
+        log.error(`Failed to send notification for ${domain.name}`);
       }
     }
   } catch (error) {
-    log.error('WhoisNotifier', `Error checking notification for ${domain.name}`);
+    log.error(`Error checking notification for ${domain.name}`);
   }
 }

--- a/server/src/service/whois/providers/base.ts
+++ b/server/src/service/whois/providers/base.ts
@@ -3,7 +3,10 @@
  * 定义查询协议的基础能力
  */
 
-import { log } from '../../../lib/logger';
+import { createLogger } from '../../../lib/logger';
+
+const log = createLogger('WhoisService').sub('Provider').sub('Base');
+
 
 /**
  * WHOIS 查询结果
@@ -141,6 +144,6 @@ export abstract class BaseQueryMethod implements IQueryMethod {
    * 日志记录
    */
   protected log(level: 'info' | 'warn' | 'error' | 'debug', message: string, meta?: Record<string, unknown>) {
-    log[level]('WhoisQuery', `[${this.name}] ${message}`, meta);
+    log.sub(this.name).tag(level.toUpperCase())[level](message, meta);
   }
 }

--- a/server/src/service/whois/rdap-server-list.ts
+++ b/server/src/service/whois/rdap-server-list.ts
@@ -5,9 +5,10 @@
  */
 
 import * as https from 'https';
-import { log } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 import { RdapCacheOperations, SystemCacheOperations } from '../../db/bal/business-adapter';
 
+const log = createLogger('WhoisService').sub('RdapServerList');
 // IANA RDAP 服务器列表 URL
 const IANA_RDAP_URL = 'https://data.iana.org/rdap/dns.json';
 
@@ -40,7 +41,7 @@ interface RdapServerConfig {
  */
 async function downloadFromIana(): Promise<IanaRdapResponse | null> {
   return new Promise((resolve, reject) => {
-    log.info('RdapServerList', `Downloading RDAP server list from ${IANA_RDAP_URL}`);
+    log.info(`Downloading RDAP server list from ${IANA_RDAP_URL}`);
 
     const options = {
       hostname: 'data.iana.org',
@@ -65,7 +66,7 @@ async function downloadFromIana(): Promise<IanaRdapResponse | null> {
         if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
           try {
             const jsonData = JSON.parse(data) as IanaRdapResponse;
-            log.info('RdapServerList', `Successfully downloaded RDAP server list`, {
+            log.info(`Successfully downloaded RDAP server list`, {
               version: jsonData.version,
               publication: jsonData.publication,
               serviceCount: jsonData.services?.length || 0,
@@ -100,7 +101,7 @@ function parseIanaData(data: IanaRdapResponse): RdapServerConfig[] {
   const configs: RdapServerConfig[] = [];
 
   if (!data.services || !Array.isArray(data.services)) {
-    log.warn('RdapServerList', 'Invalid services data from IANA');
+    log.warn('Invalid services data from IANA');
     return configs;
   }
 
@@ -125,7 +126,7 @@ function parseIanaData(data: IanaRdapResponse): RdapServerConfig[] {
     }
   }
 
-  log.info('RdapServerList', `Parsed ${configs.length} RDAP server configurations`);
+  log.info(`Parsed ${configs.length} RDAP server configurations`);
   return configs;
 }
 
@@ -136,18 +137,18 @@ async function saveToDatabase(configs: RdapServerConfig[]): Promise<void> {
   try {
     // 清空旧缓存
     await RdapCacheOperations.clearAll();
-    
+
     // 批量保存新数据
     await RdapCacheOperations.saveBatch(configs);
-    
+
     // 更新缓存时间戳
     const now = new Date();
     const expiresAt = new Date(now.getTime() + CACHE_TTL);
     await SystemCacheOperations.set(CACHE_KEY, now.toISOString(), expiresAt);
-    
-    log.info('RdapServerList', `Saved ${configs.length} RDAP servers to database`);
+
+    log.info(`Saved ${configs.length} RDAP servers to database`);
   } catch (error) {
-    log.error('RdapServerList', 'Failed to save to database', {
+    log.error('Failed to save to database', {
       error: error instanceof Error ? error.message : String(error),
     });
     throw error;
@@ -160,16 +161,16 @@ async function saveToDatabase(configs: RdapServerConfig[]): Promise<void> {
 async function loadFromDatabase(): Promise<RdapServerConfig[]> {
   try {
     const entries = await RdapCacheOperations.getAll();
-    
+
     const configs: RdapServerConfig[] = entries.map(entry => ({
       tld: entry.tld as string,
       servers: JSON.parse(entry.servers as string),
     }));
-    
-    log.debug('RdapServerList', `Loaded ${configs.length} RDAP servers from database`);
+
+    log.debug(`Loaded ${configs.length} RDAP servers from database`);
     return configs;
   } catch (error) {
-    log.error('RdapServerList', 'Failed to load from database', {
+    log.error('Failed to load from database', {
       error: error instanceof Error ? error.message : String(error),
     });
     return [];
@@ -182,22 +183,22 @@ async function loadFromDatabase(): Promise<RdapServerConfig[]> {
 async function isCacheExpired(): Promise<boolean> {
   try {
     const lastUpdateStr = await SystemCacheOperations.get(CACHE_KEY);
-    
+
     if (!lastUpdateStr) {
-      log.debug('RdapServerList', 'No cache timestamp found, cache is expired');
+      log.debug('No cache timestamp found, cache is expired');
       return true;
     }
-    
+
     const lastUpdate = new Date(lastUpdateStr).getTime();
     const now = Date.now();
     const age = now - lastUpdate;
-    
+
     const isExpired = age > CACHE_TTL;
-    log.debug('RdapServerList', `Cache age: ${Math.floor(age / 1000 / 60 / 60)} hours, expired: ${isExpired}`);
-    
+    log.debug(`Cache age: ${Math.floor(age / 1000 / 60 / 60)} hours, expired: ${isExpired}`);
+
     return isExpired;
   } catch (error) {
-    log.warn('RdapServerList', 'Failed to check cache expiration', {
+    log.warn('Failed to check cache expiration', {
       error: error instanceof Error ? error.message : String(error),
     });
     return true;
@@ -211,14 +212,14 @@ async function isCacheExpired(): Promise<boolean> {
 export async function getRdapServerList(forceRefresh = false): Promise<RdapServerConfig[]> {
   // 检查缓存是否有效
   const isExpired = forceRefresh || await isCacheExpired();
-  
+
   if (!isExpired) {
-    log.info('RdapServerList', 'Using cached RDAP server list from database');
+    log.info('Using cached RDAP server list from database');
     const configs = await loadFromDatabase();
     if (configs.length > 0) {
       return configs;
     }
-    log.warn('RdapServerList', 'Database cache is empty, will download from IANA');
+    log.warn('Database cache is empty, will download from IANA');
   }
 
   // 缓存不存在或已过期，从 IANA 下载
@@ -230,12 +231,12 @@ export async function getRdapServerList(forceRefresh = false): Promise<RdapServe
       return configs;
     }
   } catch (error) {
-    log.error('RdapServerList', 'Failed to download from IANA', {
+    log.error('Failed to download from IANA', {
       error: error instanceof Error ? error.message : String(error),
     });
 
     // 下载失败但尝试使用数据库缓存作为后备
-    log.warn('RdapServerList', 'Using database cache as fallback');
+    log.warn('Using database cache as fallback');
     const configs = await loadFromDatabase();
     if (configs.length > 0) {
       return configs;
@@ -243,7 +244,7 @@ export async function getRdapServerList(forceRefresh = false): Promise<RdapServe
   }
 
   // 下载失败且无缓存，返回空数组
-  log.error('RdapServerList', 'No RDAP server list available');
+  log.error('No RDAP server list available');
   return [];
 }
 
@@ -252,23 +253,23 @@ export async function getRdapServerList(forceRefresh = false): Promise<RdapServe
  */
 export async function findRdapServer(tld: string): Promise<string | null> {
   const normalizedTld = tld.toLowerCase().replace(/^\./, '');
-  
+
   try {
     const entry = await RdapCacheOperations.getByTld(normalizedTld);
     if (entry) {
       const servers = JSON.parse(entry.servers as string);
       if (servers.length > 0) {
-        log.debug('RdapServerList', `Found RDAP server for .${normalizedTld}`, { server: servers[0] });
+        log.debug(`Found RDAP server for .${normalizedTld}`, { server: servers[0] });
         return servers[0];
       }
     }
   } catch (error) {
-    log.warn('RdapServerList', `Failed to find RDAP server for .${normalizedTld}`, {
+    log.warn(`Failed to find RDAP server for .${normalizedTld}`, {
       error: error instanceof Error ? error.message : String(error),
     });
   }
 
-  log.debug('RdapServerList', `No RDAP server found for .${normalizedTld}`);
+  log.debug(`No RDAP server found for .${normalizedTld}`);
   return null;
 }
 
@@ -285,7 +286,7 @@ export async function findRdapServerForDomain(domain: string): Promise<string | 
  * 强制刷新 RDAP 服务器列表
  */
 export async function refreshRdapServerList(): Promise<RdapServerConfig[]> {
-  log.info('RdapServerList', 'Force refreshing RDAP server list');
+  log.info('Force refreshing RDAP server list');
   return getRdapServerList(true);
 }
 
@@ -296,7 +297,7 @@ export async function getCacheStatus(): Promise<{ exists: boolean; lastUpdated?:
   try {
     const lastUpdateStr = await SystemCacheOperations.get(CACHE_KEY);
     const stats = await RdapCacheOperations.getStats();
-    
+
     if (!lastUpdateStr) {
       return { exists: false, count: stats.count };
     }
@@ -313,7 +314,7 @@ export async function getCacheStatus(): Promise<{ exists: boolean; lastUpdated?:
       count: stats.count,
     };
   } catch (error) {
-    log.warn('RdapServerList', 'Failed to get cache status', {
+    log.warn('Failed to get cache status', {
       error: error instanceof Error ? error.message : String(error),
     });
     return { exists: false };
@@ -325,13 +326,13 @@ export async function getCacheStatus(): Promise<{ exists: boolean; lastUpdated?:
  * 在应用启动时调用，预加载缓存
  */
 export async function initRdapServerList(): Promise<void> {
-  log.info('RdapServerList', 'Initializing RDAP server list...');
-  
+  log.info('Initializing RDAP server list...');
+
   try {
     const configs = await getRdapServerList();
-    log.info('RdapServerList', `Initialized with ${configs.length} RDAP servers`);
+    log.info(`Initialized with ${configs.length} RDAP servers`);
   } catch (error) {
-    log.error('RdapServerList', 'Failed to initialize', {
+    log.error('Failed to initialize', {
       error: error instanceof Error ? error.message : String(error),
     });
   }

--- a/server/src/service/whois/scheduler.ts
+++ b/server/src/service/whois/scheduler.ts
@@ -1,6 +1,6 @@
 /**
  * WHOIS 调度器注册表
- * 
+ *
  * 所有支持 WHOIS 查询的 DNS 提供商需要实现此接口并向核心注册
  */
 
@@ -14,11 +14,11 @@ export function initWhoisSchedulers(): void {
   const { dnsProviderAdapter } = require('./providers/adapter');
   // 注册 DNSHE WHOIS 适配器
   dnsProviderAdapter.register(dnsheWhoisScheduler);
-  
+
   // 未来可以在这里注册其他提供商的适配器
   // dnsProviderAdapter.register(alicloudWhoisAdapter);
   // dnsProviderAdapter.register(cloudflareWhoisAdapter);
-  
+
   const registeredTypes = dnsProviderAdapter.getRegisteredTypes();
   console.log(`[WhoisInit] Registered WHOIS adapters for: ${registeredTypes.join(', ')}`);
 }
@@ -31,24 +31,25 @@ export async function syncAllDomainsWhois(forceRefresh: boolean = false): Promis
   const { WhoisOperations } = await import('../../db/bal/business-adapter');
   const { connect } = await import('../../db/dal/connection');
   const { taskManager } = await import('../taskManager');
-  const { log } = await import('../../lib/logger');
+  const { createLogger } = await import('../../lib/logger');
+  const log = createLogger('WhoisService').sub('Scheduler');
   const { checkWhoisForDomain } = await import('./checker');
   const { checkAndSendNotification } = await import('./notifier');
-  
-  log.info('WhoisScheduler', 'Starting WHOIS sync for all domains');
+
+  log.info('Starting WHOIS sync for all domains');
 
   let domains: any[] = [];
   try {
     domains = await WhoisOperations.getAllDomains();
   } catch (error) {
     if (error instanceof Error && error.message.includes('Database connection not initialized')) {
-      log.warn('WhoisScheduler', 'Database connection lost, attempting to reconnect...');
+      log.warn('Database connection lost, attempting to reconnect...');
       try {
         await connect();
-        log.info('WhoisScheduler', 'Database reconnected successfully, retrying...');
+        log.info('Database reconnected successfully, retrying...');
         domains = await WhoisOperations.getAllDomains();
       } catch (reconnectError) {
-        log.error('WhoisScheduler', 'Failed to reconnect to database');
+        log.error('Failed to reconnect to database');
         return;
       }
     } else {
@@ -56,7 +57,7 @@ export async function syncAllDomainsWhois(forceRefresh: boolean = false): Promis
     }
   }
 
-  log.info('WhoisScheduler', `Found ${domains.length} domains to sync`);
+  log.info(`Found ${domains.length} domains to sync`);
 
   let successCount = 0;
   let failCount = 0;
@@ -76,7 +77,7 @@ export async function syncAllDomainsWhois(forceRefresh: boolean = false): Promis
         try {
           // 跳过已禁用的域名
           if (d.enabled === 0) {
-            log.info('WhoisScheduler', `Skipping disabled domain: ${d.name}`);
+            log.info(`Skipping disabled domain: ${d.name}`);
             return;
           }
 
@@ -90,8 +91,8 @@ export async function syncAllDomainsWhois(forceRefresh: boolean = false): Promis
             const minutes = String(whoisResult.expiryDate.getMinutes()).padStart(2, '0');
             const seconds = String(whoisResult.expiryDate.getSeconds()).padStart(2, '0');
             const formattedDate = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
-            
-            const formattedApexDate = whoisResult.apexExpiryDate 
+
+            const formattedApexDate = whoisResult.apexExpiryDate
               ? (() => {
                   const y = whoisResult.apexExpiryDate!.getFullYear();
                   const m = String(whoisResult.apexExpiryDate!.getMonth() + 1).padStart(2, '0');
@@ -102,11 +103,11 @@ export async function syncAllDomainsWhois(forceRefresh: boolean = false): Promis
                   return `${y}-${m}-${d} ${h}:${min}:${s}`;
                 })()
               : null;
-              
+
             await WhoisOperations.updateExpiry(d.id, formattedDate, formattedApexDate, whoisResult.status);
 
             successCount++;
-            log.info('WhoisScheduler', `Updated expiry for ${d.name}: ${formattedDate}`);
+            log.info(`Updated expiry for ${d.name}: ${formattedDate}`);
 
             // 推送 WebSocket 消息通知前端更新
             try {
@@ -122,19 +123,19 @@ export async function syncAllDomainsWhois(forceRefresh: boolean = false): Promis
                 },
               });
             } catch (error) {
-              log.error('WhoisScheduler', 'Failed to broadcast domain_whois_updated event', { error });
+              log.error('Failed to broadcast domain_whois_updated event', { error });
             }
 
             await checkAndSendNotification(d, whoisResult.expiryDate);
           } else {
             failCount++;
             failedDomains.push(d.name);
-            log.warn('WhoisScheduler', `Failed to get expiry for ${d.name}`);
+            log.warn(`Failed to get expiry for ${d.name}`);
           }
         } catch (error) {
           failCount++;
           failedDomains.push(d.name);
-          log.error('WhoisScheduler', `Error processing ${d.name}`);
+          log.error(`Error processing ${d.name}`);
         }
       }
     );
@@ -142,7 +143,7 @@ export async function syncAllDomainsWhois(forceRefresh: boolean = false): Promis
 
   await Promise.all(tasks);
 
-  log.info('WhoisScheduler', `WHOIS sync completed: ${successCount} success, ${failCount} failed`, {
+  log.info(`WHOIS sync completed: ${successCount} success, ${failCount} failed`, {
     failedDomains: failedDomains.slice(0, 20),
     totalFailed: failedDomains.length,
   });
@@ -154,14 +155,15 @@ export async function syncAllDomainsWhois(forceRefresh: boolean = false): Promis
 export async function startWhoisJob(): Promise<void> {
   const { WhoisOperations } = await import('../../db/bal/business-adapter');
   const { taskManager } = await import('../taskManager');
-  const { log } = await import('../../lib/logger');
-  
+  const { createLogger } = await import('../../lib/logger');
+  const log = createLogger('WhoisService').sub('Scheduler');
+
   // 初始化 WHOIS 缓存表
   try {
     await WhoisOperations.ensureWhoisCacheTable();
-    log.info('WhoisScheduler', 'WHOIS cache table initialized');
+    log.info('WHOIS cache table initialized');
   } catch (error) {
-    log.error('WhoisScheduler', 'Failed to initialize WHOIS cache table');
+    log.error('Failed to initialize WHOIS cache table');
   }
 
   // 启动后 30 秒运行第一次
@@ -176,7 +178,7 @@ export async function startWhoisJob(): Promise<void> {
         retryDelay: 10000,
       },
       syncAllDomainsWhois
-    ).catch(err => log.error('WhoisScheduler', 'Initial sync error'));
+    ).catch(err => log.error('Initial sync error'));
   }, 30 * 1000);
 
   // 每小时运行一次
@@ -191,8 +193,8 @@ export async function startWhoisJob(): Promise<void> {
         retryDelay: 10000,
       },
       syncAllDomainsWhois
-    ).catch(err => log.error('WhoisScheduler', 'Scheduled sync error'));
+    ).catch(err => log.error('Scheduled sync error'));
   }, 60 * 60 * 1000);
 
-  log.info('WhoisScheduler', 'WHOIS job scheduler started (every 1 hour)');
+  log.info('WHOIS job scheduler started (every 1 hour)');
 }

--- a/server/src/utils/response.ts
+++ b/server/src/utils/response.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
-import { log } from '../lib/logger';
+import { createLogger } from '../lib/logger';
 
+const log = createLogger('Utils').sub('Response');
 /**
  * Standard API response format
  * Note: Using 'msg' instead of 'message' for consistency with existing codebase
@@ -151,26 +152,26 @@ export const asyncHandler = (fn: Function) => (req: any, res: any, next: any) =>
  * Global error handler middleware
  */
 export function globalErrorHandler(err: Error, req: any, res: Response, _next: any): void {
-  log.error('Error', 'Unhandled error', { error: err });
-  
+  log.error('Unhandled error', { error: err });
+
   // Handle specific error types
   if (err.name === 'ValidationError') {
     ResponseHelper.badRequest(res, err.message);
     return;
   }
-  
+
   if (err.name === 'UnauthorizedError') {
     ResponseHelper.unauthorized(res, 'Unauthorized');
     return;
   }
-  
+
   if (err.name === 'ForbiddenError') {
     ResponseHelper.forbidden(res, 'Forbidden');
     return;
   }
-  
+
   // Default to internal server error
-  ResponseHelper.internalError(res, process.env.NODE_ENV === 'production' 
-    ? 'Internal server error' 
+  ResponseHelper.internalError(res, process.env.NODE_ENV === 'production'
+    ? 'Internal server error'
     : err.message);
 }


### PR DESCRIPTION
### Motivation
- Unify and modernize the application logging by replacing ad-hoc `log` usages with a structured `createLogger`/SubLogger API to provide consistent module/submodule/tags, better sanitization and caller metadata.
- Provide specialized logger factories for DNS providers and internal components so provider adapters and helper modules follow the same logging conventions and avoid duplicate logger creation.
- Improve observability and safety by sanitizing sensitive data, improving error formatting, and centralizing log output formatting and levels.

### Description
- Introduce a revamped logger implementation (`server/src/lib/logger.ts`) with `createLogger(module)` producing SubLogger instances, automatic caller detection, data sanitization, colorized output, and tag/sub chaining; replace the previous ad-hoc `log` helper.
- Replace imports and usages across the codebase to use `createLogger(...)` and SubLogger chaining (e.g. `.sub('Module')`, `.tag(...)`) and update log message shapes; this change touches server, db, lib, routes and service modules to migrate to the new API.
- Add DNS provider logging helpers and a centralized providers internal module (`server/src/lib/dns/providers/internal.ts`) exporting factory functions such as `createProviderAdapterLogger`, `createProviderApiLogger`, etc., and update provider adapters to use these factories.
- Adjust many modules to remove the old multi-argument `log.*(module, message, data)` pattern in favor of `const log = createLogger(...)` then `log.info('message', { ... })`, and update several related utilities (SQL compatibility, DSM, DAL drivers, jobs, services) to use the new logger and improved message formatting.

### Testing
- Performed a TypeScript build with `npm run build` to ensure compilation across modified files and resolve logger API usage changes; the build succeeded.
- Ran linting (`npm run lint`) to validate code style changes; lint passed with no blocking errors.
- Executed basic smoke checks by starting the server and invoking key HTTP endpoints (startup, health/status, simple GET routes) to verify logging integration and no runtime crashes; smoke checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2462f57dd483279a04ff318bf74fe2)